### PR TITLE
Added the ability to get a specific cube's docker Id in the interface.

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -54,6 +54,25 @@ Go version (server): go1.3.1
 
 If you cannot see the client and server versions then it means that something is wrong with the _Docker_ installation.
 
+== Using an external Docker server
+
+When using an external docker server, such as boot2docker, additional configuration on the client is required as of 1.0.0.Alpha3.  The following properties will need to be set within the user's maven profile.
+
+[source, xml]
+<docker.api.version>1.12</docker.api.version>
+<docker.host>[boot2docker or docker host]</docker.host>
+<docker.api.url>https://${docker.host}:2376</docker.api.url>
+
+
+
+When using tls, the file ~/.docker.io.properties will also need to be installed with these options.
+
+[source, properties]
+docker.io.url=https://[boot2docker or docker host]:2376
+docker.io.version=1.12
+docker.io.dockerCertPath=[path to docker certs provided on boot2docker start]
+
+
 == Basic Example
 
 After having a _Docker_ server installed we can start using *Arquillian Cube*.

--- a/docker/src/main/java/org/arquillian/cube/impl/await/PollingAwaitStrategy.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/await/PollingAwaitStrategy.java
@@ -103,7 +103,7 @@ public class PollingAwaitStrategy implements AwaitStrategy {
 
                 break;
                 case "sscommand": {
-                    if(!Ping.ping(dockerClientExecutor, cube.getId(), resolveCommand("ss", ports.getExposedPort()), this.pollIterations, this.sleepPollTime, this.timeUnit)) {
+                    if(!Ping.ping(dockerClientExecutor, cube.getDockerId(), resolveCommand("ss", ports.getExposedPort()), this.pollIterations, this.sleepPollTime, this.timeUnit)) {
                         return false;
                     }
                 }

--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
@@ -17,11 +17,16 @@ public class CubeConfiguration {
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String SHOULD_ALLOW_TO_CONNECT_TO_RUNNING_CONTAINERS = "shouldAllowToConnectToRunningContainers";
 
+    private static final String NAME_GENERATOR = "nameGenerator";
+    private static final String NAME_GENERATOR_PREFIX = "nameGeneratorPrefix";
+
     private String dockerServerVersion;
     private String dockerServerUri;
     private String dockerRegistry;
     private boolean shouldAllowToConnectToRunningContainers = false;
     private String[] autoStartContainers = new String[0];
+    private String nameGenerator;
+    private String getNameGeneratorPrefix;
 
     private Map<String, Object> dockerContainersContent;
 
@@ -49,8 +54,22 @@ public class CubeConfiguration {
         return autoStartContainers;
     }
 
+
+    public String getNameGenerator() {
+        return nameGenerator;
+    }
+
+
+    public String getGetNameGeneratorPrefix() {
+        return getNameGeneratorPrefix;
+    }
+
+
     @SuppressWarnings("unchecked")
     public static CubeConfiguration fromMap(Map<String, String> map) {
+
+        //TODO add provider parsing here
+
         CubeConfiguration cubeConfiguration = new CubeConfiguration();
 
         if (map.containsKey(DOCKER_VERSION)) {
@@ -86,6 +105,15 @@ public class CubeConfiguration {
         if(map.containsKey(SHOULD_ALLOW_TO_CONNECT_TO_RUNNING_CONTAINERS)) {
             cubeConfiguration.shouldAllowToConnectToRunningContainers = Boolean.parseBoolean(map.get(SHOULD_ALLOW_TO_CONNECT_TO_RUNNING_CONTAINERS));
         }
+
+        if(map.containsKey( NAME_GENERATOR )){
+            cubeConfiguration.nameGenerator = map.get( NAME_GENERATOR ).trim();
+        }
+
+        if(map.containsKey( NAME_GENERATOR_PREFIX )){
+            cubeConfiguration.getNameGeneratorPrefix = map.get( NAME_GENERATOR_PREFIX ).trim();
+        }
+
         return cubeConfiguration;
     }
 }

--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeRegistrar.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeRegistrar.java
@@ -2,6 +2,8 @@ package org.arquillian.cube.impl.client;
 
 import java.util.Map;
 
+import org.arquillian.cube.impl.client.name.NameGenerator;
+import org.arquillian.cube.impl.client.name.NameGeneratorFactory;
 import org.arquillian.cube.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.impl.model.DockerCube;
 import org.arquillian.cube.impl.model.DockerCubeRegistry;
@@ -19,19 +21,26 @@ public class CubeRegistrar {
 
     @SuppressWarnings("unchecked")
     public void register(@Observes DockerClientExecutor executor, CubeConfiguration configuration, Injector injector) {
+        final NameGenerator nameGenerator = NameGeneratorFactory.getGenerator( configuration );
+
         DockerCubeRegistry registry = new DockerCubeRegistry();
 
         //TODO, add key here generation here
         Map<String, Object> containerConfigurations = configuration.getDockerContainersContent();
+
+
         for(Map.Entry<String, Object> containerConfiguration : containerConfigurations.entrySet()) {
+
+
 
             registry.addCube(
                     injector.inject(
                         new DockerCube(
                                 containerConfiguration.getKey(),
                                 (Map<String, Object>)containerConfiguration.getValue(),
-                                executor)));
+                                executor, nameGenerator)));
         }
+
         registryProducer.set(registry);
     }
 }

--- a/docker/src/main/java/org/arquillian/cube/impl/client/name/NameGenerator.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/name/NameGenerator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+package org.arquillian.cube.impl.client.name;
+
+
+/**
+ * Interface for generating names
+ */
+public interface NameGenerator {
+
+    /**
+     * Get the name to use at runtime derived from the name assigned in the file
+     * @param assignedName
+     * @return
+     */
+    String getName(final String assignedName);
+
+}

--- a/docker/src/main/java/org/arquillian/cube/impl/client/name/NameGeneratorFactory.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/name/NameGeneratorFactory.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+package org.arquillian.cube.impl.client.name;
+
+
+import org.arquillian.cube.impl.client.CubeConfiguration;
+
+
+/**
+ * Return the name generator impl based on the configuration
+ */
+public class NameGeneratorFactory {
+
+    /**
+     * Get the name generator for the configured option
+     *
+     * @param cubeConfiguration The cube configuration
+     *
+     * @return The NameGenerator instance to use when generating names.
+     */
+    public static NameGenerator getGenerator( final CubeConfiguration cubeConfiguration ) {
+
+        final String configurationName = cubeConfiguration.getNameGenerator();
+
+        //can't switch on a null
+        if ( configurationName == null ) {
+            return new StaticNameGenerator();
+        }
+
+        switch ( configurationName ) {
+            case StaticNameGenerator.TAG:
+                return new StaticNameGenerator();
+            case UniqueNameGenerator.TAG:
+                return new UniqueNameGenerator( cubeConfiguration.getGetNameGeneratorPrefix() );
+            default:
+                throw new IllegalArgumentException(
+                        "The configuration of type '" + configurationName + "' is not a valid configuration.  Use '"
+                                + StaticNameGenerator.TAG + "' or '" + UniqueNameGenerator.TAG + "'." );
+        }
+    }
+}

--- a/docker/src/main/java/org/arquillian/cube/impl/client/name/StaticNameGenerator.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/name/StaticNameGenerator.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+package org.arquillian.cube.impl.client.name;
+
+
+/**
+ * Leaves the name as specified by the user
+ */
+public class StaticNameGenerator implements  NameGenerator {
+
+    public static final String TAG = "static";
+
+    @Override
+    public String getName( final String assignedName ) {
+        return assignedName;
+    }
+}

--- a/docker/src/main/java/org/arquillian/cube/impl/client/name/UniqueNameGenerator.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/name/UniqueNameGenerator.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ *
+ *
+ */
+package org.arquillian.cube.impl.client.name;
+
+
+import java.util.UUID;
+
+
+
+/**
+ * Generates the name from a prefix, name, and assigns a timeuuid for unique
+ */
+public class UniqueNameGenerator implements  NameGenerator {
+
+
+    public static final String TAG = "unique";
+
+    private static final String DELIM = "_";
+
+
+    private String prefix;
+
+
+    public UniqueNameGenerator( final String prefix ) {
+
+
+        if ( prefix == null ) {
+            throw new IllegalArgumentException(
+                    "You must specify a name generator prefix when using the unique name generator " );
+        }
+
+        this.prefix = prefix;
+    }
+
+
+    @Override
+    public String getName( final String assignedName ) {
+        return prefix + DELIM + assignedName + DELIM + UUID.randomUUID();
+    }
+
+
+
+
+}

--- a/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
@@ -458,16 +458,23 @@ public class DockerClientExecutor {
         }
 
         int tagSeparator = imageName.indexOf(TAG_SEPARATOR);
+
         if (tagSeparator > 0) {
-            pullImageCmd.withRepository(imageName.substring(0, tagSeparator));
-            pullImageCmd.withTag(imageName.substring(tagSeparator + 1));
+            final String repository = imageName.substring(0, tagSeparator);
+            final String tag = imageName.substring( tagSeparator + 1 );
+            pullImageCmd.withRepository(repository);
+            pullImageCmd.withTag(tag);
         }
 
         InputStream exec = pullImageCmd.exec();
 
         // To wait until image is pull we need to listen input stream until it is closed by the server
         // At this point we can be sure that image is already pulled.
-        IOUtil.asString(exec);
+        final String pullResults = IOUtil.asString(exec);
+
+        if(pullResults == null || pullResults.contains( "error" )){
+            throw new RuntimeException( "Unable to pull image. \n" + pullResults );
+        }
     }
 
     public String execStart(String containerId, String... commands) {

--- a/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/docker/DockerClientExecutor.java
@@ -472,8 +472,10 @@ public class DockerClientExecutor {
         // At this point we can be sure that image is already pulled.
         final String pullResults = IOUtil.asString(exec);
 
-        if(pullResults == null || pullResults.contains( "error" )){
-            throw new RuntimeException( "Unable to pull image. \n" + pullResults );
+        final String expectedOutput = "Status: Downloaded newer image for " + imageName;
+
+        if(pullResults == null || !pullResults.contains( expectedOutput )){
+            throw new RuntimeException( "Unable to pull image. Expected output '" + expectedOutput + "' to be returned.  Instead this was returned \n" + pullResults );
         }
     }
 

--- a/docker/src/main/java/org/arquillian/cube/impl/util/BindingUtil.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/BindingUtil.java
@@ -19,8 +19,8 @@ public final class BindingUtil {
     private BindingUtil() {
     }
 
-    public static Binding binding(DockerClientExecutor executor, String cubeId) {
-        InspectContainerResponse inspectResponse = executor.getDockerClient().inspectContainerCmd( cubeId ).exec();
+    public static Binding binding(DockerClientExecutor executor, String dockerId) {
+        InspectContainerResponse inspectResponse = executor.getDockerClient().inspectContainerCmd( dockerId ).exec();
 
         HostConfig hostConfig = inspectResponse.getHostConfig();
 

--- a/docker/src/test/java/org/arquillian/cube/impl/client/name/NameGeneratorFactoryTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/name/NameGeneratorFactoryTest.java
@@ -1,0 +1,84 @@
+package org.arquillian.cube.impl.client.name;
+
+
+import java.util.HashMap;
+import java.util.Map;
+
+import org.arquillian.cube.impl.client.CubeConfiguration;
+import org.junit.Test;
+
+import static org.junit.Assert.assertTrue;
+
+
+/**
+ *
+ */
+public class NameGeneratorFactoryTest {
+
+    @Test
+    public void unspecifiedUsesStaticName() {
+        final CubeConfiguration configuration = new CubeConfiguration();
+
+        final NameGenerator generator = NameGeneratorFactory.getGenerator( configuration );
+
+        assertTrue( "Correct instance returned", generator instanceof StaticNameGenerator );
+    }
+
+
+    @Test
+    public void staticConfiguration() {
+
+        final Map<String, String> options = new HashMap<String, String>() {{
+            put( "nameGenerator", "static" );
+        }};
+        final CubeConfiguration configuration = CubeConfiguration.fromMap( options );
+
+        final NameGenerator generator = NameGeneratorFactory.getGenerator( configuration );
+
+        assertTrue( "Correct instance returned", generator instanceof StaticNameGenerator );
+    }
+
+
+    @Test
+    public void uniqueConfiguration() {
+
+        final Map<String, String> options = new HashMap<String, String>() {{
+            put( "nameGenerator", "unique" );
+            put( "nameGeneratorPrefix", "test" );
+        }};
+
+        final CubeConfiguration configuration = CubeConfiguration.fromMap( options );
+
+        final NameGenerator generator = NameGeneratorFactory.getGenerator( configuration );
+
+        assertTrue( "Correct instance returned", generator instanceof UniqueNameGenerator );
+    }
+
+
+    @Test( expected = IllegalArgumentException.class )
+    public void uniqueConfigurationNoPrefix() {
+
+        final Map<String, String> options = new HashMap<String, String>() {{
+            put( "nameGenerator", "unique" );
+        }};
+
+        final CubeConfiguration configuration = CubeConfiguration.fromMap( options );
+
+        //should throw illegal argument
+        NameGeneratorFactory.getGenerator( configuration );
+    }
+
+
+    @Test( expected = IllegalArgumentException.class )
+    public void invalidTypeName() {
+
+        final Map<String, String> options = new HashMap<String, String>() {{
+            put( "nameGenerator", "random stuff" );
+        }};
+
+        final CubeConfiguration configuration = CubeConfiguration.fromMap( options );
+
+        //should throw illegal argument, not a type we support
+        NameGeneratorFactory.getGenerator( configuration );
+    }
+}

--- a/docker/src/test/java/org/arquillian/cube/impl/client/name/StaticNameGeneratorTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/name/StaticNameGeneratorTest.java
@@ -1,0 +1,22 @@
+package org.arquillian.cube.impl.client.name;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class StaticNameGeneratorTest {
+
+    @Test
+    public void testValidName(){
+        final String expected = "testName";
+
+        final StaticNameGenerator generator = new StaticNameGenerator();
+
+        final String returned = generator.getName( expected );
+
+        assertEquals( "Same string should be returned", expected, returned );
+
+    }
+}

--- a/docker/src/test/java/org/arquillian/cube/impl/client/name/UniqueNameGeneratorTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/name/UniqueNameGeneratorTest.java
@@ -1,0 +1,46 @@
+package org.arquillian.cube.impl.client.name;
+
+
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+
+public class UniqueNameGeneratorTest {
+
+    @Test
+    public void nameGeneration(){
+
+        final String prefix = "prefix";
+        final String name = "name";
+
+        final UniqueNameGenerator generator = new UniqueNameGenerator( prefix );
+
+
+        final String returned = generator.getName( name );
+
+        final String expectedPrefix = prefix + "_";
+
+        assertTrue( "Prefix correct",  returned.startsWith( expectedPrefix ));
+
+        final String nameSection = returned.replace( expectedPrefix, "" );
+
+
+        final String expectedName = name + "_";
+
+        assertTrue("Name correct", nameSection.startsWith( expectedName ));
+
+        final String uuidSection = nameSection.replace( expectedName, "" );
+
+        //32 hex characters + 4 '-' chars
+        assertEquals("uuid section correct", 36, uuidSection.length());
+    }
+
+
+
+    @Test(expected = IllegalArgumentException.class)
+    public void noPrefixIllegal(){
+        //throws an illegal argument
+        new UniqueNameGenerator( null );
+    }
+}

--- a/docker/src/test/java/org/arquillian/cube/impl/model/DockerCubeTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/model/DockerCubeTest.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.impl.model;
 
 import java.util.HashMap;
 
+import org.arquillian.cube.impl.client.name.StaticNameGenerator;
 import org.arquillian.cube.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.event.lifecycle.AfterCreate;
 import org.arquillian.cube.spi.event.lifecycle.AfterDestroy;
@@ -34,7 +35,7 @@ public class DockerCubeTest extends AbstractManagerTestBase {
 
     @Before
     public void setup() {
-        cube = injectorInst.get().inject(new DockerCube("test", new HashMap<String, Object>(), executor));
+        cube = injectorInst.get().inject(new DockerCube("test", new HashMap<String, Object>(), executor, new StaticNameGenerator()) );
     }
 
     @Test

--- a/ftest/pom.xml
+++ b/ftest/pom.xml
@@ -15,8 +15,8 @@
         <version.wildfly>8.1.0.Final</version.wildfly>
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
         <docker.api.version>1.12</docker.api.version>
-        <docker.api.url>http://localhost:2375</docker.api.url>
-        <docker.tomcat.host>localhost</docker.tomcat.host>
+        <docker.api.host>localhost</docker.api.host>
+        <docker.api.url>http://${docker.api.host}:2375</docker.api.url>
     </properties>
 
     <dependencyManagement>

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -11,6 +11,8 @@
         <property name="serverVersion">${docker.api.version}</property>
         <property name="serverUri">${docker.api.url}</property>
         <property name="autoStartContainers">${arquillian.cube.autostart}</property>
+        <property name="nameGenerator">unique</property>
+        <property name="nameGeneratorPrefix">cube</property>
         <property name="dockerContainers">
             tomcat_default:
               image: tutum/tomcat:7.0

--- a/ftest/src/test/resources/arquillian.xml
+++ b/ftest/src/test/resources/arquillian.xml
@@ -19,14 +19,14 @@
               exposedPorts: [8089/tcp]
               await:
                 strategy: polling
-              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
+              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Djava.rmi.server.hostname=${docker.api.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
               portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             tomcat:
               image: tutum/tomcat:7.0
               exposedPorts: [8089/tcp]
               await:
                 strategy: polling
-              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
+              env: [TOMCAT_PASS=mypass, JAVA_OPTS=-Djava.rmi.server.hostname=${docker.api.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
               portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             tomcat_dockerfile:
               buildImage:
@@ -35,7 +35,7 @@
                 remove: true
               await:
                 strategy: polling
-              env: [JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
+              env: [JAVA_OPTS=-Djava.rmi.server.hostname=${docker.api.host}  -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
               portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             wildfly:
               buildImage:
@@ -69,7 +69,7 @@
         <configuration>
           <!-- This must match the docker host ip.  Otherwise it is not replaced before TomcatRemoteContainer.deploy is invoked as of Arquillian 1.1.6. Final
            ProtocolMetadataUpdater is not currently invoked until after the initial deployment to tomcat has occurred -->
-            <property name="host">${docker.tomcat.host}</property>
+            <property name="host">${docker.api.host}</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
@@ -77,14 +77,14 @@
     </container>
     <container qualifier="tomcat_default">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
+            <property name="host">${docker.api.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
+            <property name="host">${docker.api.host}</property>
             <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>

--- a/spi/src/main/java/org/arquillian/cube/spi/Cube.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/Cube.java
@@ -18,7 +18,17 @@ public interface Cube {
 
     State state();
 
+    /**
+     * Return the user assigned Id of this cube instance
+     * @return
+     */
     String getId();
+
+    /**
+     * Get the id (name) used within docker for this runtime
+     * @return
+     */
+    String getDockerId();
 
     void create() throws CubeControlException;
 


### PR DESCRIPTION
Added an internal dockerId.  This allows multiple strategies to be configured.  Fixes #67.

Note that this now separates the Cube's identifier from the Docker instance name used to start and stop the instance.  Existing implementations should still work, since the cube encapsulates the docker instance name, and the default is to use a static naming convention.  See the tests in ftest for an example of using a unique naming strategy.  