### PR TITLE
Remap the ports returned by the Container in the ProtocolMetaData

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -32,6 +32,19 @@
         </dependency>
         
         <dependency>
+            <groupId>org.jboss.arquillian.container</groupId>
+            <artifactId>arquillian-container-impl-base</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.arquillian.core</groupId>
+            <artifactId>arquillian-core-impl-base</artifactId>
+            <classifier>tests</classifier>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-all</artifactId>
             <scope>test</scope>

--- a/docker/src/main/java/org/arquillian/cube/client/CubeExtension.java
+++ b/docker/src/main/java/org/arquillian/cube/client/CubeExtension.java
@@ -9,7 +9,8 @@ public class CubeExtension implements LoadableExtension {
     public void register(ExtensionBuilder builder) {
         builder.observer(CubeConfigurator.class);
         builder.observer(CubeLifecycle.class);
-        
+        builder.observer(ProtocolMetadataUpdater.class);
+
         builder.service(TestEnricher.class, ContainerEnricher.class);
         builder.service(TestEnricher.class, CubeEnricher.class);
     }

--- a/docker/src/main/java/org/arquillian/cube/client/ProtocolMetadataUpdater.java
+++ b/docker/src/main/java/org/arquillian/cube/client/ProtocolMetadataUpdater.java
@@ -1,0 +1,90 @@
+package org.arquillian.cube.client;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.container.spi.context.annotation.DeploymentScoped;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.EventContext;
+
+public class ProtocolMetadataUpdater {
+
+    private static final String EXPOSED_PORT = "exposedPort";
+    private static final String PORT = "port";
+    private static final String PORT_BINDINGS = "portBindings";
+
+    @Inject @DeploymentScoped
+    private InstanceProducer<ProtocolMetaData> protocolMetaDataProducer;
+
+    @Inject
+    private Instance<CubeConfiguration> configInst;
+
+    @Inject
+    private Instance<Container> containerInst;
+
+    public void update(@Observes EventContext<ProtocolMetaData> eventContext) {
+
+        ProtocolMetaData originalMetaData = eventContext.getEvent();
+        ProtocolMetaData updatedMetaData = new ProtocolMetaData();
+        boolean updated = false;
+
+        Map<Integer, Integer> portMapping = getPortMappings();
+        for(Object contextObj : originalMetaData.getContexts()) {
+            if(contextObj instanceof HTTPContext) {
+                HTTPContext context = (HTTPContext)contextObj;
+                Integer mapped = portMapping.get(context.getPort());
+                if(mapped != null && mapped != context.getPort()) {
+                    updated = true;
+                    HTTPContext newContext = new HTTPContext(context.getHost(), mapped);
+                    for(Servlet servlet : context.getServlets()) {
+                        newContext.add(servlet);
+                    }
+                    updatedMetaData.addContext(newContext);
+                }
+
+            } else {
+                updatedMetaData.addContext(contextObj);
+            }
+        }
+
+        if(updated) {
+            protocolMetaDataProducer.set(updatedMetaData);
+        } else {
+            eventContext.proceed();
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private Map<Integer, Integer> getPortMappings() {
+        Map<Integer, Integer> result = new HashMap<Integer, Integer>();
+
+        CubeConfiguration config = configInst.get();
+        Container container = containerInst.get();
+
+        if(config == null || container == null) {
+            return result;
+        }
+
+        Map<String, Object> containerConfig = (Map<String, Object>)config.getDockerContainersContent().get(container.getName());
+        List<Object> bindings = (List<Object>)containerConfig.get(PORT_BINDINGS);
+        for(Object bindingObj: bindings) {
+            Map<String, Object> binding = (Map<String, Object>)bindingObj;
+            Integer port = (Integer)binding.get(PORT);
+            String exposedPort = (String)binding.get(EXPOSED_PORT);
+            if(exposedPort.indexOf("/") != -1) {
+                exposedPort = exposedPort.substring(0, exposedPort.indexOf("/"));
+            }
+            result.put(Integer.parseInt(exposedPort), port);
+        }
+
+        return result;
+    }
+}

--- a/docker/src/test/java/org/arquillian/cube/client/ProtocolMetaDataUpdaterTestCase.java
+++ b/docker/src/test/java/org/arquillian/cube/client/ProtocolMetaDataUpdaterTestCase.java
@@ -1,0 +1,136 @@
+package org.arquillian.cube.client;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.jboss.arquillian.config.descriptor.impl.ContainerDefImpl;
+import org.jboss.arquillian.container.impl.ContainerImpl;
+import org.jboss.arquillian.container.spi.Container;
+import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
+import org.jboss.arquillian.container.spi.client.deployment.Deployment;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
+import org.jboss.arquillian.container.spi.context.ContainerContext;
+import org.jboss.arquillian.container.spi.context.DeploymentContext;
+import org.jboss.arquillian.container.spi.context.annotation.ContainerScoped;
+import org.jboss.arquillian.container.spi.context.annotation.DeploymentScoped;
+import org.jboss.arquillian.container.test.AbstractContainerTestBase;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.spi.Manager;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class ProtocolMetaDataUpdaterTestCase extends AbstractContainerTestBase {
+
+    @Mock
+    private Deployment deployment;
+
+    @Mock
+    private DeployableContainer<?> deployableContainer;
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        super.addExtensions(extensions);
+        extensions.add(ProtocolMetadataUpdater.class);
+    }
+
+    @Override
+    protected void startContexts(Manager manager) {
+        super.startContexts(manager);
+        manager.getContext(ContainerContext.class).activate("test");
+        manager.getContext(DeploymentContext.class).activate(deployment);
+    }
+
+    @Test
+    public void shouldNotUpdateWhenPortsAreEqual() throws Exception {
+        Map<String, String> configuration = new HashMap<String, String>();
+        configuration.put("dockerContainers", "test:\n  portBindings:\n  - exposedPort: 80/tcp\n    ports: 80\n");
+
+        bind(ContainerScoped.class,
+             Container.class,
+             new ContainerImpl("test", deployableContainer, new ContainerDefImpl("arquillian.xml")));
+
+        getManager().bind(ApplicationScoped.class, CubeConfiguration.class, CubeConfiguration.fromMap(configuration));
+
+        ProtocolMetaData metadata = new ProtocolMetaData();
+        metadata.addContext(new HTTPContext("localhost", 80).add(new Servlet("A", "B")));
+
+        bind(DeploymentScoped.class, ProtocolMetaData.class, metadata);
+        fire(metadata);
+
+        ProtocolMetaData updated = getManager().getContext(DeploymentContext.class)
+                .getObjectStore().get(ProtocolMetaData.class);
+
+        Assert.assertEquals(metadata.getContexts(HTTPContext.class).iterator().next(), updated.getContexts(HTTPContext.class).iterator().next());
+        assertEventFired(ProtocolMetaData.class, 1);
+    }
+
+    @Test
+    public void shouldUpdateWhenPortsAreNotEqual() throws Exception {
+        Map<String, String> configuration = new HashMap<String, String>();
+        configuration.put("dockerContainers", "test:\n  portBindings:\n  - exposedPort: 80/tcp\n    port: 90\n");
+
+        bind(ContainerScoped.class,
+             Container.class,
+             new ContainerImpl("test", deployableContainer, new ContainerDefImpl("arquillian.xml")));
+
+        getManager().bind(ApplicationScoped.class, CubeConfiguration.class, CubeConfiguration.fromMap(configuration));
+
+        ProtocolMetaData metadata = new ProtocolMetaData();
+        metadata.addContext(new HTTPContext("localhost", 80).add(new Servlet("A", "B")));
+
+        bind(DeploymentScoped.class, ProtocolMetaData.class, metadata);
+        fire(metadata);
+
+        ProtocolMetaData updated = getManager().getContext(DeploymentContext.class)
+                .getObjectStore().get(ProtocolMetaData.class);
+
+        Assert.assertEquals(90, updated.getContexts(HTTPContext.class).iterator().next().getPort());
+        assertEventFired(ProtocolMetaData.class, 1); // twice, but original fire is intercepted and never hit the Counter
+    }
+
+    @Test
+    public void shouldNotFailOnMissingContainer() throws Exception {
+        Map<String, String> configuration = new HashMap<String, String>();
+        configuration.put("dockerContainers", "test:\n  portBindings:\n  - exposedPort: 80/tcp\n    port: 90\n");
+
+        getManager().bind(ApplicationScoped.class, CubeConfiguration.class, CubeConfiguration.fromMap(configuration));
+
+        ProtocolMetaData metadata = new ProtocolMetaData();
+        metadata.addContext(new HTTPContext("localhost", 80).add(new Servlet("A", "B")));
+
+        bind(DeploymentScoped.class, ProtocolMetaData.class, metadata);
+        fire(metadata);
+
+        ProtocolMetaData updated = getManager().getContext(DeploymentContext.class)
+                .getObjectStore().get(ProtocolMetaData.class);
+
+        Assert.assertEquals(80, updated.getContexts(HTTPContext.class).iterator().next().getPort());
+        assertEventFired(ProtocolMetaData.class, 1);
+    }
+
+    @Test
+    public void shouldNotFailOnMissingCubeConfiguration() throws Exception {
+        bind(ContainerScoped.class,
+                Container.class,
+                new ContainerImpl("test", deployableContainer, new ContainerDefImpl("arquillian.xml")));
+
+        ProtocolMetaData metadata = new ProtocolMetaData();
+        metadata.addContext(new HTTPContext("localhost", 80).add(new Servlet("A", "B")));
+
+        bind(DeploymentScoped.class, ProtocolMetaData.class, metadata);
+        fire(metadata);
+
+        ProtocolMetaData updated = getManager().getContext(DeploymentContext.class)
+                .getObjectStore().get(ProtocolMetaData.class);
+
+        Assert.assertEquals(80, updated.getContexts(HTTPContext.class).iterator().next().getPort());
+        assertEventFired(ProtocolMetaData.class, 1);
+    }
+}

--- a/ftest/src/test/java/org/arquillian/cube/servlet/HelloWorldServletTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/HelloWorldServletTest.java
@@ -1,8 +1,8 @@
 package org.arquillian.cube.servlet;
 
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
 
 import java.io.BufferedReader;
 import java.io.IOException;
@@ -14,6 +14,7 @@ import org.arquillian.cube.Container;
 import org.arquillian.cube.Cube;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
@@ -36,9 +37,9 @@ public class HelloWorldServletTest {
     DockerClient dockerClient;
     
     @Test
-    public void should_parse_and_load_configuration_file() throws IOException {
+    public void should_parse_and_load_configuration_file(@ArquillianResource URL base) throws IOException {
         
-        URL obj = new URL("http://localhost:8081/hello/HelloWorld");
+        URL obj = new URL(base, "HelloWorld");
         HttpURLConnection con = (HttpURLConnection) obj.openConnection();
         con.setRequestMethod("GET");
         

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,20 @@
                 <scope>import</scope>
             </dependency>
             <dependency>
+                <groupId>org.jboss.arquillian.container</groupId>
+                <artifactId>arquillian-container-impl-base</artifactId>
+                <version>${version.arquillian_core}</version>
+                <classifier>tests</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
+                <groupId>org.jboss.arquillian.core</groupId>
+                <artifactId>arquillian-core-impl-base</artifactId>
+                <version>${version.arquillian_core}</version>
+                <classifier>tests</classifier>
+                <scope>test</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.github.docker-java</groupId>
                 <artifactId>docker-java</artifactId>
                 <version>${version.docker-java}</version>


### PR DESCRIPTION
The Container only knows about the ports it self is bound to,
not how Docker is remapping them from the outside.

When e.g. the Container is bound to port 8080 inside Docker
and Docker PortForward from external port 8081 to internal
8080 the ProtocolMetaData is of. This effects the ServletProtocol
which is attempting to use this information to communicate with
the in-container test case as well as URL injection on the client
side via @ArquillianResource.

When the ProtocolMetaData is created, the object is intercepted
bu Cube to update the data based on the port we know are being
forwarded.

fixes #12
