### PR TITLE
Return ContainerConfig exposedPorts if no HostConfig boundPorts found

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
@@ -95,6 +95,9 @@ public class PollingAwaitStrategy implements AwaitStrategy {
 
             switch(this.type) {
                 case "ping": {
+                    if(ports.getBindingPort() == -1) {
+                        throw new IllegalArgumentException("Can not use polling of type " + type + " on non externally bound port " + ports.getExposedPort());
+                    }
                     if (!Ping.ping(bindings.getIP(), ports.getBindingPort(), this.pollIterations, this.sleepPollTime,
                             this.timeUnit)) {
                         return false;

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
@@ -178,7 +178,7 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
             if (hostPortValue > 0) {
                 final Binding.PortBinding bindingForExposedPort = cube.bindings().getBindingForExposedPort(hostPortValue);
 
-                if (bindingForExposedPort != null) {
+                if (bindingForExposedPort != null && bindingForExposedPort.getBindingPort() != -1) {
                     field.set(containerObjectInstance, bindingForExposedPort.getBindingPort());
                 } else {
                     throw new IllegalArgumentException(String.format("Container Object %s contains field %s annotated with %s but exposed port %s is not exposed on container object.", containerObjectInstance.getClass().getSimpleName(), field.getName(), HostPort.class.getSimpleName(), hostPortValue));


### PR DESCRIPTION
In this scenario boundPort is set to -1.

fixes #208 

I updated the 'ping' polling option to take the -1 boundPort into account. Not sure if there are other places we need to handle this as well?