### PR TITLE
Issue 81

### DIFF
--- a/containerless/pom.xml
+++ b/containerless/pom.xml
@@ -45,6 +45,8 @@
         <tests.exp.undertow>**/*Daytime*</tests.exp.undertow>
         <tests.container.node>node</tests.container.node>
         <tests.container.undertow>daytime</tests.container.undertow>
+        <docker.api.version>1.12</docker.api.version>
+        <docker.api.url>http://localhost:2375</docker.api.url>
     </properties>
 
     <profiles>

--- a/containerless/src/test/resources/arquillian.xml
+++ b/containerless/src/test/resources/arquillian.xml
@@ -5,8 +5,8 @@
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <extension qualifier="docker">
-        <property name="serverVersion">1.12</property>
-        <property name="serverUri">http://localhost:2375</property>
+        <property name="serverVersion">${docker.api.version}</property>
+        <property name="serverUri">${docker.api.url}</property>
         <property name="dockerContainers">
             daytime:
               buildImage:

--- a/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
@@ -123,9 +123,6 @@ public class DockerClientExecutor {
 
         String image = getImageName(containerConfiguration);
 
-
-
-
         CreateContainerCmd createContainerCmd = this.dockerClient.createContainerCmd(image);
         createContainerCmd.withName(name);
 
@@ -221,46 +218,7 @@ public class DockerClientExecutor {
             this.pullImage(image);
             return createContainerCmd.exec().getId();
         }
-        //we may call create when it already exists.  If this is the case, we simply swallow it
-        catch(ConflictException ce){
-
-            final String message = ce.getMessage();
-
-            if(message.contains( name ) && message.contains("already assigned")) {
-                log.info( "The container " + name + " already exists, reusing" );
-                return getContainerId( name );
-            }
-
-            //not an exception we handle, re-throw
-            throw ce;
-        }
     }
-
-
-    /**
-     * Get the container ID for the name.  If it cannot be found, an exception will be thrown
-     * @param name The image name to search
-     * @return The id for the image
-     * @throws com.github.dockerjava.api.NotFoundException if the image cannot be found by name
-     */
-    private String getContainerId(final String name) throws NotFoundException{
-        final List<Container> results = this.dockerClient.listContainersCmd().withShowAll( true ).exec();
-
-        for(Container container: results ){
-
-            for(String containerName: container.getNames()) {
-                //we have to trim off the leading slash '/' char
-                final String trimmedName = containerName.substring( 1 );
-
-                if ( name.equals( trimmedName ) ) {
-                    return container.getId();
-                }
-            }
-        }
-
-        throw new NotFoundException("Could not find a docker image id with name '" + name + "'");
-    }
-
 
     private Set<ExposedPort> resolveExposedPorts(Map<String, Object> containerConfiguration, CreateContainerCmd createContainerCmd) {
         Set<ExposedPort> allExposedPorts = new HashSet<>();
@@ -491,7 +449,7 @@ public class DockerClientExecutor {
 
     public void pullImage(String imageName) {
 
-        PullImageCmd pullImageCmd = this.dockerClient.pullImageCmd( imageName );
+        PullImageCmd pullImageCmd = this.dockerClient.pullImageCmd(imageName);
 
         if (this.cubeConfiguration.getDockerRegistry() != null) {
             pullImageCmd.withRegistry(this.cubeConfiguration.getDockerRegistry());

--- a/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
@@ -7,6 +7,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.MalformedURLException;
+import java.net.URI;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashSet;
@@ -93,11 +94,19 @@ public class DockerClientExecutor {
 
     private DockerClient dockerClient;
     private CubeConfiguration cubeConfiguration;
+    private final URI dockerUri;
 
     public DockerClientExecutor(CubeConfiguration cubeConfiguration) {
         DockerClientConfigBuilder configBuilder = DockerClientConfig.createDefaultConfigBuilder();
-        configBuilder.withVersion(cubeConfiguration.getDockerServerVersion()).withUri(
-                cubeConfiguration.getDockerServerUri());
+
+
+
+        //TODO, if this is already set from the client natively, do we want to override here?
+
+        dockerUri =  URI.create( cubeConfiguration.getDockerServerUri() );
+
+        configBuilder.withVersion(cubeConfiguration.getDockerServerVersion()).withUri( dockerUri.toString() );
+
 
         this.dockerClient = DockerClientBuilder.getInstance(configBuilder.build()).build();
         this.cubeConfiguration = cubeConfiguration;
@@ -249,7 +258,7 @@ public class DockerClientExecutor {
             }
         }
 
-        throw new NotFoundException("Could not find a docker image id with name");
+        throw new NotFoundException("Could not find a docker image id with name '" + name + "'");
     }
 
 
@@ -499,6 +508,15 @@ public class DockerClientExecutor {
         // To wait until image is pull we need to listen input stream until it is closed by the server
         // At this point we can be sure that image is already pulled.
         IOUtil.asString(exec);
+    }
+
+
+    /**
+     * Get the URI of the docker host
+     * @return
+     */
+    public URI getDockerUri(){
+        return dockerUri;
     }
 
     private static final Device[] toDevices(List<Map<String, Object>> devicesMap) {

--- a/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
@@ -23,6 +23,7 @@ import org.arquillian.cube.impl.client.CubeConfiguration;
 import org.arquillian.cube.impl.util.BindingUtil;
 import org.arquillian.cube.impl.util.IOUtil;
 
+import com.github.dockerjava.api.ConflictException;
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.NotFoundException;
 import com.github.dockerjava.api.command.BuildImageCmd;
@@ -40,6 +41,7 @@ import com.github.dockerjava.api.model.Link;
 import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
 import com.github.dockerjava.api.model.RestartPolicy;
+import com.github.dockerjava.api.model.SearchItem;
 import com.github.dockerjava.api.model.Volume;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
@@ -111,6 +113,9 @@ public class DockerClientExecutor {
         this.pingDockerServer();
 
         String image = getImageName(containerConfiguration);
+
+
+
 
         CreateContainerCmd createContainerCmd = this.dockerClient.createContainerCmd(image);
         createContainerCmd.withName(name);
@@ -207,7 +212,46 @@ public class DockerClientExecutor {
             this.pullImage(image);
             return createContainerCmd.exec().getId();
         }
+        //we may call create when it already exists.  If this is the case, we simply swallow it
+        catch(ConflictException ce){
+
+            final String message = ce.getMessage();
+
+            if(message.contains( name ) && message.contains("already assigned")) {
+                log.info( "The container " + name + " already exists, reusing" );
+                return getContainerId( name );
+            }
+
+            //not an exception we handle, re-throw
+            throw ce;
+        }
     }
+
+
+    /**
+     * Get the container ID for the name.  If it cannot be found, an exception will be thrown
+     * @param name The image name to search
+     * @return The id for the image
+     * @throws com.github.dockerjava.api.NotFoundException if the image cannot be found by name
+     */
+    private String getContainerId(final String name) throws NotFoundException{
+        final List<Container> results = this.dockerClient.listContainersCmd().withShowAll( true ).exec();
+
+        for(Container container: results ){
+
+            for(String containerName: container.getNames()) {
+                //we have to trim off the leading slash '/' char
+                final String trimmedName = containerName.substring( 1 );
+
+                if ( name.equals( trimmedName ) ) {
+                    return container.getId();
+                }
+            }
+        }
+
+        throw new NotFoundException("Could not find a docker image id with name");
+    }
+
 
     private Set<ExposedPort> resolveExposedPorts(Map<String, Object> containerConfiguration, CreateContainerCmd createContainerCmd) {
         Set<ExposedPort> allExposedPorts = new HashSet<>();
@@ -438,7 +482,7 @@ public class DockerClientExecutor {
 
     public void pullImage(String imageName) {
 
-        PullImageCmd pullImageCmd = this.dockerClient.pullImageCmd(imageName);
+        PullImageCmd pullImageCmd = this.dockerClient.pullImageCmd( imageName );
 
         if (this.cubeConfiguration.getDockerRegistry() != null) {
             pullImageCmd.withRegistry(this.cubeConfiguration.getDockerRegistry());

--- a/docker/src/main/java/org/arquillian/cube/impl/util/BindingUtil.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/BindingUtil.java
@@ -1,6 +1,5 @@
 package org.arquillian.cube.impl.util;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -8,7 +7,6 @@ import java.util.Map.Entry;
 import org.arquillian.cube.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.Binding;
 
-import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -14,6 +14,8 @@
         <version.tomcat>1.0.0.CR7</version.tomcat>
         <version.wildfly>8.1.0.Final</version.wildfly>
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
+        <docker.api.version>1.12</docker.api.version>
+        <docker.api.url>https://192.168.59.103:2376</docker.api.url>
     </properties>
 
     <dependencyManagement>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -15,8 +15,8 @@
         <version.wildfly>8.1.0.Final</version.wildfly>
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
         <docker.api.version>1.12</docker.api.version>
-        <docker.api.url>https://192.168.59.103:2376</docker.api.url>
-        <docker.tomcat.host>192.168.59.103</docker.tomcat.host>
+        <docker.api.url>https://localhost:2375</docker.api.url>
+        <docker.tomcat.host>localhost</docker.tomcat.host>
     </properties>
 
     <dependencyManagement>

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -16,6 +16,7 @@
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
         <docker.api.version>1.12</docker.api.version>
         <docker.api.url>https://192.168.59.103:2376</docker.api.url>
+        <docker.tomcat.host>192.168.59.103</docker.tomcat.host>
     </properties>
 
     <dependencyManagement>

--- a/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -49,10 +49,13 @@ public class CubeControllerTest {
         assertNotNull( cubeController );
 
         cubeController.create( TOMCAT_CUBE );
+        cubeController.start( TOMCAT_CUBE );
         cubeController.stop( TOMCAT_CUBE );
 
         //re-create again, this should be an idempotent no op and simple log it
         cubeController.create( TOMCAT_CUBE );
+        cubeController.start( TOMCAT_CUBE );
+        cubeController.stop( TOMCAT_CUBE );
 
     }
 

--- a/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.servlet;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import org.arquillian.cube.CubeController;
@@ -17,6 +18,8 @@ import org.junit.runner.RunWith;
 public class CubeControllerTest {
 
     private static final String MANUAL_START_CUBE = "database_manual";
+
+    private static final String TOMCAT_CUBE = "tomcat_default";
 
     @Deployment
     public static WebArchive create() {
@@ -39,4 +42,18 @@ public class CubeControllerTest {
         cubeController.stop(MANUAL_START_CUBE);
         cubeController.destroy(MANUAL_START_CUBE);
     }
+
+    @Test
+    @RunAsClient
+    public void containerReusable(){
+        assertNotNull( cubeController );
+
+        cubeController.create( TOMCAT_CUBE );
+        cubeController.stop( TOMCAT_CUBE );
+
+        //re-create again, this should be an idempotent no op and simple log it
+        cubeController.create( TOMCAT_CUBE );
+
+    }
+
 }

--- a/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -8,6 +8,7 @@ import org.arquillian.cube.CubeController;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.container.test.api.RunAsClient;
 import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.junit.InSequence;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
@@ -29,34 +30,47 @@ public class CubeControllerTest {
     @ArquillianResource
     private CubeController cubeController;
 
+
+    /**
+     * This test should run in the tomcat container.  This means the tomcat container is responsible
+     * for starting our manual test. This is ordered and runs before the test below this, which runs in the JVM
+     * running the maven command locally
+     */
     @Test
+    @InSequence(1)
     public void should_enrich_test_with_cube_controller_in_container() {
         assertThat(cubeController, notNullValue());
         cubeController.create(MANUAL_START_CUBE);
         cubeController.start(MANUAL_START_CUBE);
     }
 
-    @Test @RunAsClient
+
+    /**
+     * Ensure that as a different environment we can stop the cube controller.
+     */
+    @Test
+    @InSequence(2)
+    @RunAsClient
     public void should_enrich_test_with_cube_controller() {
         assertThat(cubeController, notNullValue());
         cubeController.stop(MANUAL_START_CUBE);
         cubeController.destroy(MANUAL_START_CUBE);
     }
 
-    @Test
-    @RunAsClient
-    public void containerReusable(){
-        assertThat( cubeController, notNullValue() );
-
-        cubeController.create( TOMCAT_CUBE );
-        cubeController.start( TOMCAT_CUBE );
-        cubeController.stop( TOMCAT_CUBE );
-
-        //re-create again, this should be an idempotent no op and simple log it
-        cubeController.create( TOMCAT_CUBE );
-        cubeController.start( TOMCAT_CUBE );
-        cubeController.stop( TOMCAT_CUBE );
-
-    }
+//    @Test
+//    @RunAsClient
+//    public void containerReusable(){
+//        assertThat( cubeController, notNullValue() );
+//
+//        cubeController.create( TOMCAT_CUBE );
+//        cubeController.start( TOMCAT_CUBE );
+//        cubeController.stop( TOMCAT_CUBE );
+//
+//        //re-create again, this should be an idempotent no op and simple log it
+//        cubeController.create( TOMCAT_CUBE );
+//        cubeController.start( TOMCAT_CUBE );
+//        cubeController.stop( TOMCAT_CUBE );
+//
+//    }
 
 }

--- a/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -1,7 +1,6 @@
 package org.arquillian.cube.servlet;
 
 import static org.hamcrest.CoreMatchers.notNullValue;
-import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThat;
 
 import org.arquillian.cube.CubeController;
@@ -19,8 +18,6 @@ import org.junit.runner.RunWith;
 public class CubeControllerTest {
 
     private static final String MANUAL_START_CUBE = "database_manual";
-
-    private static final String TOMCAT_CUBE = "tomcat_default";
 
     @Deployment
     public static WebArchive create() {
@@ -56,21 +53,4 @@ public class CubeControllerTest {
         cubeController.stop(MANUAL_START_CUBE);
         cubeController.destroy(MANUAL_START_CUBE);
     }
-
-//    @Test
-//    @RunAsClient
-//    public void containerReusable(){
-//        assertThat( cubeController, notNullValue() );
-//
-//        cubeController.create( TOMCAT_CUBE );
-//        cubeController.start( TOMCAT_CUBE );
-//        cubeController.stop( TOMCAT_CUBE );
-//
-//        //re-create again, this should be an idempotent no op and simple log it
-//        cubeController.create( TOMCAT_CUBE );
-//        cubeController.start( TOMCAT_CUBE );
-//        cubeController.stop( TOMCAT_CUBE );
-//
-//    }
-
 }

--- a/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -46,7 +46,7 @@ public class CubeControllerTest {
     @Test
     @RunAsClient
     public void containerReusable(){
-        assertNotNull( cubeController );
+        assertThat( cubeController, notNullValue() );
 
         cubeController.create( TOMCAT_CUBE );
         cubeController.start( TOMCAT_CUBE );

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -65,7 +65,7 @@
 
     <container qualifier="tomcat_dockerfile">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
+            <property name="host">localhost</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
@@ -73,14 +73,14 @@
     </container>
     <container qualifier="tomcat_default">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
+            <property name="host">localhost</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
+            <property name="host">localhost</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -4,8 +4,8 @@
     xsi:schemaLocation="http://jboss.org/schema/arquillian
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
-  <!-- See http://ptmccarthy.github.io/2014/07/24/remote-jmx-with-docker/ for why we have to bind the docker hostname
-  and port.  Mostly because RMI is the most idiotic protocol ever invented :(.    -->
+  <!-- We have to bind the docker hostname and port, otherwise RMI will choose a random port, which we can't forward to the docker host.
+   RMI is a difficult protocol to configure :(.    -->
 
     <extension qualifier="docker">
         <property name="serverVersion">${docker.api.version}</property>

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -5,8 +5,8 @@
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
     <extension qualifier="docker">
-        <property name="serverVersion">1.12</property>
-        <property name="serverUri">http://localhost:2375</property>
+        <property name="serverVersion">${docker.api.version}</property>
+        <property name="serverUri">${docker.api.url}</property>
         <property name="autoStartContainers">${arquillian.cube.autostart}</property>
         <property name="dockerContainers">
             tomcat_default:

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -4,6 +4,9 @@
     xsi:schemaLocation="http://jboss.org/schema/arquillian
     http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
+  <!-- See http://ptmccarthy.github.io/2014/07/24/remote-jmx-with-docker/ for why we have to bind the docker hostname
+  and port.  Mostly because RMI is the most idiotic protocol ever invented :(.    -->
+
     <extension qualifier="docker">
         <property name="serverVersion">${docker.api.version}</property>
         <property name="serverUri">${docker.api.url}</property>
@@ -14,15 +17,15 @@
               exposedPorts: [8089/tcp]
               await:
                 strategy: polling
-              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
-              portBindings: [8089/tcp, 8081->8080/tcp]
+              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
+              portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             tomcat:
               image: tutum/tomcat:7.0
               exposedPorts: [8089/tcp]
               await:
                 strategy: polling
-              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
-              portBindings: [8089/tcp, 8081->8080/tcp]
+              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
+              portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             tomcat_dockerfile:
               buildImage:
                 dockerfileLocation: src/test/resources/tomcat
@@ -30,8 +33,8 @@
                 remove: true
               await:
                 strategy: polling
-              env: [JAVA_OPTS=-Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
-              portBindings: [8089/tcp, 8081->8080/tcp]
+              env: [JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
+              portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             wildfly:
               buildImage:
                 dockerfileLocation: src/test/resources/wildfly
@@ -62,7 +65,7 @@
 
     <container qualifier="tomcat_dockerfile">
         <configuration>
-            <property name="host">localhost</property>
+            <property name="host">${docker.tomcat.host}</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
@@ -70,14 +73,14 @@
     </container>
     <container qualifier="tomcat_default">
         <configuration>
-            <property name="host">localhost</property>
+            <property name="host">${docker.tomcat.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">localhost</property>
+            <property name="host">${docker.tomcat.host}</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -65,7 +65,9 @@
 
     <container qualifier="tomcat_dockerfile">
         <configuration>
-            <property name="host">localhost</property>
+          <!-- This must match the docker host ip.  Otherwise it is not replaced before TomcatRemoteContainer.deploy is invoked as of Arquillian 1.1.6. Final
+           ProtocolMetadataUpdater is not currently invoked until after the initial deployment to tomcat has occurred -->
+            <property name="host">${docker.tomcat.host}</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
@@ -73,14 +75,14 @@
     </container>
     <container qualifier="tomcat_default">
         <configuration>
-            <property name="host">localhost</property>
+            <property name="host">${docker.tomcat.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">localhost</property>
+            <property name="host">${docker.tomcat.host}</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>


### PR DESCRIPTION
Resolves issue #81. Note that this temporarily breaks the polling strategy. We now poll the docker host IP, NOT the instance ip itself.  As a result, the ports report open even when they are not.  This issue is dependent on a fix for #52 to work correctly with a polling strategy.  A workaround is to use the wait strategy "sleeping" so that users of external docker hosts or boot2docker can run containers.  This strategy is less effective than a poll, and either introduces extra wait, or may not wait long enough.