### PR TITLE
Always update host/address configuration options on Cube mapped Conta…

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/container/DockerServerIPConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/container/DockerServerIPConfigurator.java
@@ -10,10 +10,10 @@ import java.util.Map.Entry;
 import java.util.regex.Pattern;
 
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
-import org.arquillian.cube.docker.impl.client.CubeDockerConfigurator;
 import org.arquillian.cube.docker.impl.util.ContainerUtil;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
-import org.arquillian.cube.impl.util.SystemEnvironmentVariables;
+import org.arquillian.cube.spi.Binding;
+import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.config.descriptor.api.ContainerDef;
 import org.jboss.arquillian.container.spi.Container;
@@ -33,38 +33,37 @@ public class DockerServerIPConfigurator {
     @Inject
     private Instance<OperatingSystemFamily> familyInstance;
 
-    public void applyDockerServerIpChange(@Observes BeforeSetup event, CubeRegistry cubeRegistry,
-            ContainerRegistry containerRegistry, CubeDockerConfiguration cubeConfiguration) throws InstantiationException, IllegalAccessException, MalformedURLException {
+    public void applyDockerServerIpChange(@Observes BeforeSetup event, CubeRegistry cubeRegistry, ContainerRegistry containerRegistry)
+            throws InstantiationException, IllegalAccessException, MalformedURLException {
 
         Container container = ContainerUtil.getContainerByDeployableContainer(containerRegistry,
                 event.getDeployableContainer());
         if (container == null) {
             return;
         }
+        Cube cube = cubeRegistry.getCube(container.getName());
+        if (cube == null) {
+            return; // No Cube found matching Container name, not managed by Cube
+        }
+
+        Binding binding = cube.configuredBindings();
 
         ContainerDef containerConfiguration = container.getContainerConfiguration();
-        boolean foundAttribute = resolveConfigurationPropertiesWithDockerServerIp(containerConfiguration, cubeConfiguration);
+        boolean foundAttribute = resolveConfigurationPropertiesWithDockerServerIp(containerConfiguration, binding);
 
         //if user doesn't configured in arquillian.xml the host then we can override the default value.
         if(!foundAttribute) {
-            //if it is a boot2docker host (that is a Windows or MacOSX) or docker-machine is being used (can be Linux, Windows or MacOSX) or user set DOCKER_HOST
-            if(familyInstance.get().isBoot2Docker() || cubeConfiguration.isDockerMachineName() || isDockerHostEnvironmentVarSet()) {
-                Class<?> configurationClass = container.getDeployableContainer().getConfigurationClass();
-                List<PropertyDescriptor> configurationClassHostOrAddressFields = filterConfigurationClassPropertiesByHostOrAddressAttribute(configurationClass);
-                for (PropertyDescriptor propertyDescriptor : configurationClassHostOrAddressFields) {
-                    //we get default address value and we replace to boot2docker ip
-                    containerConfiguration.overrideProperty(propertyDescriptor.getName(), cubeConfiguration.getDockerServerIp());
-                }
+            Class<?> configurationClass = container.getDeployableContainer().getConfigurationClass();
+            List<PropertyDescriptor> configurationClassHostOrAddressFields = filterConfigurationClassPropertiesByHostOrAddressAttribute(configurationClass);
+            for (PropertyDescriptor propertyDescriptor : configurationClassHostOrAddressFields) {
+                //we get default address value and we replace to boot2docker ip
+                containerConfiguration.overrideProperty(propertyDescriptor.getName(), binding.getIP());
             }
         }
 
     }
 
-    private boolean isDockerHostEnvironmentVarSet() {
-        return SystemEnvironmentVariables.getEnvironmentOrPropertyVariable(CubeDockerConfigurator.DOCKER_HOST) != null;
-    }
-
-    private boolean resolveConfigurationPropertiesWithDockerServerIp(ContainerDef containerDef, CubeDockerConfiguration cubeConfiguration) {
+    private boolean resolveConfigurationPropertiesWithDockerServerIp(ContainerDef containerDef, Binding binding) {
 
         boolean foundAttribute = false;
         for (Entry<String, String> entry : containerDef.getContainerProperties().entrySet()) {
@@ -72,7 +71,7 @@ public class DockerServerIPConfigurator {
                 //if property is already configured, doesn't matter if it is a boot2docker or not we can say that we have matched a defined property.
                 foundAttribute = true;
                 if(entry.getValue().contains(CubeDockerConfiguration.DOCKER_SERVER_IP)) {
-                    containerDef.overrideProperty(entry.getKey(), entry.getValue().replaceAll(CubeDockerConfiguration.DOCKER_SERVER_IP, cubeConfiguration.getDockerServerIp()));
+                    containerDef.overrideProperty(entry.getKey(), entry.getValue().replaceAll(CubeDockerConfiguration.DOCKER_SERVER_IP, binding.getIP()));
                 }
             }
         }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
@@ -147,7 +147,7 @@ public class DockerCube extends BaseCube {
 
     @Override
     public Binding configuredBindings() {
-        return BindingUtil.binding(configuration);
+        return BindingUtil.binding(configuration, executor);
     }
 
     @Override

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/BindingUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/BindingUtil.java
@@ -48,9 +48,9 @@ public final class BindingUtil {
         return executor.getDockerServerIp();
     }
 
-    public static Binding binding(Map<String, Object> cubeConfiguration) {
+    public static Binding binding(Map<String, Object> cubeConfiguration, DockerClientExecutor executor) {
 
-        Binding binding = new Binding(NO_GATEWAY);
+        Binding binding = new Binding(executor.getDockerServerIp());
 
         if (cubeConfiguration.containsKey("portBindings")) {
             @SuppressWarnings("unchecked")

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/container/DockerServerIPConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/container/DockerServerIPConfiguratorTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.impl.model.LocalCubeRegistry;
+import org.arquillian.cube.spi.Binding;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.config.descriptor.api.ContainerDef;
@@ -37,9 +38,6 @@ public class DockerServerIPConfiguratorTest extends AbstractManagerTestBase {
 
     @Mock
     private Cube cube;
-
-    @Mock
-    private CubeDockerConfiguration cubeConfiguration;
 
     @Mock
     private Container container;
@@ -105,9 +103,8 @@ public class DockerServerIPConfiguratorTest extends AbstractManagerTestBase {
     public void shouldRemapContainerAddressToBootToDocker() {
         Map<String, String> containerConfig = new HashMap<String, String>();
         when(containerDef.getContainerProperties()).thenReturn(containerConfig);
-        when(cubeConfiguration.getDockerServerIp()).thenReturn("192.168.0.1");
+        when(cube.configuredBindings()).thenReturn(new Binding("192.168.0.1"));
         bind(ApplicationScoped.class, OperatingSystemFamily.class, OperatingSystemFamily.MAC);
-        bind(ApplicationScoped.class, CubeDockerConfiguration.class, cubeConfiguration);
         fire(new BeforeSetup(deployableContainer));
         verify(containerDef).overrideProperty("myHost", "192.168.0.1");
     }
@@ -117,9 +114,8 @@ public class DockerServerIPConfiguratorTest extends AbstractManagerTestBase {
         Map<String, String> containerConfig = new HashMap<String, String>();
         containerConfig.put("myHost", CubeDockerConfiguration.DOCKER_SERVER_IP);
         when(containerDef.getContainerProperties()).thenReturn(containerConfig);
-        when(cubeConfiguration.getDockerServerIp()).thenReturn("192.168.0.1");
+        when(cube.configuredBindings()).thenReturn(new Binding("192.168.0.1"));
         bind(ApplicationScoped.class, OperatingSystemFamily.class, OperatingSystemFamily.MAC);
-        bind(ApplicationScoped.class, CubeDockerConfiguration.class, cubeConfiguration);
         fire(new BeforeSetup(deployableContainer));
         verify(containerDef).overrideProperty("myHost", "192.168.0.1");
     }
@@ -129,9 +125,8 @@ public class DockerServerIPConfiguratorTest extends AbstractManagerTestBase {
         Map<String, String> containerConfig = new HashMap<String, String>();
         containerConfig.put("myHost", "10.0.10.1");
         when(containerDef.getContainerProperties()).thenReturn(containerConfig);
-        when(cubeConfiguration.getDockerServerIp()).thenReturn("192.168.0.1");
+        when(cube.configuredBindings()).thenReturn(new Binding("192.168.0.1"));
         bind(ApplicationScoped.class, OperatingSystemFamily.class, OperatingSystemFamily.MAC);
-        bind(ApplicationScoped.class, CubeDockerConfiguration.class, cubeConfiguration);
         fire(new BeforeSetup(deployableContainer));
         verify(containerDef, times(0)).overrideProperty("myHost", "192.168.0.1");
     }

--- a/docker/ftest-boot2docker/pom.xml
+++ b/docker/ftest-boot2docker/pom.xml
@@ -16,8 +16,6 @@
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
         <docker.api.version>1.12</docker.api.version>
         <docker.api.url>http://localhost:2375</docker.api.url>
-        <!-- We can set tomcat host as boot2docker and Cube will resolve to boot2docker ip -->
-        <docker.tomcat.host>dockerServerIp</docker.tomcat.host>
     </properties>
 
     <dependencyManagement>

--- a/docker/ftest-boot2docker/src/test/resources/arquillian.xml
+++ b/docker/ftest-boot2docker/src/test/resources/arquillian.xml
@@ -81,7 +81,6 @@
 
     <container qualifier="tomee_dockerfile" default="true">
         <configuration>
-            <property name="httpPort">8080</property>
             <property name="user">tomee</property>
             <property name="pass">unsecured</property>
             <property name="deployerProperties">
@@ -93,21 +92,18 @@
     </container>
     <container qualifier="tomcat_dockerfile">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat_default">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
@@ -115,7 +111,6 @@
     <container qualifier="wildfly">
         <configuration>
             <property name="target">wildfly:8.1.0.Final:remote</property>
-            <property name="managementPort">9991</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>
@@ -123,7 +118,6 @@
     <container qualifier="wildfly_database">
         <configuration>
             <property name="target">wildfly:8.1.0.Final:remote</property>
-            <property name="managementPort">9991</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>
@@ -132,7 +126,6 @@
         <container qualifier="wildfly">
             <configuration>
                 <property name="target">wildfly:8.1.0.Final:remote</property>
-                <property name="managementPort">9991</property>
                 <property name="username">admin</property>
                 <property name="password">Admin#70365</property>
             </configuration>
@@ -140,7 +133,6 @@
         <container qualifier="wildfly2" default="true">
             <configuration>
                 <property name="target">wildfly:8.1.0.Final:remote</property>
-                <property name="managementPort">9992</property>
                 <property name="username">admin</property>
                 <property name="password">Admin#70365</property>
             </configuration>

--- a/docker/ftest-docker-compose/pom.xml
+++ b/docker/ftest-docker-compose/pom.xml
@@ -14,7 +14,6 @@
         <version.tomcat>1.0.0.CR7</version.tomcat>
         <docker.api.version>1.12</docker.api.version>
         <docker.api.url>http://localhost:2375</docker.api.url>
-        <docker.tomcat.host>dockerServerIp</docker.tomcat.host>
     </properties>
 
     <dependencyManagement>

--- a/docker/ftest-docker-compose/src/test/resources/arquillian.xml
+++ b/docker/ftest-docker-compose/src/test/resources/arquillian.xml
@@ -16,8 +16,6 @@
 
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
-            <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>

--- a/docker/ftest-docker-machine/src/test/resources/arquillian.xml
+++ b/docker/ftest-docker-machine/src/test/resources/arquillian.xml
@@ -16,7 +16,6 @@
 
     <container qualifier="tomcat">
         <configuration>
-            <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>

--- a/docker/ftest/pom.xml
+++ b/docker/ftest/pom.xml
@@ -16,7 +16,6 @@
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
         <docker.api.version>1.12</docker.api.version>
         <docker.api.url>http://localhost:2375</docker.api.url>
-        <docker.tomcat.host>dockerServerIp</docker.tomcat.host>
     </properties>
 
     <dependencyManagement>

--- a/docker/ftest/src/test/resources/arquillian.xml
+++ b/docker/ftest/src/test/resources/arquillian.xml
@@ -63,25 +63,18 @@
 
     <container qualifier="tomcat_dockerfile">
         <configuration>
-          <!-- This must match the docker host ip.  Otherwise it is not replaced before TomcatRemoteContainer.deploy is invoked as of Arquillian 1.1.6. Final
-           ProtocolMetadataUpdater is not currently invoked until after the initial deployment to tomcat has occurred -->
-            <property name="host">${docker.tomcat.host}</property>
-            <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat_default">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
     </container>
     <container qualifier="tomcat">
         <configuration>
-            <property name="host">${docker.tomcat.host}</property>
-            <property name="httpPort">8081</property>
             <property name="user">admin</property>
             <property name="pass">mypass</property>
         </configuration>
@@ -89,7 +82,6 @@
     <container qualifier="wildfly">
         <configuration>
             <property name="target">wildfly:8.1.0.Final:remote</property>
-            <property name="managementPort">9991</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>
@@ -97,7 +89,6 @@
     <container qualifier="wildfly_database">
         <configuration>
             <property name="target">wildfly:8.1.0.Final:remote</property>
-            <property name="managementPort">9991</property>
             <property name="username">admin</property>
             <property name="password">Admin#70365</property>
         </configuration>
@@ -106,7 +97,6 @@
         <container qualifier="wildfly">
             <configuration>
                 <property name="target">wildfly:8.1.0.Final:remote</property>
-                <property name="managementPort">9991</property>
                 <property name="username">admin</property>
                 <property name="password">Admin#70365</property>
             </configuration>
@@ -114,7 +104,6 @@
         <container qualifier="wildfly2" default="true">
             <configuration>
                 <property name="target">wildfly:8.1.0.Final:remote</property>
-                <property name="managementPort">9992</property>
                 <property name="username">admin</property>
                 <property name="password">Admin#70365</property>
             </configuration>


### PR DESCRIPTION
…iners

fixes #221 

Only moved to use Cube.configuredBindings() in this pull request. Merging DockerServerIPConfigurator and ContainerConfigurationController is not 100% streight forward since DockerServerIPConfigurator also handles the replacement of expression "dockerServerIP" in the configuration values. "dockerServerIP" is not really a Core concern. Need to think of something smart to do here to get the host/address mapping update into Core. 

Using configuredBindings() instead of bindings() since CubeStart has not yet been called when BeforeSetup is invoked. configuredBindings is updated to set the dockerServerIp as Bindings.ip.