### PR TITLE
Add Arquillian Container TCK test run using WildFly 8

### DIFF
--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -81,6 +81,63 @@
             </build>
         </profile>
         
+        <profile>
+            <id>wildfly-8-tck</id>
+            <dependencyManagement>
+                <dependencies>
+                    <dependency>
+                        <groupId>org.jboss.spec</groupId>
+                        <artifactId>jboss-javaee-7.0</artifactId>
+                        <version>1.0.1.Final</version>
+                        <type>pom</type>
+                        <scope>import</scope>
+                    </dependency>
+                </dependencies>
+            </dependencyManagement>
+            <dependencies>
+                <dependency>
+                    <groupId>org.arquillian.tck.container</groupId>
+                    <artifactId>arquillian-tck-container</artifactId>
+                    <version>1.0.0.Alpha1</version>
+                    <classifier>tests</classifier>
+                    <scope>test</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.jboss.spec.javax.servlet</groupId>
+                    <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                    <version>8.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <excludes>
+                                <exclude>org/arquillian/cube/*/**</exclude>
+                            </excludes>
+                            <dependenciesToScan>
+                                <dependency>org.arquillian.tck.container:arquillian-tck-container</dependency>
+                            </dependenciesToScan>
+                        </configuration>
+                    </plugin>
+                </plugins>
+                <testResources>
+                    <testResource>
+                        <directory>
+                            src/test/resources-wildfly
+                        </directory>
+                    </testResource>
+                </testResources>
+            </build>
+        </profile>
     </profiles>
 
 </project>

--- a/ftest/src/test/resources-wildfly/Dockerfile
+++ b/ftest/src/test/resources-wildfly/Dockerfile
@@ -1,0 +1,3 @@
+from jboss/wildfly
+RUN /opt/jboss/wildfly/bin/add-user.sh -up mgmt-users.properties admin Admin#70365 --silent
+CMD ["/opt/jboss/wildfly/bin/standalone.sh", "-b", "0.0.0.0", "-bmanagement", "0.0.0.0"]

--- a/ftest/src/test/resources-wildfly/arquillian.xml
+++ b/ftest/src/test/resources-wildfly/arquillian.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="docker">
+        <property name="serverVersion">1.12</property>
+        <property name="serverUri">http://localhost:2375</property>
+        <property name="dockerContainers">
+            wildfly:
+              buildImage:
+                dockerfileLocation: src/test/resources-wildfly
+                noCache: true
+                remove: true
+              exposedPorts: [8080/tcp, 9990/tcp]
+              await:
+                strategy: polling
+              portBindings:
+                - exposedPort: 8080/tcp
+                  port: 8080
+
+                - exposedPort: 9990/tcp
+                  port: 9990
+        </property>
+    </extension>
+
+    <container qualifier="wildfly" default="true">
+        <configuration>
+            <property name="username">admin</property>
+            <property name="password">Admin#70365</property>
+        </configuration>
+    </container>
+
+</arquillian>


### PR DESCRIPTION
Scans the Arquillian Container TCK for test cases to run
on a WildFly 8 container created via a Dockerfile and started
via Cube.
