### PR TITLE
Update AwaitStrategyTest to check for correct default value

### DIFF
--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -61,7 +61,7 @@
 
         <dependency>
             <groupId>org.mockito</groupId>
-            <artifactId>mockito-all</artifactId>
+            <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
         

--- a/docker/src/test/java/org/arquillian/cube/impl/await/AwaitStrategyTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/await/AwaitStrategyTest.java
@@ -230,7 +230,7 @@ public class AwaitStrategyTest {
         assertThat(((PollingAwaitStrategy)strategy).getPollIterations(), is(3));
         assertThat(((PollingAwaitStrategy)strategy).getSleepPollTime(), is(200));
         assertThat(((PollingAwaitStrategy)strategy).getTimeUnit(), is(TimeUnit.SECONDS));
-        assertThat(((PollingAwaitStrategy)strategy).getType(), is("ping"));
+        assertThat(((PollingAwaitStrategy)strategy).getType(), is("sscommand"));
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <version.junit>4.11</version.junit>
         <version.docker-java>0.10.5</version.docker-java>
         <version.snakeyaml>1.14</version.snakeyaml>
-        <version.mockito>1.10.8</version.mockito>
+        <version.mockito>1.10.19</version.mockito>
     </properties>
 
     <dependencyManagement>
@@ -113,9 +113,15 @@
             </dependency>
             <dependency>
                 <groupId>org.mockito</groupId>
-                <artifactId>mockito-all</artifactId>
+                <artifactId>mockito-core</artifactId>
                 <version>${version.mockito}</version>
                 <scope>test</scope>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.hamcrest</groupId>
+                        <artifactId>hamcrest-core</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.yaml</groupId>


### PR DESCRIPTION
Move to depend on mockito-core instead of mockito-all as
mockito-all bundle hamcrast 1.1 which conflcits with junit 4.11
hamcrast version 1.3 causing NoSuchMethod exceptions.