### PR TITLE
Fix DockerComposeConverterTest when building on Windows.

### DIFF
--- a/docker/docker/pom.xml
+++ b/docker/docker/pom.xml
@@ -122,4 +122,18 @@
         
     </dependencies>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <environmentVariables>
+                        <TESTIMAGENAME>MyImageName</TESTIMAGENAME>
+                    </environmentVariables>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
 </project>

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
@@ -12,7 +12,6 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Properties;
 import java.util.Random;
 import java.util.Set;
@@ -204,7 +203,7 @@ public class ContainerBuilder {
         }
 
 
-        this.logUsupportedOperations(dockerComposeContainerDefinition.keySet());
+        this.logUnsupportedOperations(dockerComposeContainerDefinition.keySet());
         return this.build();
     }
 
@@ -573,7 +572,7 @@ public class ContainerBuilder {
         return allProperties;
     }
 
-    private void logUsupportedOperations(Set<String> keys) {
+    private void logUnsupportedOperations(Set<String> keys) {
         for (String key : keys) {
             if(!AVAILABLE_COMMANDS.contains(key)) {
                 log.info(String.format("Key: %s is not implemented in Cube.", keys));

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
@@ -68,8 +68,7 @@ public class DockerComposeConverterTest {
     Map<String, Object> webapp = (Map<String, Object>) convert.get("webapp2");
     assertThat(webapp, hasKey("image"));
     final String image = (String)webapp.get("image");
-    assertThat(image, is(notNullValue()));
-    assertThat(image, is(System.getenv("USER")));
+    assertThat(image, is("MyImageName"));
   }
 
   @Test

--- a/docker/docker/src/test/resources/simple-cube-var.yml
+++ b/docker/docker/src/test/resources/simple-cube-var.yml
@@ -1,5 +1,5 @@
 webapp2:
-  image: ${USER}
+  image: ${TESTIMAGENAME}
   portBindings: [8080->8080]
   links:
     - webapp:webapp


### PR DESCRIPTION
The DockerComposeConverterTest expects that an image name in the docker-compose.yaml is correctly replaced with the content of an environment variable.
Unfortunately the env var `USER` is not available on Windows, so that the test fails.
(`USER` is probably chosen as an arbitrary image name without any further purpose.)

Fixed by explicitly setting the env variable `TESTIMAGENAME` in the configuration of the surefire plugin and using this in the yaml file.

Additionally fixed a typo in a private method name that appears in log messages (`logUsupportedOperations`)