### PR TITLE
resolves issue #181 by forcing a Unix EOL instead of a platform dependant one

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/IOUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/IOUtil.java
@@ -13,6 +13,7 @@ import java.util.Map;
 
 import org.apache.commons.compress.archivers.ArchiveEntry;
 import org.apache.commons.compress.archivers.tar.TarArchiveInputStream;
+import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang.text.StrSubstitutor;
 
 public class IOUtil {
@@ -97,7 +98,7 @@ public class IOUtil {
             String line = null;
             while ((line = bufferedReader.readLine()) != null) {
                 logwriter.write(line);
-                logwriter.write(System.lineSeparator());
+                logwriter.write(IOUtils.LINE_SEPARATOR_UNIX);
             }
 
             return logwriter.toString();


### PR DESCRIPTION
The pull request proposes to use the ``IOUtils.LINE_SEPARATOR_UNIX`` constant from ``commons-io`` (already available in the module) to specify line ending.