### PR TITLE
adds dockerServerIp substitutions instead of boot2docker

### DIFF
--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeClientCreator.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeClientCreator.java
@@ -1,9 +1,6 @@
 package org.arquillian.cube.impl.client;
 
 import org.arquillian.cube.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.impl.util.Boot2Docker;
-import org.arquillian.cube.impl.util.OperatingSystemResolver;
-import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -15,11 +12,7 @@ public class CubeClientCreator {
     @ApplicationScoped
     private InstanceProducer<DockerClientExecutor> dockerClientExecutorProducer;
 
-    @Inject
-    private Instance<Boot2Docker> boot2DockerInstance;
-    
     public void createClient(@Observes CubeConfiguration cubeConfiguration) {
-        dockerClientExecutorProducer.set(new DockerClientExecutor(cubeConfiguration, boot2DockerInstance.get(),
-                new OperatingSystemResolver()));
+        dockerClientExecutorProducer.set(new DockerClientExecutor(cubeConfiguration));
     }
 }

--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfiguration.java
@@ -10,17 +10,18 @@ import org.yaml.snakeyaml.Yaml;
 public class CubeConfiguration {
 
     private static final String DOCKER_VERSION = "serverVersion";
-    private static final String DOCKER_URI = "serverUri";
+    public static final String DOCKER_URI = "serverUri";
+    public static final String DOCKER_SERVER_IP = "dockerServerIp";
     private static final String USERNAME = "username";
     private static final String PASSWORD =  "password";
     private static final String EMAIL = "email";
-    private static final String CERT_PATH = "certPath";
+    public static final String CERT_PATH = "certPath";
     private static final String DOCKER_CONTAINERS = "dockerContainers";
     private static final String DOCKER_CONTAINERS_FILE = "dockerContainersFile";
     private static final String DOCKER_REGISTRY = "dockerRegistry";
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String CONNECTION_MODE = "connectionMode";
-    private static final String BOOT2DOCKER_PATH = "boot2dockerPath";
+    public static final String BOOT2DOCKER_PATH = "boot2dockerPath";
 
     private String dockerServerVersion;
     private String dockerServerUri;
@@ -32,6 +33,7 @@ public class CubeConfiguration {
     private String email;
     private String certPath;
     private String[] autoStartContainers = new String[0];
+    private String dockerServerIp;
 
     private Map<String, Object> dockerContainersContent;
 
@@ -79,9 +81,17 @@ public class CubeConfiguration {
         return certPath;
     }
 
+    public String getDockerServerIp() {
+        return dockerServerIp;
+    }
+
     @SuppressWarnings("unchecked")
     public static CubeConfiguration fromMap(Map<String, String> map) {
         CubeConfiguration cubeConfiguration = new CubeConfiguration();
+
+        if(map.containsKey(DOCKER_SERVER_IP)) {
+            cubeConfiguration.dockerServerIp = map.get(DOCKER_SERVER_IP);
+        }
 
         if (map.containsKey(DOCKER_VERSION)) {
             cubeConfiguration.dockerServerVersion = map.get(DOCKER_VERSION);

--- a/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfigurator.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/client/CubeConfigurator.java
@@ -1,8 +1,14 @@
 package org.arquillian.cube.impl.client;
 
+import java.io.File;
+import java.net.URI;
 import java.util.Map;
 
+import org.arquillian.cube.impl.util.Boot2Docker;
+import org.arquillian.cube.impl.util.HomeResolverUtil;
+import org.arquillian.cube.impl.util.OperatingSystemResolver;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -11,14 +17,53 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 public class CubeConfigurator {
 
     private static final String EXTENSION_NAME = "docker";
+    private static final String UNIX_SOCKET_SCHEME = "unix";
 
     @Inject
     @ApplicationScoped
     private InstanceProducer<CubeConfiguration> configurationProducer;
 
+    @Inject
+    private Instance<Boot2Docker> boot2DockerInstance;
+
     public void configure(@Observes ArquillianDescriptor arquillianDescriptor) {
         Map<String, String> config = arquillianDescriptor.extension(EXTENSION_NAME).getExtensionProperties();
-        configurationProducer.set(CubeConfiguration.fromMap(config));
+        config = resolveServerUriByOperativeSystem(config);
+        config = resolveServerIp(config);
+        CubeConfiguration cubeConfiguration = CubeConfiguration.fromMap(config);
+        configurationProducer.set(cubeConfiguration);
     }
 
+    private Map<String, String> resolveServerIp(Map<String, String> config) {
+        String dockerServerUri = config.get(CubeConfiguration.DOCKER_URI);
+        if(dockerServerUri.contains(Boot2Docker.BOOT2DOCKER_TAG)) {
+            dockerServerUri = resolveBoot2Docker(dockerServerUri, config.get(CubeConfiguration.BOOT2DOCKER_PATH));
+            config.put(CubeConfiguration.DOCKER_URI, dockerServerUri);
+            if(!config.containsKey(CubeConfiguration.CERT_PATH)) {
+                config.put(CubeConfiguration.CERT_PATH, HomeResolverUtil.resolveHomeDirectoryChar(getDefaultTlsDirectory()));
+            }
+        }
+
+        URI serverUri = URI.create(dockerServerUri);
+        String serverIp = UNIX_SOCKET_SCHEME.equalsIgnoreCase(serverUri.getScheme()) ? "localhost" : serverUri.getHost();
+        config.put(CubeConfiguration.DOCKER_SERVER_IP, serverIp);
+        return config;
+    }
+
+    private String resolveBoot2Docker(String tag,
+            String boot2DockerPath) {
+        return tag.replaceAll(Boot2Docker.BOOT2DOCKER_TAG, boot2DockerInstance.get().ip(boot2DockerPath, false));
+    }
+
+    private String getDefaultTlsDirectory() {
+        return "~" + File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm";
+    }
+
+    private Map<String, String> resolveServerUriByOperativeSystem(Map<String, String> cubeConfiguration) {
+        if(!cubeConfiguration.containsKey(CubeConfiguration.DOCKER_URI)) {
+            String serverUri = new OperatingSystemResolver().currentOperatingSystem().getFamily().getServerUri();
+            cubeConfiguration.put(CubeConfiguration.DOCKER_URI, serverUri);
+        }
+        return cubeConfiguration;
+    }
 }

--- a/docker/src/main/java/org/arquillian/cube/impl/util/BindingUtil.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/BindingUtil.java
@@ -1,6 +1,5 @@
 package org.arquillian.cube.impl.util;
 
-import java.net.URI;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -14,8 +13,6 @@ import com.github.dockerjava.api.model.HostConfig;
 
 public final class BindingUtil {
 
-    private static final String LOCALHOST = "localhost";
-    private static final String UNIX_SOCKET_SCHEME = "unix";
     public static final String PORTS_SEPARATOR = "->";
     private static final String NO_GATEWAY = null;
 
@@ -41,9 +38,7 @@ public final class BindingUtil {
     }
 
     private static String getDockerServerIp(DockerClientExecutor executor) {
-        URI dockerUri = executor.getDockerUri();
-        String dockerIp = UNIX_SOCKET_SCHEME.equalsIgnoreCase(dockerUri.getScheme()) ? LOCALHOST : dockerUri.getHost();
-        return dockerIp;
+        return executor.getDockerServerIp();
     }
 
     public static Binding binding(Map<String, Object> cubeConfiguration) {

--- a/docker/src/main/java/org/arquillian/cube/impl/util/Boot2Docker.java
+++ b/docker/src/main/java/org/arquillian/cube/impl/util/Boot2Docker.java
@@ -5,8 +5,6 @@ import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
-import org.arquillian.cube.impl.client.CubeConfiguration;
-
 public class Boot2Docker {
 
     public static final String BOOT2DOCKER_TAG = "boot2docker";
@@ -22,15 +20,15 @@ public class Boot2Docker {
         this.commandLineExecutor = commandLineExecutor;
     }
 
-    public String ip(CubeConfiguration cubeConfiguration, boolean force) {
+    public String ip(String boot2DockerPath, boolean force) {
         if(cachedIp == null || force) {
-            cachedIp = getIp(cubeConfiguration);
+            cachedIp = getIp(boot2DockerPath);
         }
         return cachedIp;
     }
 
-    private String getIp(CubeConfiguration cubeConfiguration) {
-        String output = commandLineExecutor.execCommand(createBoot2DockerCommand(cubeConfiguration), "ip");
+    private String getIp(String boot2DockerPath) {
+        String output = commandLineExecutor.execCommand(createBoot2DockerCommand(boot2DockerPath), "ip");
         Matcher m = IP_PATTERN.matcher(output);
         if(m.find()) {
             String ip = m.group();
@@ -42,8 +40,8 @@ public class Boot2Docker {
         }
     }
 
-    private String createBoot2DockerCommand(CubeConfiguration cubeConfiguration) {
-        return cubeConfiguration.getBoot2DockerPath() == null ? BOOT2DOCKER_EXEC : cubeConfiguration.getBoot2DockerPath();
+    private String createBoot2DockerCommand(String boot2DockerPath) {
+        return boot2DockerPath == null ? BOOT2DOCKER_EXEC : boot2DockerPath;
     }
 
 }

--- a/docker/src/test/java/org/arquillian/cube/impl/docker/DockerClientExecutorTest.java
+++ b/docker/src/test/java/org/arquillian/cube/impl/docker/DockerClientExecutorTest.java
@@ -6,27 +6,17 @@ package org.arquillian.cube.impl.docker;
  * Time: 5:33 PM
  */
 
-import static org.junit.Assert.assertThat;
-import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.Mockito.when;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-import org.arquillian.cube.impl.client.CubeConfiguration;
-import org.arquillian.cube.impl.util.Boot2Docker;
 import org.arquillian.cube.impl.util.CommandLineExecutor;
 import org.arquillian.cube.impl.util.IOUtil;
-import org.arquillian.cube.impl.util.OperatingSystem;
 import org.arquillian.cube.impl.util.OperatingSystemResolver;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.net.URI;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DockerClientExecutorTest {
@@ -63,68 +53,6 @@ public class DockerClientExecutorTest {
         Matcher m = HEXA_PATTERN.matcher(imageId);
         Assert.assertTrue("imageId is not an hexadecimal digit string", m.matches());
 
-    }
-
-    @Test
-    public void shouldExecuteBoot2Docker() {
-        Map<String, String> map = new HashMap<String, String>();
-        map.put("serverVersion", "1.12");
-        map.put("serverUri", "http://boot2docker:2376");
-        map.put("boot2dockerPath", "/opt/boot2docker/boot2docker");
-        CubeConfiguration cubeConfiguration =
-            CubeConfiguration.fromMap(map);
-
-        when(commandLineExecutor.execCommand("/opt/boot2docker/boot2docker", "ip")).thenReturn("The VM's Host only interface IP address is: 192.168.59.103");
-
-        DockerClientExecutor dockerClientExecutor =
-                new DockerClientExecutor(cubeConfiguration, new Boot2Docker(commandLineExecutor), operatingSystemResolver);
-        assertThat(dockerClientExecutor.getDockerUri().getHost(), is("192.168.59.103"));
-    }
-
-    @Test
-    public void shouldGetDefaultUnixSocketIfNoServerUriUnderLinux() {
-        Map<String, String> map = new HashMap<String, String>();
-        map.put("serverVersion", "1.12");
-        CubeConfiguration cubeConfiguration =
-            CubeConfiguration.fromMap(map);
-
-        when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.LINUX_OS);
-
-        DockerClientExecutor dockerClientExecutor =
-                new DockerClientExecutor(cubeConfiguration, new Boot2Docker(commandLineExecutor), operatingSystemResolver);
-        assertThat(dockerClientExecutor.getDockerUri(), is(URI.create("unix:///var/run/docker.sock")));
-    }
-
-    @Test
-    public void shouldGetDefaultBoot2DockerIfNoServerUriUnderWindows() {
-        Map<String, String> map = new HashMap<String, String>();
-        map.put("serverVersion", "1.12");
-        map.put("boot2dockerPath", "/opt/boot2docker/boot2docker");
-        CubeConfiguration cubeConfiguration =
-            CubeConfiguration.fromMap(map);
-
-        when(commandLineExecutor.execCommand("/opt/boot2docker/boot2docker", "ip")).thenReturn("The VM's Host only interface IP address is: 192.168.59.103");
-        when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.WINDOWS_7);
-
-        DockerClientExecutor dockerClientExecutor =
-                new DockerClientExecutor(cubeConfiguration, new Boot2Docker(commandLineExecutor), operatingSystemResolver);
-        assertThat(dockerClientExecutor.getDockerUri().getHost(), is("192.168.59.103"));
-    }
-
-    @Test
-    public void shouldGetDefaultBoot2DockerIfNoServerUriUnderMacOS() {
-        Map<String, String> map = new HashMap<String, String>();
-        map.put("serverVersion", "1.12");
-        map.put("boot2dockerPath", "/opt/boot2docker/boot2docker");
-        CubeConfiguration cubeConfiguration =
-            CubeConfiguration.fromMap(map);
-
-        when(commandLineExecutor.execCommand("/opt/boot2docker/boot2docker", "ip")).thenReturn("The VM's Host only interface IP address is: 192.168.59.103");
-        when(operatingSystemResolver.currentOperatingSystem()).thenReturn(OperatingSystem.MAC_OSX);
-
-        DockerClientExecutor dockerClientExecutor =
-                new DockerClientExecutor(cubeConfiguration, new Boot2Docker(commandLineExecutor), operatingSystemResolver);
-        assertThat(dockerClientExecutor.getDockerUri().getHost(), is("192.168.59.103"));
     }
 
 }

--- a/ftest-boot2docker/pom.xml
+++ b/ftest-boot2docker/pom.xml
@@ -17,7 +17,7 @@
         <docker.api.version>1.12</docker.api.version>
         <docker.api.url>http://localhost:2375</docker.api.url>
         <!-- We can set tomcat host as boot2docker and Cube will resolve to boot2docker ip -->
-        <docker.tomcat.host>boot2docker</docker.tomcat.host>
+        <docker.tomcat.host>dockerServerIp</docker.tomcat.host>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
adds dockerServerIp substitutions instead of boot2docker in container configuration and env section.