### PR TITLE
Add simple 'extends' option to configuration

### DIFF
--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
@@ -61,14 +61,14 @@ public class CubeConfiguration {
 
         if (map.containsKey(DOCKER_CONTAINERS)) {
             String content = map.get(DOCKER_CONTAINERS);
-            cubeConfiguration.dockerContainersContent = (Map<String, Object>) new Yaml().load(content);
+            cubeConfiguration.dockerContainersContent = ConfigUtil.applyExtendsRules((Map<String, Object>) new Yaml().load(content));
         }
 
         if (map.containsKey(DOCKER_CONTAINERS_FILE)) {
             String location = map.get(DOCKER_CONTAINERS_FILE);
             try {
-                cubeConfiguration.dockerContainersContent = (Map<String, Object>) new Yaml().load(new FileInputStream(
-                        location));
+                cubeConfiguration.dockerContainersContent = ConfigUtil.applyExtendsRules((Map<String, Object>) new Yaml().load(new FileInputStream(
+                        location)));
             } catch (FileNotFoundException e) {
                 throw new IllegalArgumentException(e);
             }

--- a/docker/src/main/java/org/arquillian/cube/impl/util/ConfigUtil.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/ConfigUtil.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.impl.util;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 
 public final class ConfigUtil {
 
@@ -25,5 +26,26 @@ public final class ConfigUtil {
             result[n--] = cubeIds[i];
         }
         return result;
+    }
+
+    public static Map<String, Object> applyExtendsRules(Map<String, Object> containerConfig) {
+        for(Map.Entry<String, Object> containerEntry : containerConfig.entrySet()) {
+            @SuppressWarnings("unchecked")
+            Map<String, Object> container = (Map<String, Object>)containerEntry.getValue();
+            if(container.containsKey("extends")) {
+                String extendsContainer = container.get("extends").toString();
+                if(!containerConfig.containsKey(extendsContainer)) {
+                    throw new IllegalArgumentException(containerEntry.getKey() + " extends a non existing container definition " + extendsContainer);
+                }
+                @SuppressWarnings("unchecked")
+                Map<String, Object> extendedContainer = (Map<String, Object>)containerConfig.get(extendsContainer);
+                for(Map.Entry<String, Object> extendedContainerEntry : extendedContainer.entrySet()) {
+                    if(!container.containsKey(extendedContainerEntry.getKey())) {
+                        container.put(extendedContainerEntry.getKey(), extendedContainerEntry.getValue());
+                    }
+                }
+            }
+        }
+        return containerConfig;
     }
 }

--- a/docker/src/test/java/org/arquillian/cube/impl/client/CubeConfigurationTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/CubeConfigurationTest.java
@@ -9,9 +9,9 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-import org.arquillian.cube.impl.client.CubeConfiguration;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
@@ -107,5 +107,30 @@ public class CubeConfigurationTest {
         Assert.assertEquals(2, cubeConfiguration.getAutoStartContainers().length);
         Assert.assertEquals("a", cubeConfiguration.getAutoStartContainers()[0]);
         Assert.assertEquals("b", cubeConfiguration.getAutoStartContainers()[1]);
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void should_be_able_to_extend_and_override_toplevel() throws Exception {
+        String config =
+                "tomcat6:\n" +
+                "  image: tutum/tomcat:6.0\n" +
+                "  exposedPorts: [8089/tcp]\n" +
+                "  await:\n" +
+                "    strategy: static\n" +
+                "    ip: localhost\n" +
+                "    ports: [8080, 8089]\n" +
+                "tomcat7:\n" +
+                "  extends: tomcat6\n" +
+                "  image: tutum/tomcat:7.0\n";
+
+        Map<String, String> parameters = new HashMap<String, String>();
+        parameters.put("dockerContainers", config);
+        CubeConfiguration cubeConfiguration = CubeConfiguration.fromMap(parameters);
+
+        Map<String, Object> tomcat7 = (Map<String, Object>)cubeConfiguration.getDockerContainersContent().get("tomcat7");
+        Assert.assertEquals("tutum/tomcat:7.0", tomcat7.get("image").toString());
+        Assert.assertTrue(tomcat7.containsKey("await"));
+        Assert.assertEquals("8089/tcp", ((List<Object>)tomcat7.get("exposedPorts")).get(0).toString());
     }
 }

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -50,29 +50,11 @@
                 - exposedPort: 9990/tcp
                   port: 9991
             wildfly_database:
-              buildImage:
-                dockerfileLocation: src/test/resources/wildfly
-                noCache: true
-                remove: true
-              exposedPorts: [8080/tcp, 9990/tcp]
-              await:
-                strategy: polling
+              extends: wildfly
               links:
                 - database:database
-              portBindings:
-                - exposedPort: 8080/tcp
-                  port: 8081
-
-                - exposedPort: 9990/tcp
-                  port: 9991
             wildfly2:
-              buildImage:
-                dockerfileLocation: src/test/resources/wildfly
-                noCache: true
-                remove: true
-              exposedPorts: [8080/tcp, 9990/tcp]
-              await:
-                strategy: polling
+              extends: wildfly
               portBindings:
                 - exposedPort: 8080/tcp
                   port: 8082


### PR DESCRIPTION
Allow a Docker Container configuration to extend another.
All top level config elements from the extended container
will be copied over to the new configuration unless the new
configuration has defined them.

```
tomcat:
  image: x
  exposedPorts: [8080/tcp]
tomcat2:
  extends: tomcat
  image: y
```

tomcat2 will have the same exposedPorts as tomcat, but a different image.

fixes #32
