### PR TITLE
Minor fixes for test cases.

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutomaticResolutionAutoStartParser.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutomaticResolutionAutoStartParser.java
@@ -3,10 +3,10 @@ package org.arquillian.cube.docker.impl.client;
 
 import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class AutomaticResolutionAutoStartParser implements AutoStartParser {
 
@@ -30,7 +30,7 @@ public class AutomaticResolutionAutoStartParser implements AutoStartParser {
             }
 
             if (content.containsKey("links")) {
-                Set<String> links = (Set<String>) content.get("links");
+                Collection<String> links = (Collection<String>) content.get("links");
                 for (String link : links) {
                     String[] parsed = link.split(":");
                     String name = parsed[0];

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.docker.impl.client;
 
+import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.util.Map;
@@ -163,7 +164,7 @@ public class CubeDockerConfiguration {
         if (map.containsKey(DOCKER_CONTAINERS_FILE)) {
             String location = map.get(DOCKER_CONTAINERS_FILE);
             try {
-                cubeConfiguration.dockerContainersContent = DockerContainerDefinitionParser.convert(URI.create(location), cubeConfiguration.definitionFormat);
+                cubeConfiguration.dockerContainersContent = DockerContainerDefinitionParser.convert(new File(location).toURI(), cubeConfiguration.definitionFormat);
             } catch (IOException e) {
                 throw new IllegalArgumentException(e);
             }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -93,7 +93,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
 
         fire(new CubeConfiguration());
-        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://127.0.0.1:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "http://127.0.0.1:22222"));
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_SERVER_IP, "127.0.0.1"));
 
         if(originalVar != null) {
@@ -198,6 +198,6 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         fire(cubeConfiguration);
         System.out.flush();
         System.setOut(old);
-        assertThat(baos.toString(), containsString("CubeDockerConfiguration{"));
+        assertThat(baos.toString(), containsString("CubeDockerConfiguration: "));
     }
 }


### PR DESCRIPTION
I tried to build arquillian-cube and there seem to be at least these three issues where the test cases fail on my Windows box:

- In `AutomaticResolutionAutoStartParser.java` the content returned is an `ArrayList` instead of a `Set`.
  In this case I think it's valid to only assume that the returned content is some kind of collection.
- In `CubeDockerConfiguration.java` `URI.create()` fails with a Windows path.
  I think `new File(location).toURI()` should work on all platforms.
  This is probably not only an issue with the test cases but also a general problem when having a container configuration file!
- In `CubeConfiguratorTest.java` the class `CubeDockerConfiguration` simply produces another output than expected.
  Additionally if the env variable `DOCKER_HOST` is not set the default docker URI is `http://127.0.0.1:22222`. If it is set it will be `https://...`.