### PR TITLE
Avoid ClassCastException in AutomaticResolutionStartParser

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutomaticResolutionAutoStartParser.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutomaticResolutionAutoStartParser.java
@@ -3,10 +3,10 @@ package org.arquillian.cube.docker.impl.client;
 
 import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
 
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 
 public class AutomaticResolutionAutoStartParser implements AutoStartParser {
 
@@ -30,7 +30,7 @@ public class AutomaticResolutionAutoStartParser implements AutoStartParser {
             }
 
             if (content.containsKey("links")) {
-                Set<String> links = (Set<String>) content.get("links");
+                Collection<String> links = (Collection<String>) content.get("links");
                 for (String link : links) {
                     String[] parsed = link.split(":");
                     String name = parsed[0];


### PR DESCRIPTION
At least when building on Win7 the links are returned as an ArrayList instead of a Set as expected.
Just expecting a Collection makes the test pass for me on Win.