### PR TITLE
Add support for Auto starting Cubes outside of Arquillian Containers

### DIFF
--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
@@ -4,6 +4,7 @@ import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.util.Map;
 
+import org.arquillian.cube.impl.util.ConfigUtil;
 import org.yaml.snakeyaml.Yaml;
 
 public class CubeConfiguration {
@@ -13,10 +14,12 @@ public class CubeConfiguration {
     private static final String DOCKER_CONTAINERS = "dockerContainers";
     private static final String DOCKER_CONTAINERS_FILE = "dockerContainersFile";
     private static final String DOCKER_REGISTRY = "dockerRegistry";
+    private static final String AUTO_START_CONTAINERS = "autoStartContainers";
 
     private String dockerServerVersion;
     private String dockerServerUri;
     private String dockerRegistry;
+    private String[] autoStartContainers = new String[0];
 
     private Map<String, Object> dockerContainersContent;
 
@@ -34,6 +37,10 @@ public class CubeConfiguration {
 
     public String getDockerRegistry() {
         return dockerRegistry;
+    }
+
+    public String[] getAutoStartContainers() {
+        return autoStartContainers;
     }
 
     @SuppressWarnings("unchecked")
@@ -66,7 +73,9 @@ public class CubeConfiguration {
                 throw new IllegalArgumentException(e);
             }
         }
-
+        if(map.containsKey(AUTO_START_CONTAINERS)) {
+            cubeConfiguration.autoStartContainers = ConfigUtil.trim(map.get(AUTO_START_CONTAINERS).split(","));
+        }
         return cubeConfiguration;
     }
 }

--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeExtension.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeExtension.java
@@ -15,6 +15,7 @@ public class CubeExtension implements LoadableExtension {
                .observer(CubeClientCreator.class)
                .observer(CubeRegistrar.class)
                .observer(CubeLifecycleController.class)
+               .observer(CubeSuiteLifecycleController.class)
                .observer(CubeContainerLifecycleController.class);
 
         builder.observer(ProtocolMetadataUpdater.class);

--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleController.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleController.java
@@ -1,0 +1,33 @@
+package org.arquillian.cube.impl.client;
+
+import org.arquillian.cube.impl.util.ConfigUtil;
+import org.arquillian.cube.spi.event.CreateCube;
+import org.arquillian.cube.spi.event.CubeControlEvent;
+import org.arquillian.cube.spi.event.DestroyCube;
+import org.arquillian.cube.spi.event.StartCube;
+import org.arquillian.cube.spi.event.StopCube;
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+
+public class CubeSuiteLifecycleController {
+
+    @Inject
+    private Event<CubeControlEvent> controlEvent;
+
+    public void startAutoContainers(@Observes(precedence = 100) BeforeSuite event, CubeConfiguration configuration) {
+        for(String cubeId : configuration.getAutoStartContainers()) {
+            controlEvent.fire(new CreateCube(cubeId));
+            controlEvent.fire(new StartCube(cubeId));
+        }
+    }
+
+    public void stopAutoContainers(@Observes(precedence = -100) AfterSuite event, CubeConfiguration configuration) {
+        for(String cubeId : ConfigUtil.reverse(configuration.getAutoStartContainers())) {
+            controlEvent.fire(new StopCube(cubeId));
+            controlEvent.fire(new DestroyCube(cubeId));
+        }
+    }
+}

--- a/docker/src/main/java/org/arquillian/cube/impl/util/ConfigUtil.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/ConfigUtil.java
@@ -1,0 +1,29 @@
+package org.arquillian.cube.impl.util;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public final class ConfigUtil {
+
+    private ConfigUtil() {}
+
+    public static String[] trim(String[] data) {
+        List<String> result = new ArrayList<String>();
+        for(String val : data) {
+            String trimmed = val.trim();
+            if(!trimmed.isEmpty()) {
+                result.add(trimmed);
+            }
+        }
+        return result.toArray(new String[]{});
+    }
+
+    public static String[] reverse(String[] cubeIds) {
+        String[] result = new String[cubeIds.length];
+        int n = cubeIds.length-1;
+        for(int i = 0; i < cubeIds.length; i++) {
+            result[n--] = cubeIds[i];
+        }
+        return result;
+    }
+}

--- a/docker/src/test/java/org/arquillian/cube/impl/client/CubeConfigurationTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/CubeConfigurationTest.java
@@ -12,6 +12,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import org.arquillian.cube.impl.client.CubeConfiguration;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -74,5 +75,37 @@ public class CubeConfigurationTest {
 
         String image = (String) actualTomcat.get("image");
         assertThat(image, is("tutum/tomcat:7.0"));
+    }
+
+    @Test
+    public void should_parse_empty_autostart() throws Exception {
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("autoStartContainers", "");
+
+        CubeConfiguration cubeConfiguration = CubeConfiguration.fromMap(parameters);
+        Assert.assertNotNull(cubeConfiguration.getAutoStartContainers());
+        Assert.assertEquals(0, cubeConfiguration.getAutoStartContainers().length);
+    }
+
+    @Test
+    public void should_parse_empty_values_autostart() throws Exception {
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("autoStartContainers", "  ,   ");
+
+        CubeConfiguration cubeConfiguration = CubeConfiguration.fromMap(parameters);
+        Assert.assertNotNull(cubeConfiguration.getAutoStartContainers());
+        Assert.assertEquals(0, cubeConfiguration.getAutoStartContainers().length);
+    }
+
+    @Test
+    public void should_parse_trim_autostart() throws Exception {
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("autoStartContainers", "a , b ");
+
+        CubeConfiguration cubeConfiguration = CubeConfiguration.fromMap(parameters);
+        Assert.assertNotNull(cubeConfiguration.getAutoStartContainers());
+        Assert.assertEquals(2, cubeConfiguration.getAutoStartContainers().length);
+        Assert.assertEquals("a", cubeConfiguration.getAutoStartContainers()[0]);
+        Assert.assertEquals("b", cubeConfiguration.getAutoStartContainers()[1]);
     }
 }

--- a/docker/src/test/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleControllerTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleControllerTest.java
@@ -1,0 +1,54 @@
+package org.arquillian.cube.impl.client;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.arquillian.cube.spi.event.CreateCube;
+import org.arquillian.cube.spi.event.DestroyCube;
+import org.arquillian.cube.spi.event.StartCube;
+import org.arquillian.cube.spi.event.StopCube;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.test.AbstractManagerTestBase;
+import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
+import org.junit.Test;
+
+public class CubeSuiteLifecycleControllerTest extends AbstractManagerTestBase {
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        extensions.add(CubeSuiteLifecycleController.class);
+        super.addExtensions(extensions);
+    }
+
+    @Test
+    public void shouldCreateAndStartAutoContainers() {
+
+        Map<String, String> data = new HashMap<String, String>();
+        data.put("autoStartContainers", "a,b");
+
+        CubeConfiguration configuration = CubeConfiguration.fromMap(data);
+        bind(ApplicationScoped.class, CubeConfiguration.class, configuration);
+
+        fire(new BeforeSuite());
+
+        assertEventFired(CreateCube.class, 2);
+        assertEventFired(StartCube.class, 2);
+    }
+
+    @Test
+    public void shouldStopAndDestroyAutoContainers() {
+
+        Map<String, String> data = new HashMap<String, String>();
+        data.put("autoStartContainers", "a,b");
+
+        CubeConfiguration configuration = CubeConfiguration.fromMap(data);
+        bind(ApplicationScoped.class, CubeConfiguration.class, configuration);
+
+        fire(new AfterSuite());
+
+        assertEventFired(StopCube.class, 2);
+        assertEventFired(DestroyCube.class, 2);
+    }
+}

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -8,6 +8,22 @@
     </parent>
     <artifactId>arquillian-cube-ftest</artifactId>
 
+    <properties>
+        <arquillian.cube.autostart></arquillian.cube.autostart>
+    </properties>
+
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.jboss.spec</groupId>
+                <artifactId>jboss-javaee-7.0</artifactId>
+                <version>1.0.1.Final</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
+
     <dependencies>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
@@ -19,6 +35,27 @@
             <artifactId>arquillian-cube-docker</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.jboss.spec.javax.servlet</groupId>
+            <artifactId>jboss-servlet-api_3.1_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.ejb</groupId>
+            <artifactId>jboss-ejb-api_3.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.hibernate.javax.persistence</groupId>
+            <artifactId>hibernate-jpa-2.1-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.jboss.spec.javax.annotation</groupId>
+            <artifactId>jboss-annotations-api_1.2_spec</artifactId>
+            <scope>provided</scope>
+        </dependency>
     </dependencies>
 
     <build>
@@ -27,8 +64,12 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
                     <systemPropertyVariables>
-                        <arquillian.launch>${arquillian.launch}</arquillian.launch>
+                       <arquillian.launch>${arquillian.launch}</arquillian.launch>
+                       <arquillian.cube.autostart>${arquillian.cube.autostart}</arquillian.cube.autostart>
                     </systemPropertyVariables>
+                   <excludes>
+                       <exclude>**/persistence/**</exclude>
+                   </excludes>
                 </configuration>
             </plugin>
         </plugins>
@@ -56,12 +97,6 @@
                     <version>1.0.0.CR7</version>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-servlet-api</artifactId>
-                    <version>7.0.56</version>
-                    <scope>provided</scope>
-                </dependency>
             </dependencies>
         </profile>
 
@@ -77,48 +112,17 @@
                     <version>1.0.0.CR7</version>
                     <scope>test</scope>
                 </dependency>
-                <dependency>
-                    <groupId>org.apache.tomcat</groupId>
-                    <artifactId>tomcat-servlet-api</artifactId>
-                    <version>7.0.56</version>
-                    <scope>provided</scope>
-                </dependency>
             </dependencies>
         </profile>
 
         <profile>
-            <id>wildfly-8-tck</id>
-            <properties>
-                <arquillian.launch>wildfly</arquillian.launch>
-            </properties>
-            <dependencyManagement>
-                <dependencies>
-                    <dependency>
-                        <groupId>org.jboss.spec</groupId>
-                        <artifactId>jboss-javaee-7.0</artifactId>
-                        <version>1.0.1.Final</version>
-                        <type>pom</type>
-                        <scope>import</scope>
-                    </dependency>
-                </dependencies>
-            </dependencyManagement>
+            <id>tck</id>
             <dependencies>
                 <dependency>
                     <groupId>org.arquillian.tck.container</groupId>
                     <artifactId>arquillian-tck-container</artifactId>
                     <version>1.0.0.Alpha1</version>
                     <classifier>tests</classifier>
-                    <scope>test</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.jboss.spec.javax.servlet</groupId>
-                    <artifactId>jboss-servlet-api_3.1_spec</artifactId>
-                    <scope>provided</scope>
-                </dependency>
-                <dependency>
-                    <groupId>org.wildfly</groupId>
-                    <artifactId>wildfly-arquillian-container-remote</artifactId>
-                    <version>8.1.0.Final</version>
                     <scope>test</scope>
                 </dependency>
             </dependencies>
@@ -139,10 +143,60 @@
             </build>
         </profile>
         <profile>
+            <id>wildfly-8</id>
+            <properties>
+                <arquillian.launch>wildfly</arquillian.launch>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                    <version>8.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>wildfly-8-group</id>
             <properties>
                 <arquillian.launch>wildfly-group</arquillian.launch>
             </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                    <version>8.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
+            <id>wildfly-8-database</id>
+            <properties>
+                <arquillian.launch>wildfly_database</arquillian.launch>
+                <arquillian.cube.autostart>database</arquillian.cube.autostart>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>org.wildfly</groupId>
+                    <artifactId>wildfly-arquillian-container-remote</artifactId>
+                    <version>8.1.0.Final</version>
+                    <scope>test</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <systemPropertyVariables>
+                               <arquillian.launch>${arquillian.launch}</arquillian.launch>
+                               <arquillian.cube.autostart>${arquillian.cube.autostart}</arquillian.cube.autostart>
+                            </systemPropertyVariables>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 

--- a/ftest/src/main/java/org/arquillian/cube/persistence/User.java
+++ b/ftest/src/main/java/org/arquillian/cube/persistence/User.java
@@ -1,0 +1,30 @@
+package org.arquillian.cube.persistence;
+
+import java.util.UUID;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+
+@Entity
+public class User {
+
+    @Id
+    private String id;
+
+    private String name;
+
+    protected User() {}
+
+    public User(String name) {
+        this.id = UUID.randomUUID().toString();
+        this.name = name;
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+}

--- a/ftest/src/main/java/org/arquillian/cube/persistence/UserRepository.java
+++ b/ftest/src/main/java/org/arquillian/cube/persistence/UserRepository.java
@@ -1,0 +1,24 @@
+package org.arquillian.cube.persistence;
+
+import javax.annotation.sql.DataSourceDefinition;
+import javax.ejb.Stateless;
+import javax.persistence.EntityManager;
+import javax.persistence.PersistenceContext;
+
+@DataSourceDefinition(
+  name = "java:app/TestDataSource",
+  className = "org.h2.jdbcx.JdbcDataSource",
+  url = "jdbc:h2:tcp://database:1521/opt/h2-data/test",
+  user = "sa",
+  password = "sa"
+)
+@Stateless
+public class UserRepository {
+
+    @PersistenceContext
+    private EntityManager em;
+
+    public void store(User user) {
+        em.persist(user);
+    }
+}

--- a/ftest/src/test/java/org/arquillian/cube/persistence/UserRepositoryTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/persistence/UserRepositoryTest.java
@@ -1,0 +1,35 @@
+package org.arquillian.cube.persistence;
+
+import java.io.IOException;
+
+import javax.inject.Inject;
+
+import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.EmptyAsset;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.api.spec.WebArchive;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+@RunWith(Arquillian.class)
+public class UserRepositoryTest {
+
+    @Deployment
+    public static WebArchive create() {
+        return ShrinkWrap.create(WebArchive.class)
+                .addClasses(User.class, UserRepository.class, UserRepositoryTest.class)
+                .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml")
+                .addAsResource("test-persistence.xml", "META-INF/persistence.xml")
+                .addAsManifestResource(new StringAsset("Dependencies: com.h2database.h2\n"),"MANIFEST.MF");
+    }
+
+    @Inject
+    private UserRepository repository;
+
+    @Test
+    public void shouldStoreUser() throws IOException {
+        repository.store(new User("test"));
+    }
+}

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -7,6 +7,7 @@
     <extension qualifier="docker">
         <property name="serverVersion">1.12</property>
         <property name="serverUri">http://localhost:2375</property>
+        <property name="autoStartContainers">${arquillian.cube.autostart}</property>
         <property name="dockerContainers">
             tomcat:
               image: tutum/tomcat:7.0
@@ -48,6 +49,22 @@
 
                 - exposedPort: 9990/tcp
                   port: 9991
+            wildfly_database:
+              buildImage:
+                dockerfileLocation: src/test/resources/wildfly
+                noCache: true
+                remove: true
+              exposedPorts: [8080/tcp, 9990/tcp]
+              await:
+                strategy: polling
+              links:
+                - database:database
+              portBindings:
+                - exposedPort: 8080/tcp
+                  port: 8081
+
+                - exposedPort: 9990/tcp
+                  port: 9991
             wildfly2:
               buildImage:
                 dockerfileLocation: src/test/resources/wildfly
@@ -62,6 +79,17 @@
 
                 - exposedPort: 9990/tcp
                   port: 9992
+            database:
+              image: zhilvis/h2-db
+              exposedPorts: [81/tcp, 1521/tcp]
+              await:
+                strategy: polling
+              portBindings:
+                - exposedPort: 1521/tcp
+                  port: 1521
+
+                - exposedPort: 81/tcp
+                  port: 8181
         </property>
     </extension>
 
@@ -82,6 +110,14 @@
         </configuration>
     </container>
     <container qualifier="wildfly">
+        <configuration>
+            <property name="target">wildfly:8.1.0.Final:remote</property>
+            <property name="managementPort">9991</property>
+            <property name="username">admin</property>
+            <property name="password">Admin#70365</property>
+        </configuration>
+    </container>
+    <container qualifier="wildfly_database">
         <configuration>
             <property name="target">wildfly:8.1.0.Final:remote</property>
             <property name="managementPort">9991</property>

--- a/ftest/src/test/resources/test-persistence.xml
+++ b/ftest/src/test/resources/test-persistence.xml
@@ -1,0 +1,14 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<persistence xmlns="http://java.sun.com/xml/ns/persistence" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_1_0.xsd"
+    version="1.0">
+    <persistence-unit name="test">
+        <jta-data-source>java:app/TestDataSource</jta-data-source>
+        <exclude-unlisted-classes>false</exclude-unlisted-classes>
+        <properties>
+            <property name="hibernate.hbm2ddl.auto" value="create-drop" />
+            <property name="hibernate.show_sql" value="true" />
+            <property name="wildfly.jpa.twophasebootstrap" value="false" />
+        </properties>
+    </persistence-unit>
+</persistence>


### PR DESCRIPTION
Adds configuration option autoStartContainers that takes a list
of cubeIds to create/start/stop/destroy in the Suite scope.

fixes #15
