### PR TITLE
Add support for auto starting Cubes in parallel

### DIFF
--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleController.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleController.java
@@ -1,9 +1,13 @@
 package org.arquillian.cube.impl.client;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
 
 import org.arquillian.cube.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.impl.util.ConfigUtil;
+import org.arquillian.cube.impl.util.AutoStartOrderUtil;
 import org.arquillian.cube.spi.event.CreateCube;
 import org.arquillian.cube.spi.event.CubeControlEvent;
 import org.arquillian.cube.spi.event.DestroyCube;
@@ -14,6 +18,7 @@ import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.api.threading.ExecutorService;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 
@@ -25,37 +30,116 @@ public class CubeSuiteLifecycleController {
     @Inject
     private Instance<DockerClientExecutor> dockerClientExecutor;
 
-    public void startAutoContainers(@Observes(precedence = 100) BeforeSuite event, CubeConfiguration configuration) {
-        for(String cubeId : configuration.getAutoStartContainers()) {
+    @Inject
+    private Instance<ExecutorService> executorServiceInst;
 
-            if(configuration.shouldAllowToConnectToRunningContainers() && isCubeRunning(cubeId)) {
-                controlEvent.fire(new PreRunningCube(cubeId));
-            } else {
-                controlEvent.fire(new CreateCube(cubeId));
-                controlEvent.fire(new StartCube(cubeId));
-            }
-        }
+    public void startAutoContainers(@Observes(precedence = 100) BeforeSuite event, final CubeConfiguration configuration) {
+        List<String[]> autoStartSteps = AutoStartOrderUtil.getAutoStartOrder(configuration);
+        startAllSteps(autoStartSteps, configuration.shouldAllowToConnectToRunningContainers());
     }
 
     public void stopAutoContainers(@Observes(precedence = -100) AfterSuite event, CubeConfiguration configuration) {
-        for(String cubeId : ConfigUtil.reverse(configuration.getAutoStartContainers())) {
-            controlEvent.fire(new StopCube(cubeId));
-            controlEvent.fire(new DestroyCube(cubeId));
+        List<String[]> autoStopSteps = AutoStartOrderUtil.getAutoStopOrder(configuration);
+        stopAllSteps(autoStopSteps);
+    }
+
+    private void startAllSteps(List<String[]> autoStartSteps, boolean allowToConnectToRunningContainers) {
+        for(final String[] cubeIds : autoStartSteps) {
+            Map<String, Future<RuntimeException>> stepStatus = new HashMap<>();
+
+            // Start
+            for(final String cubeId : cubeIds) {
+                Future<RuntimeException> result = executorServiceInst.get().submit(new StartCubes(cubeId, allowToConnectToRunningContainers));
+                stepStatus.put(cubeId, result);
+            }
+
+            waitForCompletion(stepStatus, "Could not auto start container");
+        }
+    }
+
+    private void stopAllSteps(List<String[]> autoStopSteps) {
+        for(final String[] cubeIds : autoStopSteps) {
+            Map<String, Future<RuntimeException>> stepStatus = new HashMap<>();
+
+            // Start
+            for(final String cubeId : cubeIds) {
+                Future<RuntimeException> result = executorServiceInst.get().submit(new StopCubes(cubeId));
+                stepStatus.put(cubeId, result);
+            }
+
+            // wait
+            waitForCompletion(stepStatus, "Could not auto stop container");
+        }
+    }
+
+    private void waitForCompletion(Map<String, Future<RuntimeException>> stepStatus, String message) {
+        for(final Map.Entry<String, Future<RuntimeException>> result: stepStatus.entrySet()) {
+            try {
+                RuntimeException e = result.getValue().get();
+                if(e != null) {
+                    throw e;
+                }
+            } catch (Exception e) {
+                throw new RuntimeException(message + " " + result.getKey(), e);
+            }
         }
     }
 
     private boolean isCubeRunning(String cube) {
         //TODO should we create an adapter class so we don't expose client classes in this part?
-          List<com.github.dockerjava.api.model.Container> runningContainers = dockerClientExecutor.get().listRunningContainers();
-          for (com.github.dockerjava.api.model.Container container : runningContainers) {
-              for (String name : container.getNames()) {
-                  if(name.startsWith("/")) name = name.substring(1); //Names array adds an slash to the docker name container.
-                  if(name.equals(cube)) { //cube id is the container name in docker0 Id in docker is the hash that identifies it.
-                      return true;
-                  }
-              }
-          }
+        List<com.github.dockerjava.api.model.Container> runningContainers = dockerClientExecutor.get().listRunningContainers();
+        for (com.github.dockerjava.api.model.Container container : runningContainers) {
+            for (String name : container.getNames()) {
+                if(name.startsWith("/")) name = name.substring(1); //Names array adds an slash to the docker name container.
+                if(name.equals(cube)) { //cube id is the container name in docker0 Id in docker is the hash that identifies it.
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
 
-          return false;
-      }
+    private final class StartCubes implements Callable<RuntimeException> {
+        private final boolean allowToConnectToRunningContainers;
+        private final String cubeId;
+
+        private StartCubes(String cubeId, boolean shouldAllowToConnectToRunningContainers) {
+            this.cubeId = cubeId;
+            this.allowToConnectToRunningContainers = shouldAllowToConnectToRunningContainers;
+        }
+
+        @Override
+        public RuntimeException call() throws Exception {
+            try {
+                if(allowToConnectToRunningContainers && isCubeRunning(cubeId)) {
+                    controlEvent.fire(new PreRunningCube(cubeId));
+                } else {
+                    controlEvent.fire(new CreateCube(cubeId));
+                    controlEvent.fire(new StartCube(cubeId));
+                }
+            } catch(RuntimeException e) {
+                return e;
+            }
+            return null;
+        }
+    }
+
+    private final class StopCubes implements Callable<RuntimeException> {
+        private final String cubeId;
+
+        private StopCubes(String cubeId) {
+            this.cubeId = cubeId;
+        }
+
+        @Override
+        public RuntimeException call() throws Exception {
+            try {
+                controlEvent.fire(new StopCube(cubeId));
+                controlEvent.fire(new DestroyCube(cubeId));
+            } catch(RuntimeException e) {
+                return e;
+            }
+            return null;
+        }
+    }
 }

--- a/docker/src/main/java/org/arquillian/cube/impl/util/AutoStartOrderUtil.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/AutoStartOrderUtil.java
@@ -1,0 +1,250 @@
+package org.arquillian.cube.impl.util;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import org.arquillian.cube.impl.client.CubeConfiguration;
+
+public class AutoStartOrderUtil {
+
+    public static List<String[]> getAutoStopOrder(CubeConfiguration config) {
+        List<String[]> autoStartOrder = getAutoStartOrder(config);
+        Collections.reverse(autoStartOrder);
+        return autoStartOrder;
+    }
+
+    public static List<String[]> getAutoStartOrder(CubeConfiguration config) {
+        List<String[]> sorted = new ArrayList<>();
+        List<Step> steps = sort(from(config));
+        for(Step step : steps) {
+            sorted.add(step.getIDs());
+        }
+        return sorted;
+    }
+
+    static List<Step> sort(Set<Node> nodes) {
+        List<Step> steps = new ArrayList<>();
+
+        List<Node> remaining = new ArrayList<>(nodes);
+        int previousSize = remaining.size();
+        while(!remaining.isEmpty()) {
+            Step step = new Step();
+            for(int i = 0; i < remaining.size(); i++) {
+                Node node = remaining.get(i);
+                if(!node.hasParent() || nodesInStep(steps, node.getParents())) {
+                    step.add(node);
+                    remaining.remove(i);
+                    --i;
+                }
+            }
+            if(previousSize == remaining.size()) {
+                throw new IllegalArgumentException("Could not resolve autoStart order. " + nodes);
+            }
+            previousSize = remaining.size();
+            steps.add(step);
+        }
+        return steps;
+    }
+
+    static Set<Node> from(CubeConfiguration config) {
+        Map<String, Node> nodes = new HashMap<>();
+        String[] autoStartContainers = config.getAutoStartContainers();
+        Map<String, Object> containerDefinitions = config.getDockerContainersContent();
+
+        for(String autoStart : autoStartContainers) {
+            if(containerDefinitions.containsKey(autoStart)) {
+                nodes.put(autoStart, Node.from(autoStart));
+            }
+        }
+
+        Map<String, Node> autoStartNodes = new HashMap<>(nodes);
+        for(Map.Entry<String, Node> node : autoStartNodes.entrySet()) {
+            addAll(nodes, config, node.getKey());
+        }
+
+        return new HashSet<>(nodes.values());
+    }
+
+    private static boolean nodesInStep(List<Step> steps, Set<Node> nodes) {
+        for(Node node: nodes) {
+            if(!nodeInStep(steps, node)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean nodeInStep(List<Step> steps, Node node) {
+        for(Step step : steps) {
+            if(step.contains(node)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    @SuppressWarnings("unchecked")
+    private static void addAll(Map<String, Node> nodes, CubeConfiguration config, String id) {
+        Map<String, Object> content = (Map<String, Object>)config.getDockerContainersContent().get(id);
+        if(content == null) {
+            return;
+        }
+        Node parent = nodes.get(id);
+        if(content.containsKey("links")) {
+            List<String> links = (List<String>)content.get("links");
+            for(String link : links) {
+                String[] parsed = link.split(":");
+                String name = parsed[0];
+
+                if(config.getDockerContainersContent().containsKey(name)) {
+                    Node child = nodes.get(name);
+                    if(child == null) {
+                        child = Node.from(name);
+                        nodes.put(name, child);
+                    }
+                    // Only continue recursively if this was a new found child
+                    if(child.addAsChildOf(parent)) {
+                        addAll(nodes, config, name);
+                    }
+                }
+            }
+        }
+    }
+
+    public static class Node {
+        private String id;
+        private Set<Node> parents;
+        private Set<Node> children;
+
+        private Node(String id) {
+            this.id = id;
+            this.parents = new HashSet<>();
+            this.children = new HashSet<>();
+        }
+
+        public String getId() {
+            return id;
+        }
+
+        public boolean addAsParentOf(Node node) {
+            if(!this.parents.contains(node)) {
+                this.parents.add(node);
+                node.addAsChildOf(this);
+                return true;
+            }
+            return false;
+        }
+
+        public boolean addAsChildOf(Node node) {
+            if(!this.children.contains(node)) {
+                this.children.add(node);
+                node.addAsParentOf(this);
+                return true;
+            }
+            return false;
+        }
+
+        public Set<Node> getParents() {
+            return parents;
+        }
+
+        public boolean hasParent() {
+            return this.parents.size() > 0;
+        }
+
+        public static Node from(String id) {
+            return new Node(id);
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Node [id=" + id);
+            if(!parents.isEmpty()) {
+                sb.append(", parents=" + nodeList(parents));
+            }
+            if(!children.isEmpty()) {
+                sb.append(", children="+ nodeList(children));
+            }
+            sb.append("]");
+            return sb.toString();
+        }
+
+        @Override
+        public int hashCode() {
+            final int prime = 31;
+            int result = 1;
+            result = prime * result + ((id == null) ? 0 : id.hashCode());
+            return result;
+        }
+
+        @Override
+        public boolean equals(Object obj) {
+            if (this == obj)
+                return true;
+            if (obj == null)
+                return false;
+            if (getClass() != obj.getClass())
+                return false;
+            Node other = (Node) obj;
+            if (id == null) {
+                if (other.id != null)
+                    return false;
+            } else if (!id.equals(other.id))
+                return false;
+            return true;
+        }
+    }
+
+    public static class Step {
+        private Set<Node> nodes;
+
+        private Step() {
+            this.nodes = new HashSet<>();
+        }
+
+        public boolean contains(Node node) {
+            return this.nodes.contains(node);
+        }
+
+        public void add(Node node) {
+            if(!this.nodes.contains(node)) {
+                this.nodes.add(node);
+            }
+        }
+
+        public String[] getIDs() {
+            String[] ids = new String[this.nodes.size()];
+            Node[] nodes = this.nodes.toArray(new Node[]{});
+            for(int i = 0; i < nodes.length; i++) {
+                ids[i] = nodes[i].getId();
+            }
+            return ids;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder sb = new StringBuilder();
+            sb.append("Step [ids=" + nodeList(nodes));
+            sb.append("]");
+            return sb.toString();
+        }
+    }
+
+    private static String nodeList(Set<Node> nodes) {
+        StringBuilder sb = new StringBuilder();
+        Node[] array = nodes.toArray(new Node[]{});
+        for(int i = 0; i < array.length; i++) {
+            sb.append(array[i].getId());
+            if(i < array.length-1) {
+                sb.append(",");
+            }
+        }
+        return sb.toString();
+    }
+}

--- a/docker/src/test/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleControllerTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/client/CubeSuiteLifecycleControllerTest.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.impl.client;
 
-import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 
 import org.arquillian.cube.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.event.CreateCube;
@@ -15,6 +16,7 @@ import org.arquillian.cube.spi.event.PreRunningCube;
 import org.arquillian.cube.spi.event.StartCube;
 import org.arquillian.cube.spi.event.StopCube;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.test.AbstractManagerTestBase;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
@@ -31,9 +33,27 @@ public class CubeSuiteLifecycleControllerTest extends AbstractManagerTestBase {
     @Mock
     private DockerClientExecutor executor;
 
+    // TEMP Workaround for ARQ-1910
+    public static class MiniDelayExtension {
+        Random random = new Random();
+        public void create(@Observes(precedence = 100) CreateCube a) throws Exception {
+            Thread.sleep(random.nextInt(30) + 10);
+        }
+        public void start(@Observes(precedence = 100) StartCube a) throws Exception {
+            Thread.sleep(random.nextInt(30) + 10);
+        }
+        public void stop(@Observes(precedence = 100) StopCube a) throws Exception {
+            Thread.sleep(random.nextInt(30) + 10);
+        }
+        public void destroy(@Observes(precedence = 100) DestroyCube a) throws Exception {
+            Thread.sleep(random.nextInt(30) + 10);
+        }
+    }
+
     @Override
     protected void addExtensions(List<Class<?>> extensions) {
         extensions.add(CubeSuiteLifecycleController.class);
+        extensions.add(MiniDelayExtension.class);
         super.addExtensions(extensions);
     }
 
@@ -42,6 +62,7 @@ public class CubeSuiteLifecycleControllerTest extends AbstractManagerTestBase {
 
         Map<String, String> data = new HashMap<String, String>();
         data.put("autoStartContainers", "a,b");
+        data.put("dockerContainers", "a:\n  image: a\nb:\n  image: a\n");
 
         CubeConfiguration configuration = CubeConfiguration.fromMap(data);
         bind(ApplicationScoped.class, CubeConfiguration.class, configuration);
@@ -57,6 +78,7 @@ public class CubeSuiteLifecycleControllerTest extends AbstractManagerTestBase {
 
         Map<String, String> data = new HashMap<String, String>();
         data.put("autoStartContainers", "a,b");
+        data.put("dockerContainers", "a:\n  image: a\nb:\n  image: a\n");
 
         CubeConfiguration configuration = CubeConfiguration.fromMap(data);
         bind(ApplicationScoped.class, CubeConfiguration.class, configuration);
@@ -72,6 +94,7 @@ public class CubeSuiteLifecycleControllerTest extends AbstractManagerTestBase {
         Map<String, String> data = new HashMap<String, String>();
         data.put("autoStartContainers", "a,b");
         data.put("shouldAllowToConnectToRunningContainers", "true");
+        data.put("dockerContainers", "a:\n  image: a\nb:\n  image: a\n");
         
         CubeConfiguration configuration = CubeConfiguration.fromMap(data);
         bind(ApplicationScoped.class, CubeConfiguration.class, configuration);

--- a/docker/src/test/java/org/arquillian/cube/impl/util/AutoStartOrderUtilTestCase.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/util/AutoStartOrderUtilTestCase.java
@@ -1,0 +1,188 @@
+package org.arquillian.cube.impl.util;
+
+
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.arquillian.cube.impl.client.CubeConfiguration;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class AutoStartOrderUtilTestCase {
+
+    private static final String SCENARIO_NO_KNOWN_LINK =
+            "A:\n" +
+            "  links:\n" +
+            "    - B:B\n";
+
+    private static final String SCENARIO_SINGLE_LINK =
+            "A:\n" +
+            "  links:\n" +
+            "    - B:B\n" +
+            "B:\n" +
+            "  image: a\n";
+
+    private static final String SCENARIO_MULTIPLE_ROOTS =
+            "A:\n" +
+            "  image: a\n" +
+            "B:\n" +
+            "  image: a\n";
+
+    private static final String SCENARIO_MULTIPLE_ROOTS_AND_SINGLE_LINK =
+            "A:\n" +
+            "  links:\n" +
+            "    - B:B\n" +
+            "B:\n" +
+            "  image: a\n" +
+            "C:\n" +
+            "  image: a\n";
+
+    private static final String SCENARIO_SINGLE_ROOT_AND_MULTIPLE_LINKS =
+            "A:\n" +
+            "  links:\n" +
+            "    - B:B\n" +
+            "B:\n" +
+            "  image: a\n" +
+            "C:\n" +
+            "  links:\n" +
+            "    - B:B\n";
+
+    private static final String SCENARIO_MULTI_ROOT_AND_MULTIPLE_LINKS =
+            "A:\n" +
+            "  links:\n" +
+            "    - B:B\n" +
+            "    - D:D\n" +
+            "B:\n" +
+            "  image: a\n" +
+            "C:\n" +
+            "  links:\n" +
+            "    - B:B\n" +
+            "D:\n" +
+            "  links:\n" +
+            "    - E:E\n" +
+            "E:\n" +
+            "  image: a\n" +
+            "F:\n" +
+            "  links:\n" +
+            "    - E:E\n" +
+            "    - C:C\n"  ;
+
+    private static final String SCENARIO_RECURSIVE_LINKS =
+            "A:\n" +
+            "  links:\n" +
+            "    - B:B\n" +
+            "B:\n" +
+            "  links:\n" +
+            "    - A:A\n";
+
+    @Test
+    public void shouldSortNoKnownLinks() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_NO_KNOWN_LINK, "A"));
+
+        assertExecutionSteps(sorted, new String[]{"A"});
+    }
+
+    @Test
+    public void shouldSortSingleLink() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_SINGLE_LINK, "A"));
+
+        assertExecutionSteps(sorted, new String[]{"B"}, new String[]{"A"});
+    }
+
+    @Test
+    public void shouldSortSingleNonLinkedRoots() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_MULTIPLE_ROOTS, "A"));
+
+        assertExecutionSteps(sorted, new String[]{"A"});
+    }
+
+    @Test
+    public void shouldSortMultipleNonLinkedRoots() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_MULTIPLE_ROOTS, "A", "B"));
+
+        assertExecutionSteps(sorted, new String[]{"A", "B"});
+    }
+
+    @Test
+    public void shouldSortMultipleRootWithSingleLinks() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_MULTIPLE_ROOTS_AND_SINGLE_LINK, "C", "A"));
+
+        assertExecutionSteps(sorted, new String[]{"B", "C"}, new String[]{"A"});
+    }
+
+    @Test
+    public void shouldSortSingleRootWithMultipleLinks() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_SINGLE_ROOT_AND_MULTIPLE_LINKS, "C", "A"));
+
+        assertExecutionSteps(sorted, new String[]{"B"}, new String[]{"A", "C"});
+    }
+
+    @Test
+    public void shouldSortMultiRootWithMultipleLinks() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_MULTI_ROOT_AND_MULTIPLE_LINKS, "A", "F"));
+
+        assertExecutionSteps(sorted, new String[]{"B", "E"}, new String[]{"D", "C"}, new String[]{"A", "F"});
+    }
+
+    @Test
+    public void shouldSortInReverseMultiRootWithMultipleLinks() throws Exception {
+        List<String[]> sorted = AutoStartOrderUtil.getAutoStopOrder(
+                create(SCENARIO_MULTI_ROOT_AND_MULTIPLE_LINKS, "A", "F"));
+
+        assertExecutionSteps(sorted, new String[]{"A", "F"}, new String[]{"D", "C"}, new String[]{"B", "E"});
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldFailOnRecursiveLinks() throws Exception {
+        AutoStartOrderUtil.getAutoStartOrder(
+                create(SCENARIO_RECURSIVE_LINKS, "A", "B"));
+    }
+
+    private void assertExecutionSteps(List<String[]> actuals, String[]... expecteds) {
+        Assert.assertEquals("Number of steps to should match", expecteds.length, actuals.size());
+
+        for(int i = 0; i < actuals.size(); i++) {
+            List<String> actual = Arrays.asList(actuals.get(i));
+            String[] expected = expecteds[i];
+            Assert.assertEquals("Number of cubes in step[" + i +"] should match", expected.length, actual.size());
+
+            for(String expectedId : expected) {
+                Assert.assertTrue("Cube[" + expectedId + "] should have been in step[" + i + "] Found[" + join(actual) + "]", actual.contains(expectedId));
+            }
+        }
+    }
+
+    private CubeConfiguration create(String setup, String... autoStart) {
+        Map<String, String> config = new HashMap<>();
+        if(autoStart != null && autoStart.length > 0) {
+            config.put("autoStartContainers", join(autoStart));
+        }
+        config.put("dockerContainers", setup);
+        return CubeConfiguration.fromMap(config);
+    }
+
+    private String join(Collection<String> strings) {
+        return join(strings.toArray(new String[]{}));
+    }
+
+    private String join(String... auto) {
+        StringBuilder sb = new StringBuilder();
+        for(int i = 0; i < auto.length; i++) {
+            sb.append(auto[i]);
+            if(i < auto.length -1) {
+                sb.append(",");
+            }
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
Cubes configured for auto start will now be sorted and
executed in correct start up order based on the
defined links in the configuration.

When linked levels are defined, A->B->C, the parallel execution
will occure in steps per link.

If A->B:
 * then no real parallel can be done since B needs to be
   started before A

If A->B and C->B
 * then B will be started, so A and C in parallel.

If A and B (no link)
 * then A and B will be started in parallel

If A->B and autoStartContainers= A
 * then B will also be started since it's required by A

fixes #73