### PR TITLE
Remove dependency on Cube Docker

### DIFF
--- a/containerless/pom.xml
+++ b/containerless/pom.xml
@@ -11,7 +11,7 @@
     <dependencies>
         <dependency>
             <groupId>org.arquillian.cube</groupId>
-            <artifactId>arquillian-cube-docker</artifactId>
+            <artifactId>arquillian-cube-spi</artifactId>
         </dependency>
 
         <dependency>
@@ -19,6 +19,17 @@
             <artifactId>arquillian-container-test-spi</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>commons-lang</groupId>
+            <artifactId>commons-lang</artifactId>
+            <version>2.6</version>
+        </dependency>
+
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-docker</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>

--- a/containerless/src/main/java/org/arquillian/cube/impl/containerless/ContainerlessDockerDeployableContainer.java
+++ b/containerless/src/main/java/org/arquillian/cube/impl/containerless/ContainerlessDockerDeployableContainer.java
@@ -7,7 +7,6 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.logging.Logger;
 
-import org.arquillian.cube.docker.impl.util.IOUtil;
 import org.arquillian.cube.spi.Binding;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
@@ -22,10 +21,12 @@ import org.jboss.arquillian.container.spi.client.container.LifecycleException;
 import org.jboss.arquillian.container.spi.client.protocol.ProtocolDescription;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.HTTPContext;
 import org.jboss.arquillian.container.spi.client.protocol.metadata.ProtocolMetaData;
+import org.jboss.arquillian.container.spi.client.protocol.metadata.Servlet;
 import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.Filters;
 import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.exporter.TarExporter;
 import org.jboss.shrinkwrap.api.exporter.ZipExporter;
@@ -94,7 +95,7 @@ public class ContainerlessDockerDeployableContainer implements DeployableContain
                         // fire events as usually.
                         controlEvent.fire(new CreateCube(cube));
                         controlEvent.fire(new StartCube(cube));
-                        return createProtocolMetadata(cube);
+                        return createProtocolMetadata(cube, archive);
                     } catch (FileNotFoundException e) {
                         throw new IllegalArgumentException("Containerless Docker container requires a file named "
                                 + DOCKERFILE_TEMPLATE);
@@ -142,12 +143,31 @@ public class ContainerlessDockerDeployableContainer implements DeployableContain
         }
     }
 
-    private ProtocolMetaData createProtocolMetadata(Cube cube) {
+    private ProtocolMetaData createProtocolMetadata(Cube cube, Archive<?> deployment) {
         Binding bindings = cube.bindings();
         //ProtocolMetadataUpdater will reajust the port to the exposed ones.
         HTTPContext httpContext = new HTTPContext(bindings.getIP(), configuration.getEmbeddedPort());
+
+        // TEMP HACK to allow in-container testing without communicating with the Server mgm api
+        if(containsArquillianServletProtocol(deployment)) {
+            addArquillianTestServlet(deployment, httpContext);
+        }
         return new ProtocolMetaData().addContext(httpContext);
     }
+
+    private boolean containsArquillianServletProtocol(Archive<?> deployment) {
+        return deployment.getContent(Filters.include(".*arquillian-protocol.jar")).size() > 0;
+	}
+
+	private void addArquillianTestServlet(Archive<?> deployment, HTTPContext httpContext) {
+        httpContext.add(new Servlet("ArquillianServletRunner", extractContextName(deployment)));
+	}
+
+	private String extractContextName(Archive<?> deployment) {
+        String name = deployment.getName();
+        name = name.substring(0, name.lastIndexOf("."));
+        return name;
+	}
 
     @Override
     public void undeploy(Archive<?> archive) throws DeploymentException {

--- a/containerless/src/main/java/org/arquillian/cube/impl/containerless/IOUtil.java
+++ b/containerless/src/main/java/org/arquillian/cube/impl/containerless/IOUtil.java
@@ -1,0 +1,56 @@
+package org.arquillian.cube.impl.containerless;
+
+import java.io.BufferedReader;
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.StringWriter;
+import java.util.Map;
+
+import org.apache.commons.lang.text.StrSubstitutor;
+
+public class IOUtil {
+
+    private IOUtil() {
+        super();
+    }
+
+    public static String replacePlaceholders(String templateContent, Map<String, String> values) {
+        StrSubstitutor sub = new StrSubstitutor(values);
+        return sub.replace(templateContent);
+    }
+
+    public static void toFile(String content, File output) {
+
+        try {
+            BufferedWriter writer = new BufferedWriter(new FileWriter(output));
+            writer.write(content);
+            writer.flush();
+            writer.close();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static String asStringPreservingNewLines(InputStream response) {
+        StringWriter logwriter = new StringWriter();
+
+        try {
+            BufferedReader bufferedReader = new BufferedReader(new InputStreamReader(response));
+
+            String line = null;
+            while ((line = bufferedReader.readLine()) != null) {
+                logwriter.write(line);
+                logwriter.write(System.lineSeparator());
+            }
+
+            return logwriter.toString();
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/IOUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/IOUtil.java
@@ -3,10 +3,8 @@ package org.arquillian.cube.docker.impl.util;
 import java.io.BufferedInputStream;
 import java.io.BufferedOutputStream;
 import java.io.BufferedReader;
-import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -58,18 +56,6 @@ public class IOUtil {
     public static String replacePlaceholders(String templateContent, Map<String, String> values) {
         StrSubstitutor sub = new StrSubstitutor(values);
         return sub.replace(templateContent);
-    }
-
-    public static void toFile(String content, File output) {
-
-        try {
-            BufferedWriter writer = new BufferedWriter(new FileWriter(output));
-            writer.write(content);
-            writer.flush();
-            writer.close();
-        } catch (IOException e) {
-            throw new RuntimeException(e);
-        }
     }
 
     public static String substringBetween(String str, String open, String close) {


### PR DESCRIPTION
Containerless Container is reusable between Cube Docker
and Cube OpenShift.

* Add support for Servlet Protocol discovery and 'fake'
mapping of ServletTestRunner in ProtocolMetadata. This allow
for in container testing of prepared Docker images.