### PR TITLE
Check ExposedPort on ContainerIP during polling await check

### DIFF
--- a/docker/src/main/java/org/arquillian/cube/await/PollingAwaitStrategy.java
+++ b/docker/src/main/java/org/arquillian/cube/await/PollingAwaitStrategy.java
@@ -43,11 +43,10 @@ public class PollingAwaitStrategy implements AwaitStrategy {
         // this approach only works if you are not using boot2docker. In next versions we will add support for
         // boot2docker
         String containerIp = networkSettings.getIpAddress();
-        Collection<Binding> hostIpPort = bindings.values();
 
         // wait until container available
-        for (Binding binding : hostIpPort) {
-            if(!Ping.ping(containerIp, binding.getHostPort(), DEFAULT_POLL_ITERATIONS, DEFAULT_SLEEP_POLL_TIME,
+        for (Map.Entry<ExposedPort, Binding> binding : bindings.entrySet()) {
+            if(!Ping.ping(containerIp, binding.getKey().getPort(), DEFAULT_POLL_ITERATIONS, DEFAULT_SLEEP_POLL_TIME,
                     TimeUnit.MILLISECONDS)) {
                 return false;
             }

--- a/ftest/src/test/java/org/arquillian/cube/servlet/HelloWorldServletTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/HelloWorldServletTest.java
@@ -38,7 +38,7 @@ public class HelloWorldServletTest {
     @Test
     public void should_parse_and_load_configuration_file() throws IOException {
         
-        URL obj = new URL("http://localhost:8080/hello/HelloWorld");
+        URL obj = new URL("http://localhost:8081/hello/HelloWorld");
         HttpURLConnection con = (HttpURLConnection) obj.openConnection();
         con.setRequestMethod("GET");
         

--- a/ftest/src/test/resources-tomcat-7-dockerfile/arquillian.xml
+++ b/ftest/src/test/resources-tomcat-7-dockerfile/arquillian.xml
@@ -21,14 +21,14 @@
                   port: 8089
                   
                 - exposedPort: 8080/tcp
-                  port: 8080
+                  port: 8081
         </property>
     </extension>
 
     <container qualifier="tomcat" default="true">
         <configuration>
             <property name="host">localhost</property>
-            <property name="httpPort">8080</property>
+            <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>

--- a/ftest/src/test/resources-tomcat-7/arquillian.xml
+++ b/ftest/src/test/resources-tomcat-7/arquillian.xml
@@ -19,14 +19,14 @@
                   port: 8089
                   
                 - exposedPort: 8080/tcp
-                  port: 8080
+                  port: 8081
         </property>
     </extension>
 
     <container qualifier="tomcat" default="true">
         <configuration>
             <property name="host">localhost</property>
-            <property name="httpPort">8080</property>
+            <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>


### PR DESCRIPTION
Docker sets up a forward from localhost:Port to containerIP:ExposedPort.
We need to check the containerIP:ExposedPort and not the
containerIP:Port.

fixes #10
