### PR TITLE
Add configuration Object model

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/model/LocalCubeRegistry.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/LocalCubeRegistry.java
@@ -9,14 +9,14 @@ import org.arquillian.cube.spi.CubeRegistry;
 
 public class LocalCubeRegistry implements CubeRegistry {
 
-    private List<Cube> cubes;
+    private List<Cube<?>> cubes;
 
     public LocalCubeRegistry() {
-        this.cubes = new ArrayList<Cube>();
+        this.cubes = new ArrayList<Cube<?>>();
     }
 
     @Override
-    public void addCube(Cube cube) {
+    public void addCube(Cube<?> cube) {
         this.cubes.add(cube);
     }
 
@@ -31,9 +31,9 @@ public class LocalCubeRegistry implements CubeRegistry {
     }
 
     @Override
-    public List<Cube> getByMetadata(Class<?> metadata) {
-        List<Cube> cubes = new ArrayList<>();
-        for (Cube cube : this.cubes) {
+    public List<Cube<?>> getByMetadata(Class<?> metadata) {
+        List<Cube<?>> cubes = new ArrayList<>();
+        for (Cube<?> cube : this.cubes) {
             if (cube.hasMetadata(metadata)) {
                 cubes.add(cube);
             }
@@ -42,8 +42,8 @@ public class LocalCubeRegistry implements CubeRegistry {
     }
 
     @Override
-    public Cube getCube(String id) {
-        for(Cube cube : this.cubes) {
+    public Cube<?> getCube(String id) {
+        for(Cube<?> cube : this.cubes) {
             if(cube.getId().equals(id)) {
                 return cube;
             }
@@ -52,7 +52,12 @@ public class LocalCubeRegistry implements CubeRegistry {
     }
 
     @Override
-    public List<Cube> getCubes() {
+    public <T extends Cube<?>> T getCube(String id, Class<T> type) {
+        return type.cast(getCube(id));
+    }
+
+    @Override
+    public List<Cube<?>> getCubes() {
         return Collections.unmodifiableList(cubes);
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.docker.impl.await;
 
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Logger;
 
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.Cube;
 
@@ -11,39 +11,34 @@ public class AwaitStrategyFactory {
 
     private static final Logger log = Logger.getLogger(AwaitStrategyFactory.class.getName());
 
-    private static final String AWAIT = "await";
-    private static final String STRATEGY = "strategy";
-
     private AwaitStrategyFactory() {
         super();
     }
 
-    public static final AwaitStrategy create(DockerClientExecutor dockerClientExecutor, Cube cube, Map<String, Object> options) {
+    public static final AwaitStrategy create(DockerClientExecutor dockerClientExecutor, Cube cube, CubeContainer options) {
 
-        if(options.containsKey(AWAIT)) {
+        if(options.getAwait() != null) {
+            Await await = options.getAwait();
 
-            @SuppressWarnings("unchecked")
-            Map<String, Object> awaitOptions = (Map<String, Object>) options.get(AWAIT);
+            if (await.getStrategy() != null) {
 
-            if (awaitOptions.containsKey(STRATEGY)) {
-
-                String strategy = ((String) awaitOptions.get(STRATEGY)).toLowerCase();
+                String strategy = ((String) await.getStrategy()).toLowerCase();
                 switch(strategy) {
-                    case PollingAwaitStrategy.TAG: return new PollingAwaitStrategy(cube, dockerClientExecutor, awaitOptions);
+                    case PollingAwaitStrategy.TAG: return new PollingAwaitStrategy(cube, dockerClientExecutor, await);
                     case NativeAwaitStrategy.TAG: return new NativeAwaitStrategy(cube, dockerClientExecutor);
-                    case StaticAwaitStrategy.TAG: return new StaticAwaitStrategy(cube, awaitOptions);
-                    case SleepingAwaitStrategy.TAG: return new SleepingAwaitStrategy(cube, awaitOptions);
+                    case StaticAwaitStrategy.TAG: return new StaticAwaitStrategy(cube, await);
+                    case SleepingAwaitStrategy.TAG: return new SleepingAwaitStrategy(cube, await);
                     default: return new NativeAwaitStrategy(cube, dockerClientExecutor);
                 }
 
             } else {
                 log.fine("No await strategy is set and Native one is going to be used.");
-                return new PollingAwaitStrategy(cube, dockerClientExecutor, new HashMap<String, Object>());
+                return new PollingAwaitStrategy(cube, dockerClientExecutor, new Await());
             }
 
         } else {
             log.fine("No await strategy is set and Polling strategy is going to be used.");
-            return new PollingAwaitStrategy(cube, dockerClientExecutor, new HashMap<String, Object>());
+            return new PollingAwaitStrategy(cube, dockerClientExecutor, new Await());
         }
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
+import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.util.IOUtil;
 import org.arquillian.cube.docker.impl.util.Ping;
@@ -22,9 +23,6 @@ public class PollingAwaitStrategy implements AwaitStrategy {
     private static final int DEFAULT_SLEEP_POLL_TIME = 500;
     private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
     private static final String DEFAULT_POLL_TYPE = "sscommand";
-    private static final String POLLING_TIME = "sleepPollingTime";
-    private static final String ITERATIONS = "iterations";
-    private static final String POLL_TYPE = "type";
 
     private int pollIterations = DEFAULT_POLL_ITERATIONS;
     private int sleepPollTime = DEFAULT_SLEEP_POLL_TIME;
@@ -34,24 +32,23 @@ public class PollingAwaitStrategy implements AwaitStrategy {
     private DockerClientExecutor dockerClientExecutor;
     private Cube cube;
 
-    public PollingAwaitStrategy(Cube cube, DockerClientExecutor dockerClientExecutor, Map<String, Object> params) {
+    public PollingAwaitStrategy(Cube cube, DockerClientExecutor dockerClientExecutor, Await params) {
         this.cube = cube;
         this.dockerClientExecutor = dockerClientExecutor;
-        if (params.containsKey(POLLING_TIME)) {
-            configurePollingTime(params);
+        if (params.getSleepPollingTime() != null) {
+            configurePollingTime(params.getSleepPollingTime());
         }
 
-        if (params.containsKey(ITERATIONS)) {
-            this.pollIterations = (Integer) params.get(ITERATIONS);
+        if (params.getIterations() != null) {
+            this.pollIterations = params.getIterations();
         }
 
-        if(params.containsKey(POLL_TYPE)) {
-            this.type = (String) params.get(POLL_TYPE);
+        if(params.getType() != null) {
+            this.type = params.getType();
         }
     }
 
-    private void configurePollingTime(Map<String, Object> params) {
-        Object sleepTime = params.get(POLLING_TIME);
+    private void configurePollingTime(Object sleepTime) {
         if(sleepTime instanceof Integer) {
             this.sleepPollTime = (Integer) sleepTime;
         } else {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepingAwaitStrategy.java
@@ -1,10 +1,10 @@
 package org.arquillian.cube.docker.impl.await;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
+import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.spi.Cube;
 
 public class SleepingAwaitStrategy implements AwaitStrategy {
@@ -15,19 +15,17 @@ public class SleepingAwaitStrategy implements AwaitStrategy {
 
     private static final int DEFAULT_SLEEP_TIME = 500;
     private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
-    private static final String SLEEPING_TIME = "sleepTime";
 
     private int sleepTime = DEFAULT_SLEEP_TIME;
     private TimeUnit timeUnit = DEFAULT_TIME_UNIT;
 
-    public SleepingAwaitStrategy(Cube cube, Map<String, Object> params) {
-        if (params.containsKey(SLEEPING_TIME)) {
-            configureSleepingTime(params);
+    public SleepingAwaitStrategy(Cube cube, Await params) {
+        if (params.getSleepTime() != null) {
+            configureSleepingTime(params.getSleepTime());
         }
     }
 
-    private void configureSleepingTime(Map<String, Object> params) {
-        Object sleepTime = params.get(SLEEPING_TIME);
+    private void configureSleepingTime(Object sleepTime) {
         if(sleepTime instanceof Integer) {
             this.sleepTime = (Integer) sleepTime;
         } else {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StaticAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StaticAwaitStrategy.java
@@ -1,27 +1,20 @@
 package org.arquillian.cube.docker.impl.await;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 
+import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.docker.impl.util.Ping;
 import org.arquillian.cube.spi.Cube;
 
 public class StaticAwaitStrategy implements AwaitStrategy {
-
-    private static final String PORTS = "ports";
-
-    private static final String IP = "ip";
 
     public static final String TAG = "static";
 
     private static final int DEFAULT_POLL_ITERATIONS = 10;
     private static final int DEFAULT_SLEEP_POLL_TIME = 500;
     private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
-    private static final String POLLING_TIME = "sleepPollingTime";
-    private static final String ITERATIONS = "iterations";
 
     private int pollIterations = DEFAULT_POLL_ITERATIONS;
     private int sleepPollTime = DEFAULT_SLEEP_POLL_TIME;
@@ -30,22 +23,20 @@ public class StaticAwaitStrategy implements AwaitStrategy {
     private String ip;
     private List<Integer> ports = new ArrayList<Integer>();
 
-    @SuppressWarnings("unchecked")
-    public StaticAwaitStrategy(Cube cube, Map<String, Object> params) {
-        this.ip = (String) params.get(IP);
-        this.ports.addAll((Collection<? extends Integer>) params.get(PORTS));
+    public StaticAwaitStrategy(Cube cube, Await params) {
+        this.ip = params.getIp();
+        this.ports.addAll(params.getPorts());
 
-        if (params.containsKey(POLLING_TIME)) {
-            configurePollingTime(params);
+        if (params.getSleepPollingTime() != null) {
+            configurePollingTime(params.getSleepPollingTime());
         }
 
-        if (params.containsKey(ITERATIONS)) {
-            this.pollIterations = (Integer) params.get(ITERATIONS);
+        if (params.getIterations() != null) {
+            this.pollIterations = params.getIterations();
         }
     }
 
-    private void configurePollingTime(Map<String, Object> params) {
-        Object sleepTime = params.get(POLLING_TIME);
+    private void configurePollingTime(Object sleepTime) {
         if(sleepTime instanceof Integer) {
             this.sleepPollTime = (Integer) sleepTime;
         } else {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutoStartParserFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutoStartParserFactory.java
@@ -1,10 +1,10 @@
 package org.arquillian.cube.docker.impl.client;
 
-import java.util.Map;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
 
 public class AutoStartParserFactory {
 
-    public static AutoStartParser create(String expression, Map<String, Object> containersDefinition) {
+    public static AutoStartParser create(String expression, CubeContainers containersDefinition) {
         if(isRegularExpressionBased(expression)) {
             return new RegularExpressionAutoStartParser(expression, containersDefinition);
         } else {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutomaticResolutionAutoStartParser.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AutomaticResolutionAutoStartParser.java
@@ -1,16 +1,22 @@
 
 package org.arquillian.cube.docker.impl.client;
 
-import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import java.util.*;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.client.config.Link;
+import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
 
 public class AutomaticResolutionAutoStartParser implements AutoStartParser {
 
     private List<String> deployableContainers;
-    private Map<String, Object> containerDefinition;
+    private CubeContainers containerDefinition;
 
-    public AutomaticResolutionAutoStartParser(List<String> deployableContainers, Map<String, Object> containerDefinitions) {
+    public AutomaticResolutionAutoStartParser(List<String> deployableContainers, CubeContainers containerDefinitions) {
         this.deployableContainers = deployableContainers;
         this.containerDefinition = containerDefinitions;
     }
@@ -21,18 +27,17 @@ public class AutomaticResolutionAutoStartParser implements AutoStartParser {
         Map<String, AutoStartOrderUtil.Node> nodes = new HashMap<>();
 
         for(String deployableContainer : this.deployableContainers) {
-            Map<String, Object> content = (Map<String, Object>) containerDefinition.get(deployableContainer);
+            CubeContainer content = containerDefinition.get(deployableContainer);
             if (content == null) {
                 return nodes;
             }
 
-            if (content.containsKey("links")) {
-                Collection<String> links = (Collection<String>) content.get("links");
-                for (String link : links) {
-                    String[] parsed = link.split(":");
-                    String name = parsed[0];
+            if (content.getLinks() != null) {
+                Collection<Link> links = content.getLinks();
+                for (Link link : links) {
+                    String name = link.getName();
 
-                    if (containerDefinition.containsKey(name)) {
+                    if (containerDefinition.get(name) != null) {
                         AutoStartOrderUtil.Node child = AutoStartOrderUtil.Node.from(name);
                         nodes.put(name, child);
                     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CommaSeparatedAutoStartParser.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CommaSeparatedAutoStartParser.java
@@ -3,15 +3,16 @@ package org.arquillian.cube.docker.impl.client;
 import java.util.HashMap;
 import java.util.Map;
 
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
 import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
 import org.arquillian.cube.docker.impl.util.ConfigUtil;
 
 public class CommaSeparatedAutoStartParser implements AutoStartParser {
 
     private String expression;
-    private Map<String, Object> containerDefinitions;
+    private CubeContainers containerDefinitions;
 
-    public CommaSeparatedAutoStartParser(String expression, Map<String, Object> containerDefinitions) {
+    public CommaSeparatedAutoStartParser(String expression, CubeContainers containerDefinitions) {
         this.expression = expression;
         this.containerDefinitions = containerDefinitions;
     }
@@ -22,7 +23,7 @@ public class CommaSeparatedAutoStartParser implements AutoStartParser {
 
         String[] autoStartContainers = ConfigUtil.trim(expression.split(","));
         for (String autoStart : autoStartContainers) {
-            if (containerDefinitions.containsKey(autoStart)) {
+            if (containerDefinitions.get(autoStart) != null) {
                 nodes.put(autoStart, AutoStartOrderUtil.Node.from(autoStart));
             }
         }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/Converter.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/Converter.java
@@ -1,7 +1,7 @@
 package org.arquillian.cube.docker.impl.client;
 
-import java.util.Map;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
 
 public interface Converter {
-    Map<String, Object> convert();
+    CubeContainers convert();
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerAutoStartConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerAutoStartConfigurator.java
@@ -1,14 +1,14 @@
 package org.arquillian.cube.docker.impl.client;
 
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.jboss.arquillian.core.api.annotation.Observes;
-
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map;
 
 public class CubeDockerAutoStartConfigurator {
 
@@ -22,10 +22,10 @@ public class CubeDockerAutoStartConfigurator {
     }
 
 
-    private AutoStartParser resolveNotSetAutoStart(ContainerRegistry containerRegistry, Map<String, Object> containerDefinition) {
+    private AutoStartParser resolveNotSetAutoStart(ContainerRegistry containerRegistry, CubeContainers containers) {
         //we want to use the automatic autoconfiguration
         List<String> containersName = toContainersName(containerRegistry.getContainers());
-        return new AutomaticResolutionAutoStartParser(containersName, containerDefinition);
+        return new AutomaticResolutionAutoStartParser(containersName, containers);
     }
 
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
@@ -8,7 +8,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.arquillian.cube.docker.impl.util.IOUtil;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.util.ConfigUtil;
 
 public class CubeDockerConfiguration {
 
@@ -46,7 +47,7 @@ public class CubeDockerConfiguration {
     private boolean dockerInsideDockerResolution = true;
     private AutoStartParser autoStartContainers = null;
 
-    private Map<String, Object> dockerContainersContent;
+    private CubeContainers dockerContainersContent;
 
     public String getDockerServerUri() {
         return dockerServerUri;
@@ -56,7 +57,7 @@ public class CubeDockerConfiguration {
         return dockerServerVersion;
     }
 
-    public Map<String, Object> getDockerContainersContent() {
+    public CubeContainers getDockerContainersContent() {
         return dockerContainersContent;
     }
 
@@ -116,7 +117,6 @@ public class CubeDockerConfiguration {
         return dockerInsideDockerResolution;
     }
 
-    @SuppressWarnings("unchecked")
     public static CubeDockerConfiguration fromMap(Map<String, String> map) {
         CubeDockerConfiguration cubeConfiguration = new CubeDockerConfiguration();
 
@@ -219,7 +219,7 @@ public class CubeDockerConfiguration {
 
         if (map.containsKey(AUTO_START_CONTAINERS)) {
             String expression = map.get(AUTO_START_CONTAINERS);
-            Map<String, Object> containerDefinitions = cubeConfiguration.getDockerContainersContent();
+            CubeContainers containerDefinitions = cubeConfiguration.getDockerContainersContent();
             AutoStartParser autoStartParser = AutoStartParserFactory.create(expression, containerDefinitions);
 
             cubeConfiguration.autoStartContainers = autoStartParser;
@@ -301,7 +301,7 @@ public class CubeDockerConfiguration {
             content.append("  ").append(AUTO_START_CONTAINERS).append(" = ").append(autoStartContainers).append(SEP);
         }
         if (dockerContainersContent != null) {
-            String output = IOUtil.asString(dockerContainersContent);
+            String output = ConfigUtil.dump(dockerContainersContent);
             content.append("  ").append(DOCKER_CONTAINERS).append(" = ").append(output).append(SEP);
         }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
@@ -12,7 +12,8 @@ public class CubeDockerExtension implements LoadableExtension {
 
     @Override
     public void register(ExtensionBuilder builder) {
-        builder.observer(CubeDockerConfigurator.class)
+        builder.observer(TopCreator.class)
+               .observer(CubeDockerConfigurator.class)
                .observer(DockerClientCreator.class)
                .observer(CubeDockerRegistrar.class)
                .observer(CubeSuiteLifecycleController.class)

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerRegistrar.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerRegistrar.java
@@ -2,6 +2,8 @@ package org.arquillian.cube.docker.impl.client;
 
 import java.util.Map;
 
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.model.DockerCube;
 import org.arquillian.cube.spi.CubeRegistry;
@@ -10,18 +12,17 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 
 public class CubeDockerRegistrar {
 
-    @SuppressWarnings("unchecked")
     public void register(@Observes DockerClientExecutor executor, CubeDockerConfiguration configuration, Injector injector, CubeRegistry registry) {
 
         //TODO, add key here generation here
-        Map<String, Object> containerConfigurations = configuration.getDockerContainersContent();
-        for(Map.Entry<String, Object> containerConfiguration : containerConfigurations.entrySet()) {
+        CubeContainers containerConfigurations = configuration.getDockerContainersContent();
+        for(Map.Entry<String, CubeContainer> containerConfiguration : containerConfigurations.getContainers().entrySet()) {
 
             registry.addCube(
                     injector.inject(
                         new DockerCube(
                                 containerConfiguration.getKey(),
-                                (Map<String, Object>)containerConfiguration.getValue(),
+                                containerConfiguration.getValue(),
                                 executor)));
         }
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/DockerContainerDefinitionParser.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/DockerContainerDefinitionParser.java
@@ -1,10 +1,6 @@
 package org.arquillian.cube.docker.impl.client;
 
 
-import org.arquillian.cube.docker.impl.docker.cube.CubeConverter;
-import org.arquillian.cube.docker.impl.docker.compose.DockerComposeConverter;
-import org.arquillian.cube.docker.impl.util.IOUtil;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URI;
@@ -13,9 +9,12 @@ import java.net.URL;
 import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.Map;
 import java.util.logging.Logger;
+
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.docker.compose.DockerComposeConverter;
+import org.arquillian.cube.docker.impl.docker.cube.CubeConverter;
+import org.arquillian.cube.docker.impl.util.IOUtil;
 
 public class DockerContainerDefinitionParser {
 
@@ -28,7 +27,7 @@ public class DockerContainerDefinitionParser {
         super();
     }
 
-    public static Map<String, Object> convert(Path definitionFilePath, DefinitionFormat definitionFormat) throws IOException {
+    public static CubeContainers convert(Path definitionFilePath, DefinitionFormat definitionFormat) throws IOException {
         switch (definitionFormat) {
             case COMPOSE: {
                 DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(definitionFilePath);
@@ -45,17 +44,17 @@ public class DockerContainerDefinitionParser {
         }
     }
 
-    public static Map<String, Object> convert(DefinitionFormat definitionFormat, URI... uris) throws IOException {
-        Map<String, Object> finalDefinition = new HashMap<>();
+    public static CubeContainers convert(DefinitionFormat definitionFormat, URI... uris) throws IOException {
+        CubeContainers finalDefinition = new CubeContainers();
         for (URI uri : uris) {
-            Map<String, Object> convertedDocument = convert(uri, definitionFormat);
-            merge(finalDefinition, convertedDocument);
+            CubeContainers convertedDocument = convert(uri, definitionFormat);
+            finalDefinition.merge(convertedDocument);
         }
 
         return finalDefinition;
     }
 
-    private static Map<String, Object> convert(URI uri, DefinitionFormat definitionFormat) throws IOException {
+    private static CubeContainers convert(URI uri, DefinitionFormat definitionFormat) throws IOException {
         try {
             Path definitionFilePath = Paths.get(uri);
             return convert(definitionFilePath, definitionFormat);
@@ -80,12 +79,7 @@ public class DockerContainerDefinitionParser {
         }
     }
 
-
-    private static void merge(Map<String, Object> finalDefinition, Map<String, Object> convertedDocument) {
-        IOUtil.deepMerge(finalDefinition, convertedDocument);
-    }
-
-    public static Map<String, Object> convert(String content, DefinitionFormat definitionFormat) {
+    public static CubeContainers convert(String content, DefinitionFormat definitionFormat) {
         switch (definitionFormat) {
             case COMPOSE: {
                 DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(content);
@@ -102,7 +96,7 @@ public class DockerContainerDefinitionParser {
         }
     }
 
-    public static Map<String, Object> convertDefault(DefinitionFormat definitionFormat) throws IOException {
+    public static CubeContainers convertDefault(DefinitionFormat definitionFormat) throws IOException {
         URI defaultUri = null;
         try {
             switch (definitionFormat) {
@@ -132,7 +126,7 @@ public class DockerContainerDefinitionParser {
         }
         if (defaultUri == null) {
             logger.fine("No Docker container definitions has been found. Probably you have defined some Containers using Container Object pattern and @Cube annotation");
-            return new HashMap<>();
+            return new CubeContainers();
         }
         return convert(Paths.get(defaultUri), definitionFormat);
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/RegularExpressionAutoStartParser.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/RegularExpressionAutoStartParser.java
@@ -1,21 +1,22 @@
 package org.arquillian.cube.docker.impl.client;
 
-import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
-
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
+
 public class RegularExpressionAutoStartParser implements AutoStartParser {
 
     public static final String REGULAR_EXPRESSION_PREFIX = "regexp:";
 
     private String expression;
-    private Map<String, Object> containerDefinitions;
+    private CubeContainers containerDefinitions;
 
-    public RegularExpressionAutoStartParser(String expression, Map<String, Object> containerDefinitions) {
+    public RegularExpressionAutoStartParser(String expression, CubeContainers containerDefinitions) {
         if(!expression.startsWith(REGULAR_EXPRESSION_PREFIX)) {
             throw new IllegalArgumentException("Regular Expression AutoStartParser should begin with "+REGULAR_EXPRESSION_PREFIX);
         }
@@ -29,7 +30,7 @@ public class RegularExpressionAutoStartParser implements AutoStartParser {
 
         String regularExpression = getRegularExpression(expression);
         Pattern pattern = Pattern.compile(regularExpression);
-        Set<String> definedContainers = containerDefinitions.keySet();
+        Set<String> definedContainers = containerDefinitions.getContainerIds();
         for(String containerName : definedContainers) {
             Matcher matcher = pattern.matcher(containerName);
             if(matcher.matches()) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
@@ -1,0 +1,79 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+import java.util.List;
+
+public class Await {
+
+    private String strategy;
+
+    // static
+    private String ip;
+    private List<Integer> ports;
+
+    // polling
+    private Object sleepPollingTime; // Integer or String expression
+    private Integer iterations;
+    private String type;
+
+    // sleeping
+    private Object sleepTime;
+
+    public Await() {
+    }
+
+    public String getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(String strategy) {
+        this.strategy = strategy;
+    }
+
+    public String getIp() {
+        return ip;
+    }
+
+    public void setIp(String ip) {
+        this.ip = ip;
+    }
+
+    public List<Integer> getPorts() {
+        return ports;
+    }
+
+    public void setPorts(List<Integer> ports) {
+        this.ports = ports;
+    }
+
+    public Object getSleepPollingTime() {
+        return sleepPollingTime;
+    }
+
+    public void setSleepPollingTime(Object sleepPollingTime) {
+        this.sleepPollingTime = sleepPollingTime;
+    }
+
+    public Integer getIterations() {
+        return iterations;
+    }
+
+    public void setIterations(Integer iterations) {
+        this.iterations = iterations;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public Object getSleepTime() {
+        return sleepTime;
+    }
+
+    public void setSleepTime(Object sleepTime) {
+        this.sleepTime = sleepTime;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/BeforeStop.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/BeforeStop.java
@@ -1,0 +1,26 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class BeforeStop {
+
+    private Copy copy;
+    private Log log;
+
+    public BeforeStop() {
+    }
+
+    public Copy getCopy() {
+        return copy;
+    }
+
+    public void setCopy(Copy copy) {
+        this.copy = copy;
+    }
+
+    public Log getLog() {
+        return log;
+    }
+
+    public void setLog(Log log) {
+        this.log = log;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/BuildImage.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/BuildImage.java
@@ -1,0 +1,49 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class BuildImage {
+    private String dockerfileLocation;
+    private String dockerfileName; // both??
+    private boolean noCache = false;
+    private boolean remove = false;
+
+    protected BuildImage() {}
+
+    public BuildImage(String dockerfileLocation, String dockerfileName, boolean noCache, boolean remove) {
+        this.dockerfileLocation = dockerfileLocation;
+        this.dockerfileName = dockerfileName;
+        this.noCache = noCache;
+        this.remove = remove;
+    }
+
+    public String getDockerfileLocation() {
+        return dockerfileLocation;
+    }
+
+    public void setDockerfileLocation(String dockerFileLocation) {
+        this.dockerfileLocation = dockerFileLocation;
+    }
+
+    public String getDockerfileName() {
+        return dockerfileName;
+    }
+
+    public void setDockerfileName(String dockerFileName) {
+        this.dockerfileName = dockerFileName;
+    }
+
+    public boolean isNoCache() {
+        return noCache;
+    }
+
+    public void setNoCache(boolean noCache) {
+        this.noCache = noCache;
+    }
+
+    public boolean isRemove() {
+        return remove;
+    }
+
+    public void setRemove(boolean remove) {
+        this.remove = remove;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Copy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Copy.java
@@ -1,0 +1,26 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class Copy {
+
+    private String from;
+    private String to;
+
+    public Copy() {
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
@@ -1,0 +1,410 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+import java.lang.reflect.Field;
+import java.util.Collection;
+import java.util.Map;
+
+public class CubeContainer {
+
+    private String workingDir;
+    private Boolean disableNetwork;
+    private String hostName;
+    private Collection<String> portSpecs;
+    private String user;
+    private Boolean tty;
+    private Boolean stdinOpen;
+    private Boolean stdinOnce;
+    private Integer memoryLimit;
+    private Integer memorySwap;
+    private Integer cpuShares;
+    private String cpuSet;
+    private Boolean attachStdin;
+    private Boolean attachSterr;
+    private Collection<String> env;
+    private Collection<String> cmd;
+    private Collection<String> dns;
+    private Collection<String> volumes;
+    private Collection<String> volumesFrom;
+    private Collection<String> binds;
+    private Collection<Link> links;
+    private Collection<PortBinding> portBindings;
+    private Collection<ExposedPort> exposedPorts;
+    private Boolean privileged;
+    private Boolean publishAllPorts;
+    private String networkMode;
+    private Collection<String> dnsSearch;
+    private Collection<Device> devices;
+    private RestartPolicy restartPolicy;
+    private Collection<String> capAdd;
+    private Collection<String> capDrop;
+    private Collection<String> extraHosts;
+    private Collection<String> entryPoint;
+    private String domainName;
+    private Boolean alwaysPull = false;
+    private Await await;
+
+    private Image image;
+    private String extendsImage;
+
+    private boolean ReadonlyRootfs;
+    private Map<String, String> labels;
+
+    private BuildImage buildImage;
+
+    private Collection<BeforeStop> beforeStop;
+
+    public Image getImage() {
+        return image;
+    }
+
+    public void setImage(Image image) {
+        this.image = image;
+    }
+
+    public BuildImage getBuildImage() {
+        return buildImage;
+    }
+
+    public void setBuildImage(BuildImage buildImage) {
+        this.buildImage = buildImage;
+    }
+
+    public Collection<PortBinding> getPortBindings() {
+        return portBindings;
+    }
+
+    public void setPortBindings(Collection<PortBinding> portBindings) {
+        this.portBindings = portBindings;
+    }
+
+    public Collection<ExposedPort> getExposedPorts() {
+        return exposedPorts;
+    }
+
+    public void setExposedPorts(Collection<ExposedPort> exposedPorts) {
+        this.exposedPorts = exposedPorts;
+    }
+
+    public Boolean getReadonlyRootfs() {
+        return ReadonlyRootfs;
+    }
+
+    public void setReadonlyRootfs(Boolean readonlyRootfs) {
+        this.ReadonlyRootfs = readonlyRootfs;
+    }
+
+    public Map<String, String> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(Map<String, String> labels) {
+        this.labels = labels;
+    }
+
+    public String getWorkingDir() {
+        return workingDir;
+    }
+
+    public void setWorkingDir(String workingDir) {
+        this.workingDir = workingDir;
+    }
+
+    public Boolean getDisableNetwork() {
+        return disableNetwork;
+    }
+
+    public void setDisableNetwork(Boolean disableNetwork) {
+        this.disableNetwork = disableNetwork;
+    }
+
+    public String getHostName() {
+        return hostName;
+    }
+
+    public void setHostName(String hostName) {
+        this.hostName = hostName;
+    }
+
+    public Collection<String> getPortSpecs() {
+        return portSpecs;
+    }
+
+    public void setPortSpecs(Collection<String> portSpecs) {
+        this.portSpecs = portSpecs;
+    }
+
+    public String getUser() {
+        return user;
+    }
+
+    public void setUser(String user) {
+        this.user = user;
+    }
+
+    public Boolean getTty() {
+        return tty;
+    }
+
+    public void setTty(Boolean tty) {
+        this.tty = tty;
+    }
+
+    public Boolean getStdinOpen() {
+        return stdinOpen;
+    }
+
+    public void setStdinOpen(Boolean stdinOpen) {
+        this.stdinOpen = stdinOpen;
+    }
+
+    public Boolean getStdinOnce() {
+        return stdinOnce;
+    }
+
+    public void setStdinOnce(Boolean stdinOnce) {
+        this.stdinOnce = stdinOnce;
+    }
+
+    public Integer getMemoryLimit() {
+        return memoryLimit;
+    }
+
+    public void setMemoryLimit(Integer memoryLimit) {
+        this.memoryLimit = memoryLimit;
+    }
+
+    public Integer getMemorySwap() {
+        return memorySwap;
+    }
+
+    public void setMemorySwap(Integer memorySwap) {
+        this.memorySwap = memorySwap;
+    }
+
+    public Integer getCpuShares() {
+        return cpuShares;
+    }
+
+    public void setCpuShares(Integer cpuShares) {
+        this.cpuShares = cpuShares;
+    }
+
+    public String getCpuSet() {
+        return cpuSet;
+    }
+
+    public void setCpuSet(String cpuSet) {
+        this.cpuSet = cpuSet;
+    }
+
+    public Boolean getAttachStdin() {
+        return attachStdin;
+    }
+
+    public void setAttachStdin(Boolean attachStdin) {
+        this.attachStdin = attachStdin;
+    }
+
+    public Boolean getAttachSterr() {
+        return attachSterr;
+    }
+
+    public void setAttachSterr(Boolean attachSterr) {
+        this.attachSterr = attachSterr;
+    }
+
+    public Collection<String> getEnv() {
+        return env;
+    }
+
+    public void setEnv(Collection<String> env) {
+        this.env = env;
+    }
+
+    public Collection<String> getCmd() {
+        return cmd;
+    }
+
+    public void setCmd(Collection<String> cmd) {
+        this.cmd = cmd;
+    }
+
+    public Collection<String> getDns() {
+        return dns;
+    }
+
+    public void setDns(Collection<String> dns) {
+        this.dns = dns;
+    }
+
+    public Collection<String> getVolumes() {
+        return volumes;
+    }
+
+    public void setVolumes(Collection<String> volumes) {
+        this.volumes = volumes;
+    }
+
+    public Collection<String> getVolumesFrom() {
+        return volumesFrom;
+    }
+
+    public void setVolumesFrom(Collection<String> volumesFrom) {
+        this.volumesFrom = volumesFrom;
+    }
+
+    public Collection<String> getBinds() {
+        return binds;
+    }
+
+    public void setBinds(Collection<String> binds) {
+        this.binds = binds;
+    }
+
+    public Collection<Link> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Collection<Link> links) {
+        this.links = links;
+    }
+
+    public Boolean getPrivileged() {
+        return privileged;
+    }
+
+    public void setPrivileged(Boolean privileged) {
+        this.privileged = privileged;
+    }
+
+    public Boolean getPublishAllPorts() {
+        return publishAllPorts;
+    }
+
+    public void setPublishAllPorts(Boolean publishAllPorts) {
+        this.publishAllPorts = publishAllPorts;
+    }
+
+    public String getNetworkMode() {
+        return networkMode;
+    }
+
+    public void setNetworkMode(String networkMode) {
+        this.networkMode = networkMode;
+    }
+
+    public Collection<String> getDnsSearch() {
+        return dnsSearch;
+    }
+
+    public void setDnsSearch(Collection<String> dnsSearch) {
+        this.dnsSearch = dnsSearch;
+    }
+
+    public Collection<Device> getDevices() {
+        return devices;
+    }
+
+    public void setDevices(Collection<Device> devices) {
+        this.devices = devices;
+    }
+
+    public Collection<String> getCapAdd() {
+        return capAdd;
+    }
+
+    public void setCapAdd(Collection<String> capAdd) {
+        this.capAdd = capAdd;
+    }
+
+    public Collection<String> getCapDrop() {
+        return capDrop;
+    }
+
+    public void setCapDrop(Collection<String> capDrop) {
+        this.capDrop = capDrop;
+    }
+
+    public Collection<String> getExtraHosts() {
+        return extraHosts;
+    }
+
+    public void setExtraHosts(Collection<String> extraHosts) {
+        this.extraHosts = extraHosts;
+    }
+
+    public Collection<String> getEntryPoint() {
+        return entryPoint;
+    }
+
+    public void setEntryPoint(Collection<String> entryPoint) {
+        this.entryPoint = entryPoint;
+    }
+
+    public String getDomainName() {
+        return domainName;
+    }
+
+    public void setDomainName(String domainName) {
+        this.domainName = domainName;
+    }
+
+    public Boolean getAlwaysPull() {
+        return alwaysPull;
+    }
+
+    public void setAlwaysPull(Boolean alwaysPull) {
+        this.alwaysPull = alwaysPull;
+    }
+
+    public RestartPolicy getRestartPolicy() {
+        return restartPolicy;
+    }
+
+    public void setRestartPolicy(RestartPolicy restartPolicy) {
+        this.restartPolicy = restartPolicy;
+    }
+
+    public Await getAwait() {
+        return await;
+    }
+
+    public void setAwait(Await await) {
+        this.await = await;
+    }
+
+    public String getExtends() {
+        return extendsImage;
+    }
+
+    public void setExtends(String extendsImage) {
+        this.extendsImage = extendsImage;
+    }
+
+    public Collection<BeforeStop> getBeforeStop() {
+        return beforeStop;
+    }
+
+    public void setBeforeStop(Collection<BeforeStop> beforeStop) {
+        this.beforeStop = beforeStop;
+    }
+
+    public void merge(CubeContainer container) {
+        try {
+            Field[] fields = CubeContainer.class.getDeclaredFields();
+            for (Field field : fields) {
+                if (!field.isAccessible()) {
+                    field.setAccessible(true);
+                }
+
+                Object thisVal = field.get(this);
+                if (thisVal == null) {
+                    Object otherVal = field.get(container);
+                    field.set(this, otherVal);
+                }
+            }
+        } catch (Exception e) {
+            throw new RuntimeException("Could not merge objects", e);
+        }
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainers.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainers.java
@@ -1,0 +1,50 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class CubeContainers {
+
+    private Map<String, CubeContainer> containers;
+
+    public CubeContainers() {
+        this.containers = new LinkedHashMap<String, CubeContainer>();
+    }
+
+    public Map<String, CubeContainer> getContainers() {
+        return containers;
+    }
+
+    public Set<String> getContainerIds() {
+        return containers.keySet();
+    }
+
+    public void setContainers(Map<String, CubeContainer> containers) {
+        this.containers = containers;
+    }
+
+    public CubeContainer get(String id) {
+        return containers.get(id);
+    }
+
+    public void add(String id, CubeContainer container) {
+        this.containers.put(id, container);
+    }
+
+    public void merge(CubeContainers otherContainers) {
+        for (Map.Entry<String, CubeContainer> thisContainer : containers.entrySet()) {
+            if (otherContainers.get(thisContainer.getKey()) != null) {
+                thisContainer.getValue().merge(otherContainers.get(thisContainer.getKey()));
+            }
+        }
+        Map<String, CubeContainer> addAll = new HashMap<String, CubeContainer>();
+        for (Map.Entry<String, CubeContainer> otherContainer : otherContainers.getContainers().entrySet()) {
+            if (get(otherContainer.getKey()) == null) {
+                addAll.put(otherContainer.getKey(), otherContainer.getValue());
+            }
+        }
+        containers.putAll(addAll);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Device.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Device.java
@@ -1,0 +1,40 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class Device {
+    private String pathOnHost;
+    private String pathInContainer;
+    private String cGroupPermissions;
+
+    public Device() { }
+
+    public Device(String pathOnHost, String pathInContainer, String cGroupPermissions) {
+        super();
+        this.pathOnHost = pathOnHost;
+        this.pathInContainer = pathInContainer;
+        this.cGroupPermissions = cGroupPermissions;
+    }
+
+    public String getPathOnHost() {
+        return pathOnHost;
+    }
+
+    public void setPathOnHost(String pathOnHost) {
+        this.pathOnHost = pathOnHost;
+    }
+
+    public String getPathInContainer() {
+        return pathInContainer;
+    }
+
+    public void setPathInContainer(String pathInContainer) {
+        this.pathInContainer = pathInContainer;
+    }
+
+    public String getcGroupPermissions() {
+        return cGroupPermissions;
+    }
+
+    public void setcGroupPermissions(String cGroupPermissions) {
+        this.cGroupPermissions = cGroupPermissions;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/ExposedPort.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/ExposedPort.java
@@ -1,0 +1,73 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class ExposedPort {
+    private int exposed;
+    private String type = "tcp";
+
+    public ExposedPort(int exposed, String type) {
+        this.exposed = exposed;
+        if(type != null) {
+            this.type = type;
+        }
+    }
+
+    public int getExposed() {
+        return exposed;
+    }
+
+    public void setExposed(int exposed) {
+        this.exposed = exposed;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    @Override
+    public String toString() {
+        return exposed + "/" + type;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + exposed;
+        result = prime * result + ((type == null) ? 0 : type.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        ExposedPort other = (ExposedPort) obj;
+        if (exposed != other.exposed)
+            return false;
+        if (type == null) {
+            if (other.type != null)
+                return false;
+        } else if (!type.equals(other.type))
+            return false;
+        return true;
+    }
+
+    public static ExposedPort valueOf(String exp) {
+        int exposed;
+        String type = null;
+        String[] parts = exp.split("/");
+        exposed = Integer.parseInt(parts[0]);
+        if (parts.length > 1) {
+            type = parts[1];
+        }
+        return new ExposedPort(exposed, type);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Image.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Image.java
@@ -1,0 +1,71 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class Image {
+    private String name;
+    private String tag;
+
+    public Image(String name, String tag) {
+        this.name = name;
+        this.tag = tag;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public String toImageRef() {
+        return toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        result = prime * result + ((tag == null) ? 0 : tag.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Image other = (Image) obj;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        if (tag == null) {
+            if (other.tag != null)
+                return false;
+        } else if (!tag.equals(other.tag))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        return name + (tag != null ? ":" + tag : "");
+    }
+
+    public static Image valueOf(String image) {
+        String name = null;
+        String tag = null;
+
+        String[] parts = image.split(":");
+        name = parts[0];
+        if (parts.length > 1) {
+            tag = parts[1];
+        }
+        return new Image(name, tag);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Link.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Link.java
@@ -1,0 +1,97 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+public class Link {
+
+    private String name;
+    private String alias;
+
+    public Link(String name, String alias) {
+        this.name = name;
+        this.alias = alias;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getAlias() {
+        if (alias == null) {
+            return name;
+        }
+        return alias;
+    }
+
+    public void setAlias(String alias) {
+        this.alias = alias;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+        sb.append(name);
+        if (alias != null) {
+            sb.append(":").append(alias);
+        }
+        return sb.toString();
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + ((alias == null) ? 0 : alias.hashCode());
+        result = prime * result + ((name == null) ? 0 : name.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        Link other = (Link) obj;
+        if (alias == null) {
+            if (other.alias != null)
+                return false;
+        } else if (!alias.equals(other.alias))
+            return false;
+        if (name == null) {
+            if (other.name != null)
+                return false;
+        } else if (!name.equals(other.name))
+            return false;
+        return true;
+    }
+
+    public static Link valueOf(String links) {
+        String[] link = links.split(":");
+        String name = link[0];
+        String alias = null;
+        if (link.length == 2) {
+            alias = link[1];
+        }
+        return new Link(name, alias);
+    }
+
+    public static Collection<Link> valuesOf(Collection<String> links) {
+        if (links == null) {
+            return null;
+        }
+        List<Link> result = new ArrayList<Link>();
+        for (String link : links) {
+            result.add(valueOf(link));
+        }
+        return result;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Log.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Log.java
@@ -1,0 +1,62 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class Log {
+
+    private String to;
+    private Boolean follow;
+    private Boolean stdout;
+    private Boolean stderr;
+    private Boolean timestamps;
+    private Integer tail;
+
+    public Log() {
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public Boolean getFollow() {
+        return follow;
+    }
+
+    public void setFollow(Boolean follow) {
+        this.follow = follow;
+    }
+
+    public Boolean getStdout() {
+        return stdout;
+    }
+
+    public void setStdout(Boolean stdout) {
+        this.stdout = stdout;
+    }
+
+    public Boolean getStderr() {
+        return stderr;
+    }
+
+    public void setStderr(Boolean stderr) {
+        this.stderr = stderr;
+    }
+
+    public Boolean getTimestamps() {
+        return timestamps;
+    }
+
+    public void setTimestamps(Boolean timestamps) {
+        this.timestamps = timestamps;
+    }
+
+    public Integer getTail() {
+        return tail;
+    }
+
+    public void setTail(Integer tail) {
+        this.tail = tail;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/PortBinding.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/PortBinding.java
@@ -1,0 +1,121 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class PortBinding {
+    private String host;
+    private int bound;
+    private ExposedPort exposed;
+
+    public PortBinding(String host, int bound, ExposedPort exposed) {
+        super();
+        this.host = host;
+        this.bound = bound;
+        this.exposed = exposed;
+    }
+
+    public String getHost() {
+        return host;
+    }
+
+    public void setHost(String host) {
+        this.host = host;
+    }
+
+    public int getBound() {
+        return bound;
+    }
+
+    public void setBound(int bound) {
+        this.bound = bound;
+    }
+
+    public ExposedPort getExposedPort() {
+        return exposed;
+    }
+
+    public void setExposedPort(ExposedPort exposed) {
+        this.exposed = exposed;
+    }
+
+    @Override
+    public int hashCode() {
+        final int prime = 31;
+        int result = 1;
+        result = prime * result + bound;
+        result = prime * result + ((exposed == null) ? 0 : exposed.hashCode());
+        result = prime * result + ((host == null) ? 0 : host.hashCode());
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj)
+            return true;
+        if (obj == null)
+            return false;
+        if (getClass() != obj.getClass())
+            return false;
+        PortBinding other = (PortBinding) obj;
+        if (bound != other.bound)
+            return false;
+        if (exposed == null) {
+            if (other.exposed != null)
+                return false;
+        } else if (!exposed.equals(other.exposed))
+            return false;
+        if (host == null) {
+            if (other.host != null)
+                return false;
+        } else if (!host.equals(other.host))
+            return false;
+        return true;
+    }
+
+    @Override
+    public String toString() {
+        StringBuilder sb = new StringBuilder();
+
+        if(host != null) {
+            sb.append(host).append(":");
+        }
+        if(exposed.getExposed() != bound) {
+            sb.append(bound).append("->");
+        }
+        sb.append(exposed.getExposed()).append("/").append(exposed.getType());
+
+        return sb.toString();
+    }
+
+    public static PortBinding valueOf(String portBinding) {
+        ExposedPort exposed;
+        int bound;
+        String host = null;
+
+        String[] elements = portBinding.split("->");
+        if (elements.length == 1) {
+            // exposed port is only set and same port will be used as port binding.
+            int positionOfProtocolSeparator = elements[0].indexOf("/");
+            String bindingPortValue = elements[0];
+            if(positionOfProtocolSeparator > -1) {
+                //means that the protocol part is also set.
+                bindingPortValue = elements[0].substring(0, positionOfProtocolSeparator);
+            }
+            exposed = ExposedPort.valueOf(elements[0]);
+            bound = exposed.getExposed();
+
+            if(bindingPortValue.indexOf(":") != -1) {
+                host = bindingPortValue.substring(0, bindingPortValue.lastIndexOf(":"));
+            }
+        } else if (elements.length == 2) {
+            exposed = ExposedPort.valueOf(elements[1]);
+            if(elements[0].indexOf(":") != -1) {
+                host = elements[0].substring(0, elements[0].lastIndexOf(":"));
+                bound = Integer.parseInt(elements[0].substring(elements[0].lastIndexOf(":")+1, elements[0].length()));
+            } else {
+                bound = Integer.parseInt(elements[0]);
+            }
+        } else {
+            throw new IllegalArgumentException("Could not create PortBinding from " + portBinding);
+        }
+        return new PortBinding(host, bound, exposed);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/RestartPolicy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/RestartPolicy.java
@@ -1,0 +1,31 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class RestartPolicy {
+
+    private String name;
+    private Integer maximumRetryCount;
+
+    public RestartPolicy() { }
+
+    public RestartPolicy(String name, Integer maximumRetryCount) {
+        super();
+        this.name = name;
+        this.maximumRetryCount = maximumRetryCount;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public Integer getMaximumRetryCount() {
+        return maximumRetryCount;
+    }
+
+    public void setMaximumRetryCount(Integer maximumRetryCount) {
+        this.maximumRetryCount = maximumRetryCount;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/AfterClassContainerObjectObserver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/AfterClassContainerObjectObserver.java
@@ -22,8 +22,8 @@ public class AfterClassContainerObjectObserver {
     public void stopContainerObjects(@Observes AfterClass afterClass) {
 
         final CubeController cubeController = cubeControllerInstance.get();
-        final List<Cube> byMetadata = cubeRegistryInstance.get().getByMetadata(IsContainerObject.class);
-        for (Cube cube : byMetadata) {
+        final List<Cube<?>> byMetadata = cubeRegistryInstance.get().getByMetadata(IsContainerObject.class);
+        for (Cube<?> cube : byMetadata) {
             // To support fork tests
             final Class<?> testJavaClass = afterClass.getTestClass().getJavaClass();
             if (testJavaClass.equals(cube.getMetadata(IsContainerObject.class).getTestClass())) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
@@ -6,18 +6,31 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
 import java.util.logging.Logger;
 
 import org.arquillian.cube.CubeController;
-import org.arquillian.cube.containerobject.*;
 import org.arquillian.cube.containerobject.Cube;
+import org.arquillian.cube.containerobject.CubeDockerFile;
+import org.arquillian.cube.containerobject.HostPort;
+import org.arquillian.cube.containerobject.Image;
+import org.arquillian.cube.containerobject.IsContainerObject;
+import org.arquillian.cube.containerobject.Link;
+import org.arquillian.cube.docker.impl.client.config.BuildImage;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.model.DockerCube;
 import org.arquillian.cube.docker.impl.util.ContainerObjectUtil;
 import org.arquillian.cube.docker.impl.util.DockerFileUtil;
 import org.arquillian.cube.impl.util.ReflectionUtil;
-import org.arquillian.cube.spi.*;
+import org.arquillian.cube.spi.Binding;
+import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -103,7 +116,7 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
                 cubeContainerClazzAnnotation = annotatedMethodWithCubeDockerFile.getAnnotation(CubeDockerFile.class);
                 final Object archive = annotatedMethodWithCubeDockerFile.invoke(null, new Object[0]);
                 if (archive instanceof Archive) {
-                    Archive<?> genericArchive = (Archive) archive;
+                    Archive<?> genericArchive = (Archive<?>) archive;
                     output = createTemporalDirectoryForCopyingDockerfile(cubeContainerClazz, cubeName);
                     logger.finer(String.format("Created %s directory for storing contents of %s cube.", output, cubeName));
                     genericArchive.as(ExplodedExporter.class).exportExplodedInto(output);
@@ -144,7 +157,7 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
 
             //Creates Cube and Registers into the Cube Registry
 
-            org.arquillian.cube.spi.Cube cube;
+            org.arquillian.cube.spi.Cube<?> cube;
             if (imageSet) {
                 cube = createCubeFromImage(cubeName, cubePortBinding, links, cubeContainerClazz.getAnnotation(Image.class), output, testCase.getClass());
             } else {
@@ -169,7 +182,7 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
         return null;
     }
 
-    private void enrichHostPort(Object containerObjectInstance, org.arquillian.cube.spi.Cube cube) throws IllegalAccessException {
+    private void enrichHostPort(Object containerObjectInstance, org.arquillian.cube.spi.Cube<?> cube) throws IllegalAccessException {
         final List<Field> fieldsWithHostPort = ReflectionUtil.getFieldsWithAnnotation(containerObjectInstance.getClass(), HostPort.class);
 
         for ( Field field : fieldsWithHostPort) {
@@ -242,48 +255,59 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
     }
 
 
-    private org.arquillian.cube.spi.Cube createCubeFromDockerfile(String cubeName, String[] portBinding, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, File dockerfileLocation, Class<?> testClass) {
-        final Map<String, Object> configuration = createConfigurationFromDockerfie(portBinding, links, cubeContainerClazzAnnotation, dockerfileLocation);
-        BaseCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
+    private org.arquillian.cube.spi.Cube<?> createCubeFromDockerfile(String cubeName, String[] portBinding, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, File dockerfileLocation, Class<?> testClass) {
+        CubeContainer configuration = createConfigurationFromDockerfie(portBinding, links, cubeContainerClazzAnnotation, dockerfileLocation);
+        DockerCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
         newCube.addMetadata(new IsContainerObject(testClass));
         injectorInstance.get().inject(newCube);
         return newCube;
     }
 
-    private org.arquillian.cube.spi.Cube createCubeFromImage(String cubeName, String[] portBinding, Set<String> links, Image image, File dockerfileLocation, Class<?> testClass) {
-        final Map<String, Object> configuration = createConfigurationFromImage(portBinding, links, image, dockerfileLocation);
-        BaseCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
+    private org.arquillian.cube.spi.Cube<?> createCubeFromImage(String cubeName, String[] portBinding, Set<String> links, Image image, File dockerfileLocation, Class<?> testClass) {
+        final CubeContainer configuration = createConfigurationFromImage(portBinding, links, image, dockerfileLocation);
+        DockerCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
         newCube.addMetadata(new IsContainerObject(testClass));
         injectorInstance.get().inject(newCube);
         return newCube;
     }
 
-    private Map<String, Object> createConfigurationFromDockerfie(String[] portBinding, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, File dockerfileLocation) {
-        Map<String, Object> configuration = new HashMap<>();
-        configuration.put(DockerClientExecutor.PORT_BINDINGS, Arrays.asList(portBinding));
+    private CubeContainer createConfigurationFromDockerfie(String[] portBinding, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, File dockerfileLocation) {
+        CubeContainer configuration = new CubeContainer();
+
+        List<PortBinding> bindings = new ArrayList<PortBinding>();
+        for(String binding : portBinding) {
+            bindings.add(PortBinding.valueOf(binding));
+        }
+        configuration.setPortBindings(bindings);
 
         if (links.size() > 0) {
-            configuration.put(DockerClientExecutor.LINKS, new HashSet<>(links));
+            configuration.setLinks(org.arquillian.cube.docker.impl.client.config.Link.valuesOf(links));
         }
 
-        Map<String, Object> dockerfileConfiguration = new HashMap<>();
-        dockerfileConfiguration.put(DockerClientExecutor.DOCKERFILE_LOCATION, dockerfileLocation.getAbsolutePath());
-        dockerfileConfiguration.put(DockerClientExecutor.REMOVE, cubeContainerClazzAnnotation.remove());
-        dockerfileConfiguration.put(DockerClientExecutor.NO_CACHE, cubeContainerClazzAnnotation.nocache());
+        BuildImage dockerfileConfiguration = new BuildImage(
+                dockerfileLocation.getAbsolutePath(),
+                null,
+                cubeContainerClazzAnnotation.nocache(),
+                cubeContainerClazzAnnotation.remove());
 
-        configuration.put(DockerClientExecutor.BUILD_IMAGE, dockerfileConfiguration);
+        configuration.setBuildImage(dockerfileConfiguration);
         return configuration;
     }
 
-    private Map<String, Object> createConfigurationFromImage(String[] portBinding, Set<String> links, Image image, File dockerfileLocation) {
-        Map<String, Object> configuration = new HashMap<>();
-        configuration.put(DockerClientExecutor.PORT_BINDINGS, Arrays.asList(portBinding));
+    private CubeContainer createConfigurationFromImage(String[] portBinding, Set<String> links, Image image, File dockerfileLocation) {
+        CubeContainer configuration = new CubeContainer();
+
+        List<PortBinding> bindings = new ArrayList<PortBinding>();
+        for(String binding : portBinding) {
+            bindings.add(PortBinding.valueOf(binding));
+        }
+        configuration.setPortBindings(bindings);
 
         if (links.size() > 0) {
-            configuration.put(DockerClientExecutor.LINKS, new HashSet<>(links));
+            configuration.setLinks(org.arquillian.cube.docker.impl.client.config.Link.valuesOf(links));
         }
 
-        configuration.put(DockerClientExecutor.IMAGE, image.value());
+        configuration.setImage(org.arquillian.cube.docker.impl.client.config.Image.valueOf(image.value()));
         return configuration;
     }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -12,26 +12,27 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
 import java.nio.ByteBuffer;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.logging.Logger;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.ws.rs.ProcessingException;
 
-import com.github.dockerjava.api.async.ResultCallback;
-import com.github.dockerjava.api.model.*;
-
-import com.github.dockerjava.core.async.ResultCallbackTemplate;
-import com.github.dockerjava.core.command.BuildImageResultCallback;
-import com.github.dockerjava.core.command.LogContainerResultCallback;
-import com.github.dockerjava.core.command.PullImageResultCallback;
 import org.apache.http.conn.UnsupportedSchemeException;
 import org.arquillian.cube.TopContainer;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
+import org.arquillian.cube.docker.impl.client.config.BuildImage;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.arquillian.cube.docker.impl.util.BindingUtil;
 import org.arquillian.cube.docker.impl.util.HomeResolverUtil;
-import org.arquillian.cube.docker.impl.util.IOUtil;
 
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.NotFoundException;
@@ -44,12 +45,27 @@ import com.github.dockerjava.api.command.PingCmd;
 import com.github.dockerjava.api.command.PullImageCmd;
 import com.github.dockerjava.api.command.StartContainerCmd;
 import com.github.dockerjava.api.command.TopContainerResponse;
+import com.github.dockerjava.api.model.Bind;
+import com.github.dockerjava.api.model.Capability;
+import com.github.dockerjava.api.model.ChangeLog;
+import com.github.dockerjava.api.model.Container;
+import com.github.dockerjava.api.model.Device;
+import com.github.dockerjava.api.model.ExposedPort;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.InternetProtocol;
+import com.github.dockerjava.api.model.Link;
+import com.github.dockerjava.api.model.Ports;
 import com.github.dockerjava.api.model.Ports.Binding;
+import com.github.dockerjava.api.model.RestartPolicy;
+import com.github.dockerjava.api.model.Volume;
+import com.github.dockerjava.api.model.VolumesFrom;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.github.dockerjava.core.DockerClientConfig;
 import com.github.dockerjava.core.DockerClientConfig.DockerClientConfigBuilder;
-
-import static org.arquillian.cube.docker.impl.util.YamlUtil.*;
+import com.github.dockerjava.core.async.ResultCallbackTemplate;
+import com.github.dockerjava.core.command.BuildImageResultCallback;
+import com.github.dockerjava.core.command.LogContainerResultCallback;
+import com.github.dockerjava.core.command.PullImageResultCallback;
 
 public class DockerClientExecutor {
 
@@ -146,7 +162,7 @@ public class DockerClientExecutor {
         return this.dockerClient.listContainersCmd().exec();
     }
 
-    public String createContainer(String name, Map<String, Object> containerConfiguration) {
+    public String createContainer(String name, CubeContainer containerConfiguration) {
 
         // we check if Docker server is up and correctly configured.
         this.pingDockerServer();
@@ -162,170 +178,148 @@ public class DockerClientExecutor {
             createContainerCmd.withExposedPorts(allExposedPorts.toArray(new ExposedPort[numberOfExposedPorts]));
         }
 
-        if(containerConfiguration.containsKey(READ_ONLY_ROOT_FS)) {
-            createContainerCmd.withReadonlyRootfs(asBoolean(containerConfiguration, READ_ONLY_ROOT_FS));
+        if(containerConfiguration.getReadonlyRootfs() != null) {
+            createContainerCmd.withReadonlyRootfs(containerConfiguration.getReadonlyRootfs());
         }
 
-        if(containerConfiguration.containsKey(LABELS)) {
-            Map<String, String> labels = asMapOfStrings(containerConfiguration, LABELS);
-            createContainerCmd.withLabels(labels);
+        if(containerConfiguration.getLabels() != null) {
+            createContainerCmd.withLabels(containerConfiguration.getLabels());
         }
 
-        if (containerConfiguration.containsKey(WORKING_DIR)) {
-            createContainerCmd.withWorkingDir(asString(containerConfiguration, WORKING_DIR));
+        if (containerConfiguration.getWorkingDir() != null) {
+            createContainerCmd.withWorkingDir(containerConfiguration.getWorkingDir());
         }
 
-        if (containerConfiguration.containsKey(DISABLE_NETWORK)) {
-            createContainerCmd.withNetworkDisabled(asBoolean(containerConfiguration, DISABLE_NETWORK));
+        if (containerConfiguration.getDisableNetwork() != null) {
+            createContainerCmd.withNetworkDisabled(containerConfiguration.getDisableNetwork());
         }
 
-        if (containerConfiguration.containsKey(HOST_NAME)) {
-            createContainerCmd.withHostName(asString(containerConfiguration, HOST_NAME));
+        if (containerConfiguration.getHostName() != null) {
+            createContainerCmd.withHostName(containerConfiguration.getHostName());
         }
 
-        if (containerConfiguration.containsKey(PORT_SPECS)) {
-            Collection<String> portSpecs = asListOfString(containerConfiguration, PORT_SPECS);
-            createContainerCmd.withPortSpecs(portSpecs.toArray(new String[portSpecs.size()]));
+        if (containerConfiguration.getPortSpecs() != null) {
+            createContainerCmd.withPortSpecs(containerConfiguration.getPortSpecs().toArray(new String[0]));
         }
 
-        if (containerConfiguration.containsKey(USER)) {
-            createContainerCmd.withUser(asString(containerConfiguration, USER));
+        if (containerConfiguration.getUser() != null) {
+            createContainerCmd.withUser(containerConfiguration.getUser());
         }
 
-        if (containerConfiguration.containsKey(TTY)) {
-            createContainerCmd.withTty(asBoolean(containerConfiguration, TTY));
+        if(containerConfiguration.getTty() != null) {
+            createContainerCmd.withTty(containerConfiguration.getTty());
+        }
+        if(containerConfiguration.getStdinOpen() != null) {
+            createContainerCmd.withStdinOpen(containerConfiguration.getStdinOpen());
         }
 
-        if (containerConfiguration.containsKey(STDIN_OPEN)) {
-            createContainerCmd.withStdinOpen(asBoolean(containerConfiguration, STDIN_OPEN));
+        if (containerConfiguration.getStdinOnce() != null) {
+            createContainerCmd.withStdInOnce(containerConfiguration.getStdinOnce());
         }
 
-        if (containerConfiguration.containsKey(STDIN_ONCE)) {
-            createContainerCmd.withStdInOnce(asBoolean(containerConfiguration, STDIN_ONCE));
+        if (containerConfiguration.getMemoryLimit() != null) {
+            createContainerCmd.withMemoryLimit(containerConfiguration.getMemoryLimit());
         }
 
-        if (containerConfiguration.containsKey(MEMORY_LIMIT)) {
-            createContainerCmd.withMemoryLimit(asInt(containerConfiguration, MEMORY_LIMIT));
+        if (containerConfiguration.getMemorySwap() != null) {
+            createContainerCmd.withMemorySwap(containerConfiguration.getMemorySwap());
         }
 
-        if (containerConfiguration.containsKey(MEMORY_SWAP)) {
-            createContainerCmd.withMemorySwap(asInt(containerConfiguration, MEMORY_SWAP));
+        if (containerConfiguration.getCpuShares() != null) {
+            createContainerCmd.withCpuShares(containerConfiguration.getCpuShares());
         }
 
-        if (containerConfiguration.containsKey(CPU_SHARES)) {
-            createContainerCmd.withCpuShares(asInt(containerConfiguration, CPU_SHARES));
+        if(containerConfiguration.getCpuSet() != null) {
+            createContainerCmd.withCpuset(containerConfiguration.getCpuSet());
         }
 
-        if(containerConfiguration.containsKey(CPU_SET)) {
-            createContainerCmd.withCpuset(asString(containerConfiguration, CPU_SET));
+        if (containerConfiguration.getAttachStdin() != null) {
+            createContainerCmd.withAttachStdin(containerConfiguration.getAttachStdin());
         }
 
-        if (containerConfiguration.containsKey(ATTACH_STDIN)) {
-            createContainerCmd.withAttachStdin(asBoolean(containerConfiguration, ATTACH_STDIN));
+        if (containerConfiguration.getAttachSterr() != null) {
+            createContainerCmd.withAttachStderr(containerConfiguration.getAttachSterr());
         }
 
-        if (containerConfiguration.containsKey(ATTACH_STDERR)) {
-            createContainerCmd.withAttachStderr(asBoolean(containerConfiguration, ATTACH_STDERR));
+        if (containerConfiguration.getEnv() != null) {
+            createContainerCmd.withEnv(resolveDockerServerIpInList(containerConfiguration.getEnv()).toArray(new String[0]));
         }
 
-        if (containerConfiguration.containsKey(ENV)) {
-            Collection<String> env = asListOfString(containerConfiguration, ENV);
-            env = resolveDockerServerIpInList(env);
-            createContainerCmd.withEnv(env.toArray(new String[env.size()]));
+        if (containerConfiguration.getCmd() != null) {
+            createContainerCmd.withCmd(containerConfiguration.getCmd().toArray(new String[0]));
         }
 
-        if (containerConfiguration.containsKey(CMD)) {
-            Collection<String> cmd = asListOfString(containerConfiguration, CMD);
-            createContainerCmd.withCmd(cmd.toArray(new String[cmd.size()]));
+        if (containerConfiguration.getDns() != null) {
+            createContainerCmd.withDns(containerConfiguration.getDns().toArray(new String[0]));
         }
 
-        if (containerConfiguration.containsKey(DNS)) {
-            Collection<String> dns = asListOfString(containerConfiguration, DNS);
-            createContainerCmd.withDns(dns.toArray(new String[dns.size()]));
+        if (containerConfiguration.getVolumes() != null) {
+            createContainerCmd.withVolumes(toVolumes(containerConfiguration.getVolumes()));
         }
 
-        if (containerConfiguration.containsKey(VOLUMES)) {
-            Collection<String> volumes = asListOfString(containerConfiguration, VOLUMES);
-            createContainerCmd.withVolumes(toVolumes(volumes));
+        if (containerConfiguration.getVolumesFrom() != null) {
+            createContainerCmd.withVolumesFrom(toVolumesFrom(containerConfiguration.getVolumesFrom()));
         }
 
-        if (containerConfiguration.containsKey(VOLUMES_FROM)) {
-            Collection<String> volumesFrom = asListOfString(containerConfiguration, VOLUMES_FROM);
-            createContainerCmd.withVolumesFrom(toVolumesFrom(volumesFrom));
+        if (containerConfiguration.getBinds() != null) {
+            createContainerCmd.withBinds(toBinds(containerConfiguration.getBinds()));
         }
 
-        if (containerConfiguration.containsKey(BINDS)) {
-            Collection<String> binds = asListOfString(containerConfiguration, BINDS);
-            createContainerCmd.withBinds(toBinds(binds));
+        if (containerConfiguration.getLinks() != null) {
+            createContainerCmd.withLinks(toLinks(containerConfiguration.getLinks()));
         }
 
-        if (containerConfiguration.containsKey(LINKS)) {
-            createContainerCmd.withLinks(toLinks(asListOfString(containerConfiguration, LINKS)));
+        if (containerConfiguration.getPortBindings() != null) {
+            createContainerCmd.withPortBindings(toPortBindings(containerConfiguration.getPortBindings()));
         }
 
-        if (containerConfiguration.containsKey(PORT_BINDINGS)) {
-            Collection<String> portBindings = asListOfString(containerConfiguration, PORT_BINDINGS);
-
-            Ports ports = assignPorts(portBindings);
-            createContainerCmd.withPortBindings(ports);
+        if (containerConfiguration.getPrivileged() != null) {
+            createContainerCmd.withPrivileged(containerConfiguration.getPrivileged());
         }
 
-        if (containerConfiguration.containsKey(PRIVILEGED)) {
-            createContainerCmd.withPrivileged(asBoolean(containerConfiguration, PRIVILEGED));
+        if (containerConfiguration.getPublishAllPorts() != null) {
+            createContainerCmd.withPublishAllPorts(containerConfiguration.getPublishAllPorts());
         }
 
-        if (containerConfiguration.containsKey(PUBLISH_ALL_PORTS)) {
-            createContainerCmd.withPublishAllPorts(asBoolean(containerConfiguration, PUBLISH_ALL_PORTS));
+        if (containerConfiguration.getNetworkMode() != null) {
+            createContainerCmd.withNetworkMode(containerConfiguration.getNetworkMode());
         }
 
-        if (containerConfiguration.containsKey(NETWORK_MODE)) {
-            createContainerCmd.withNetworkMode(asString(containerConfiguration, NETWORK_MODE));
+        if (containerConfiguration.getDnsSearch() != null) {
+            createContainerCmd.withDnsSearch(containerConfiguration.getDnsSearch().toArray(new String[0]));
         }
 
-        if (containerConfiguration.containsKey(DNS_SEARCH)) {
-            Collection<String> dnsSearch = asListOfString(containerConfiguration, DNS_SEARCH);
-            createContainerCmd.withDnsSearch(dnsSearch.toArray(new String[dnsSearch.size()]));
+        if (containerConfiguration.getDevices() != null) {
+            createContainerCmd.withDevices(toDevices(containerConfiguration.getDevices()));
         }
 
-        if (containerConfiguration.containsKey(DEVICES)) {
-
-            Collection<Map<String, Object>> devices = asListOfMap(containerConfiguration, DEVICES);
-            createContainerCmd.withDevices(toDevices(devices));
+        if (containerConfiguration.getRestartPolicy() != null) {
+            createContainerCmd.withRestartPolicy(toRestartPolicy(containerConfiguration.getRestartPolicy()));
         }
 
-        if (containerConfiguration.containsKey(RESTART_POLICY)) {
-            Map<String, Object> restart = asMap(containerConfiguration, RESTART_POLICY);
-            createContainerCmd.withRestartPolicy(toRestatPolicy(restart));
+        if (containerConfiguration.getCapAdd() != null) {
+            createContainerCmd.withCapAdd(toCapability(containerConfiguration.getCapAdd()));
         }
 
-        if (containerConfiguration.containsKey(CAP_ADD)) {
-            Collection<String> capAdds = asListOfString(containerConfiguration, CAP_ADD);
-            createContainerCmd.withCapAdd(toCapability(capAdds));
+        if (containerConfiguration.getCapDrop() != null) {
+            createContainerCmd.withCapDrop(toCapability(containerConfiguration.getCapDrop()));
         }
 
-        if (containerConfiguration.containsKey(CAP_DROP)) {
-            Collection<String> capDrop = asListOfString(containerConfiguration, CAP_DROP);
-            createContainerCmd.withCapDrop(toCapability(capDrop));
+        if(containerConfiguration.getExtraHosts() != null) {
+            createContainerCmd.withExtraHosts(containerConfiguration.getExtraHosts().toArray(new String[0]));
+        }
+        if(containerConfiguration.getEntryPoint() != null) {
+            createContainerCmd.withEntrypoint(containerConfiguration.getEntryPoint().toArray(new String[0]));
         }
 
-        if(containerConfiguration.containsKey(EXTRA_HOSTS)) {
-            Collection<String> extraHosts = asListOfString(containerConfiguration, EXTRA_HOSTS);
-            createContainerCmd.withExtraHosts(extraHosts.toArray(new String[extraHosts.size()]));
-        }
-        if(containerConfiguration.containsKey(ENTRYPOINT)) {
-            Collection<String> entrypoints = asListOfString(containerConfiguration, ENTRYPOINT);
-            createContainerCmd.withEntrypoint(entrypoints.toArray(new String[entrypoints.size()]));
-        }
-
-        if(containerConfiguration.containsKey(DOMAINNAME)) {
-            String domainName = asString(containerConfiguration, DOMAINNAME);
-            createContainerCmd.withDomainName(domainName);
+        if(containerConfiguration.getDomainName() != null) {
+            createContainerCmd.withDomainName(containerConfiguration.getDomainName());
         }
 
         boolean alwaysPull = false;
 
-        if (containerConfiguration.containsKey(ALWAYS_PULL)) {
-            alwaysPull = asBoolean(containerConfiguration, ALWAYS_PULL);
+        if (containerConfiguration.getAlwaysPull() != null) {
+            alwaysPull = containerConfiguration.getAlwaysPull();
         }
 
         if ( alwaysPull ) {
@@ -372,38 +366,41 @@ public class DockerClientExecutor {
         return resolvedEnv;
     }
 
-    private Set<ExposedPort> resolveExposedPorts(Map<String, Object> containerConfiguration,
+    private Set<ExposedPort> resolveExposedPorts(CubeContainer containerConfiguration,
             CreateContainerCmd createContainerCmd) {
         Set<ExposedPort> allExposedPorts = new HashSet<>();
-        if (containerConfiguration.containsKey(PORT_BINDINGS)) {
-            Collection<String> portBindings = asListOfString(containerConfiguration, PORT_BINDINGS);
-
-            Ports assignPorts = assignPorts(portBindings);
-            Map<ExposedPort, Binding[]> bindings = assignPorts.getBindings();
-            Set<ExposedPort> exposedPorts = bindings.keySet();
-            allExposedPorts.addAll(exposedPorts);
+        if (containerConfiguration.getPortBindings() != null) {
+            for(PortBinding binding : containerConfiguration.getPortBindings()) {
+                allExposedPorts.add(new ExposedPort(binding.getExposedPort().getExposed(), InternetProtocol.parse(binding.getExposedPort().getType())));
+            }
         }
-        if (containerConfiguration.containsKey(EXPOSED_PORTS)) {
-            Set<ExposedPort> exposedPorts = toExposedPorts(asListOfString(containerConfiguration, EXPOSED_PORTS));
-            allExposedPorts.addAll(exposedPorts);
+        if (containerConfiguration.getExposedPorts() != null) {
+            for(org.arquillian.cube.docker.impl.client.config.ExposedPort port : containerConfiguration.getExposedPorts()) {
+                allExposedPorts.add(new ExposedPort(port.getExposed(), InternetProtocol.parse(port.getType())));
+            }
         }
         return allExposedPorts;
     }
 
-    private String getImageName(Map<String, Object> containerConfiguration) {
+    private String getImageName(CubeContainer containerConfiguration) {
         String image;
 
-        if (containerConfiguration.containsKey(IMAGE)) {
-            image = asString(containerConfiguration, IMAGE);
+        if (containerConfiguration.getImage() != null) {
+            image = containerConfiguration.getImage().toImageRef();
         } else {
 
-            if (containerConfiguration.containsKey(BUILD_IMAGE)) {
+            if (containerConfiguration.getBuildImage() != null) {
 
-                Map<String, Object> params = asMap(containerConfiguration, BUILD_IMAGE);
+                BuildImage buildImage = containerConfiguration.getBuildImage();
 
-                if (params.containsKey(DOCKERFILE_LOCATION)) {
-                    String dockerfileLocation = asString(params, DOCKERFILE_LOCATION);
-                    image = this.buildImage(dockerfileLocation, params);
+                if (buildImage.getDockerfileLocation() != null) {
+                    Map<String, Object> params = new HashMap<String, Object>(); //(containerConfiguration, BUILD_IMAGE);
+                    params.put("noCache", buildImage.isNoCache());
+                    params.put("remove", buildImage.isRemove());
+                    params.put("dockerFileLocation", buildImage.getDockerfileLocation());
+                    params.put("dockerFileName", buildImage.getDockerfileName());
+
+                    image = this.buildImage(buildImage.getDockerfileLocation(), params);
                 } else {
                     throw new IllegalArgumentException(
                             "A tar file with Dockerfile on root or a directory with a Dockerfile should be provided.");
@@ -419,36 +416,20 @@ public class DockerClientExecutor {
         return image;
     }
 
-    public void startContainer(String id, Map<String, Object> containerConfiguration) {
+    public void startContainer(String id, CubeContainer containerConfiguration) {
         StartContainerCmd startContainerCmd = this.dockerClient.startContainerCmd(id);
 
         startContainerCmd.exec();
     }
 
-    private Ports assignPorts(Collection<String> portBindings) {
+    private Ports toPortBindings(Collection<PortBinding> portBindings) {
         Ports ports = new Ports();
-        for (String portBinding : portBindings) {
-            String[] elements = portBinding.split(PORTS_SEPARATOR);
-
-            if (elements.length == 1) {
-
-                log.info("Only exposed port is set and it will be used as port binding as well. " + elements[0]);
-
-                // exposed port is only set and same port will be used as port binding.
-                int positionOfProtocolSeparator = elements[0].indexOf("/");
-                String bindingPortValue = elements[0];
-                if(positionOfProtocolSeparator > -1) {
-                    //means that the protocol part is also set. 
-                    bindingPortValue = elements[0].substring(0, positionOfProtocolSeparator);
-                }
-                ports.bind(ExposedPort.parse(elements[0]), toBinding(bindingPortValue));
-            } else {
-                if (elements.length == 2) {
-                    // port and exposed port are set
-                    ports.bind(ExposedPort.parse(elements[1]), toBinding(elements[0]));
-                }
-            }
-
+        for (PortBinding portBinding : portBindings) {
+            ports.bind(
+                    new ExposedPort(
+                            portBinding.getExposedPort().getExposed(),
+                            InternetProtocol.parse(portBinding.getExposedPort().getType())),
+                    new Binding(portBinding.getHost(), portBinding.getBound()));
         }
         return ports;
     }
@@ -661,23 +642,23 @@ public class DockerClientExecutor {
         return dockerUri;
     }
 
-    private static final Device[] toDevices(Collection<Map<String, Object>> devicesMap) {
-        Device[] devices = new Device[devicesMap.size()];
+    private static final Device[] toDevices(Collection<org.arquillian.cube.docker.impl.client.config.Device> deviceList) {
+        Device[] devices = new Device[deviceList.size()];
 
         int i = 0;
-        for (Map<String, Object> device : devicesMap) {
-            if (device.containsKey(PATH_ON_HOST)
-                    && device.containsKey(PATH_IN_CONTAINER)) {
+        for (org.arquillian.cube.docker.impl.client.config.Device device : deviceList) {
+            if (device.getPathOnHost() != null
+                    && device.getPathInContainer() != null) {
 
                 String cGroupPermissions;
-                if (device.containsKey(C_GROUP_PERMISSIONS)) {
-                    cGroupPermissions = asString(device, C_GROUP_PERMISSIONS);
+                if (device.getcGroupPermissions() != null) {
+                    cGroupPermissions = device.getcGroupPermissions();
                 } else {
                     cGroupPermissions = DEFAULT_C_GROUPS_PERMISSION;
                 }
 
-                String pathOnHost = asString(device, PATH_ON_HOST);
-                String pathInContainer = asString(device, PATH_IN_CONTAINER);
+                String pathOnHost = device.getPathOnHost();
+                String pathInContainer = device.getPathInContainer();
 
                 devices[i] = new Device(cGroupPermissions, pathInContainer, pathOnHost);
                 i++;
@@ -687,12 +668,12 @@ public class DockerClientExecutor {
         return devices;
     }
 
-    private static final RestartPolicy toRestatPolicy(Map<String, Object> restart) {
-        if (restart.containsKey("name")) {
-            String name = asString(restart, "name");
+    private static final RestartPolicy toRestartPolicy(org.arquillian.cube.docker.impl.client.config.RestartPolicy restart) {
+        if (restart.getName() != null) {
+            String name = restart.getName();
 
             if ("failure".equals(name)) {
-                return RestartPolicy.onFailureRestart(asInt(restart, "maximumRetryCount"));
+                return RestartPolicy.onFailureRestart(restart.getMaximumRetryCount());
             } else {
                 if ("restart".equals(name)) {
                     return RestartPolicy.alwaysRestart();
@@ -706,21 +687,11 @@ public class DockerClientExecutor {
         }
     }
 
-    private static final Binding toBinding(String port) {
-        if (port.contains(TAG_SEPARATOR)) {
-            String host = port.substring(0, port.lastIndexOf(TAG_SEPARATOR));
-            int extractedPort = Integer.parseInt(port.substring(port.lastIndexOf(TAG_SEPARATOR) + 1, port.length()));
-            return Ports.Binding(host, extractedPort);
-        } else {
-            return Ports.Binding(Integer.parseInt(port));
-        }
-    }
-
-    private static final Link[] toLinks(Collection<String> linkList) {
+    private static final Link[] toLinks(Collection<org.arquillian.cube.docker.impl.client.config.Link> linkList) {
         Link[] links = new Link[linkList.size()];
         int i=0;
-        for (String link : linkList) {
-            links[i] = Link.parse(link);
+        for (org.arquillian.cube.docker.impl.client.config.Link link : linkList) {
+            links[i] = new Link(link.getName(), link.getAlias());
             i++;
         }
 
@@ -745,16 +716,6 @@ public class DockerClientExecutor {
         }
 
         return binds;
-    }
-
-    private static final Set<ExposedPort> toExposedPorts(Collection<String> exposedPortsList) {
-        Set<ExposedPort> exposedPorts = new HashSet<>();
-
-        for (String exposedPort : exposedPortsList) {
-            exposedPorts.add(ExposedPort.parse(exposedPort));
-        }
-
-        return exposedPorts;
     }
 
     private static final Volume[] toVolumes(Collection<String> volumesList) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverter.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverter.java
@@ -1,23 +1,20 @@
 package org.arquillian.cube.docker.impl.docker.compose;
 
-import org.arquillian.cube.docker.impl.client.Converter;
-import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.docker.impl.util.IOUtil;
-import org.yaml.snakeyaml.Yaml;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asMap;
 
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Collection;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Map;
-import java.util.Properties;
 import java.util.Set;
-import java.util.Map.Entry;
 
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asMap;
+import org.arquillian.cube.docker.impl.client.Converter;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.util.IOUtil;
+import org.yaml.snakeyaml.Yaml;
 
 public class DockerComposeConverter implements Converter {
 
@@ -28,7 +25,7 @@ public class DockerComposeConverter implements Converter {
         try (FileInputStream inputStream = new FileInputStream(location.toFile())) {
             String content = IOUtil.asStringPreservingNewLines(inputStream);
             content = resolvePlaceholders(content);
-            this.dockerComposeDefinitionMap = (Map<String, Object>) new Yaml().load(content);
+            this.dockerComposeDefinitionMap = loadConfig(content);
             this.dockerComposeRootDirectory = location.getParent();
         }
     }
@@ -45,7 +42,7 @@ public class DockerComposeConverter implements Converter {
 
     private DockerComposeConverter(String content) {
         String resolvePlaceholders = resolvePlaceholders(content);
-        this.dockerComposeDefinitionMap = (Map<String, Object>) new Yaml().load(content);
+        this.dockerComposeDefinitionMap = loadConfig(resolvePlaceholders);
         this.dockerComposeRootDirectory = Paths.get(".");
     }
 
@@ -61,33 +58,25 @@ public class DockerComposeConverter implements Converter {
         return new DockerComposeConverter(content);
     }
 
-    public Map<String, Object> convert() {
-        Map<String, Object> dockerCubeDefinitionMap = new HashMap<>();
+    public CubeContainers convert() {
+        CubeContainers cubeContainers = new CubeContainers();
 
         Set<String> names = dockerComposeDefinitionMap.keySet();
 
         for(String name : names) {
-            Map<String, Object> containerCubeDefinition = convertContainer(asMap(dockerComposeDefinitionMap, name));
-            dockerCubeDefinitionMap.put(name, containerCubeDefinition);
+            CubeContainer cubeContainer = convertContainer(asMap(dockerComposeDefinitionMap, name));
+            cubeContainers.add(name, cubeContainer);
         }
-        return dockerCubeDefinitionMap;
+        return cubeContainers;
     }
 
-    private Map<String, Object> convertContainer(Map<String, Object> dockerComposeContainerDefinition) {
+    private CubeContainer convertContainer(Map<String, Object> dockerComposeContainerDefinition) {
         ContainerBuilder containerBuilder = new ContainerBuilder(this.dockerComposeRootDirectory);
-        Map<String, Object> conf = containerBuilder.build(dockerComposeContainerDefinition);
-        if (conf.containsKey(DockerClientExecutor.ENV)) {
-            conf.put(DockerClientExecutor.ENV, toEnvironment((Properties) conf.get(DockerClientExecutor.ENV)));
-        }
-        return conf;
-    }
-    private Collection<String> toEnvironment(Properties properties) {
-        Set<String> listOfEnvironment = new HashSet<>();
-        Set<Entry<Object, Object>> entrySet = properties.entrySet();
-        for (Entry<Object, Object> entry : entrySet) {
-            listOfEnvironment.add(entry.getKey() + "=" + entry.getValue());
-        }
-        return listOfEnvironment;
+        return containerBuilder.build(dockerComposeContainerDefinition);
     }
 
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> loadConfig(String content) {
+        return (Map<String, Object>) new Yaml().load(content);
+    }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/cube/CubeConverter.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/cube/CubeConverter.java
@@ -1,26 +1,25 @@
 package org.arquillian.cube.docker.impl.docker.cube;
 
-import org.arquillian.cube.docker.impl.client.Converter;
-import org.arquillian.cube.docker.impl.util.ConfigUtil;
-import org.yaml.snakeyaml.Yaml;
-
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.Map;
+
+import org.arquillian.cube.docker.impl.client.Converter;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.util.ConfigUtil;
 
 public class CubeConverter implements Converter {
 
-    private final Map<String, Object> dockerCubeDefinitionMap;
+    private final CubeContainers dockerCubeDefinitionMap;
 
     private CubeConverter(Path location) throws IOException {
         FileInputStream inputStream = new FileInputStream(location.toFile());
-        this.dockerCubeDefinitionMap = ConfigUtil.applyExtendsRules((Map<String, Object>) new Yaml().load(inputStream));
+        this.dockerCubeDefinitionMap = ConfigUtil.load(inputStream);
         inputStream.close();
     }
 
     private CubeConverter(String content) {
-        this.dockerCubeDefinitionMap = ConfigUtil.applyExtendsRules((Map<String, Object>) new Yaml().load(content));
+        this.dockerCubeDefinitionMap = ConfigUtil.load(content);
     }
 
     public static CubeConverter create(Path location) {
@@ -36,7 +35,7 @@ public class CubeConverter implements Converter {
     }
 
     @Override
-    public Map<String, Object> convert() {
+    public CubeContainers convert() {
         return this.dockerCubeDefinitionMap;
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
@@ -14,6 +14,7 @@ import java.util.logging.Logger;
 import org.arquillian.cube.ChangeLog;
 import org.arquillian.cube.TopContainer;
 import org.arquillian.cube.docker.impl.await.AwaitStrategyFactory;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.util.BindingUtil;
 import org.arquillian.cube.docker.impl.util.IOUtil;
@@ -30,10 +31,11 @@ import org.arquillian.cube.spi.event.lifecycle.BeforeDestroy;
 import org.arquillian.cube.spi.event.lifecycle.BeforeStart;
 import org.arquillian.cube.spi.event.lifecycle.BeforeStop;
 import org.arquillian.cube.spi.event.lifecycle.CubeLifecyleEvent;
+import org.arquillian.cube.spi.metadata.IsBuildable;
 import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.annotation.Inject;
 
-public class DockerCube extends BaseCube {
+public class DockerCube extends BaseCube<CubeContainer> {
 
     private static final Logger log = Logger.getLogger(DockerCube.class.getName());
 
@@ -41,17 +43,27 @@ public class DockerCube extends BaseCube {
     private String id;
     private Binding binding = null;
 
-    private Map<String, Object> configuration;
+    private CubeContainer configuration;
 
     @Inject
     private Event<CubeLifecyleEvent> lifecycle;
 
     private DockerClientExecutor executor;
 
-    public DockerCube(String id, Map<String, Object> configuration, DockerClientExecutor executor) {
+    public DockerCube(String id, CubeContainer configuration, DockerClientExecutor executor) {
         this.id = id;
         this.configuration = configuration;
         this.executor = executor;
+        addDefaultMetadata();
+    }
+
+    private void addDefaultMetadata() {
+        if(configuration.getBuildImage() !=null) {
+            String path = configuration.getBuildImage().getDockerfileLocation();
+            if(path != null) {
+                addMetadata(new IsBuildable(path));
+            }
+        }
     }
 
     @Override
@@ -169,7 +181,7 @@ public class DockerCube extends BaseCube {
     }
 
     @Override
-    public Map<String, Object> configuration() {
+    public CubeContainer configuration() {
         return configuration;
     }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/AutoStartOrderUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/AutoStartOrderUtil.java
@@ -1,11 +1,18 @@
 package org.arquillian.cube.docker.impl.util;
 
-import java.util.*;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import org.arquillian.cube.docker.impl.client.AutoStartParser;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.Link;
 
 public class AutoStartOrderUtil {
 
@@ -85,20 +92,18 @@ public class AutoStartOrderUtil {
         return false;
     }
 
-    @SuppressWarnings("unchecked")
     private static void addAll(Map<String, Node> nodes, CubeDockerConfiguration config, String id) {
-        Map<String, Object> content = (Map<String, Object>)config.getDockerContainersContent().get(id);
+        CubeContainer content = config.getDockerContainersContent().get(id);
         if(content == null) {
             return;
         }
         Node parent = nodes.get(id);
-        if(content.containsKey("links")) {
-            Collection<String> links = (Collection<String>)content.get("links");
-            for(String link : links) {
-                String[] parsed = link.split(":");
-                String name = parsed[0];
+        if(content.getLinks() != null) {
+            Collection<Link> links = content.getLinks();
+            for(Link link : links) {
+                String name = link.getName();
 
-                if(config.getDockerContainersContent().containsKey(name)) {
+                if(config.getDockerContainersContent().get(name) != null) {
                     Node child = nodes.get(name);
                     if(child == null) {
                         child = Node.from(name);

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ConfigUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ConfigUtil.java
@@ -1,8 +1,27 @@
 package org.arquillian.cube.docker.impl.util;
 
+import java.io.ByteArrayInputStream;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.client.config.ExposedPort;
+import org.arquillian.cube.docker.impl.client.config.Image;
+import org.arquillian.cube.docker.impl.client.config.Link;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
+import org.yaml.snakeyaml.Yaml;
+import org.yaml.snakeyaml.constructor.Constructor;
+import org.yaml.snakeyaml.introspector.Property;
+import org.yaml.snakeyaml.nodes.Node;
+import org.yaml.snakeyaml.nodes.NodeId;
+import org.yaml.snakeyaml.nodes.NodeTuple;
+import org.yaml.snakeyaml.nodes.ScalarNode;
+import org.yaml.snakeyaml.nodes.Tag;
+import org.yaml.snakeyaml.representer.Represent;
+import org.yaml.snakeyaml.representer.Representer;
 
 public final class ConfigUtil {
 
@@ -28,24 +47,95 @@ public final class ConfigUtil {
         return result;
     }
 
-    public static Map<String, Object> applyExtendsRules(Map<String, Object> containerConfig) {
-        for(Map.Entry<String, Object> containerEntry : containerConfig.entrySet()) {
-            @SuppressWarnings("unchecked")
-            Map<String, Object> container = (Map<String, Object>)containerEntry.getValue();
-            if(container.containsKey("extends")) {
-                String extendsContainer = container.get("extends").toString();
-                if(!containerConfig.containsKey(extendsContainer)) {
-                    throw new IllegalArgumentException(containerEntry.getKey() + " extends a non existing container definition " + extendsContainer);
-                }
-                @SuppressWarnings("unchecked")
-                Map<String, Object> extendedContainer = (Map<String, Object>)containerConfig.get(extendsContainer);
-                for(Map.Entry<String, Object> extendedContainerEntry : extendedContainer.entrySet()) {
-                    if(!container.containsKey(extendedContainerEntry.getKey())) {
-                        container.put(extendedContainerEntry.getKey(), extendedContainerEntry.getValue());
-                    }
-                }
+    public static String dump(CubeContainers containers) {
+        Yaml yaml = new Yaml(new CubeRepresenter());
+        return yaml.dump(containers);
+    }
+
+    private static class CubeRepresenter extends Representer {
+        public CubeRepresenter() {
+            this.representers.put(PortBinding.class, new ToStringRepresent());
+            this.representers.put(ExposedPort.class, new ToStringRepresent());
+            this.representers.put(Image.class, new ToStringRepresent());
+            this.representers.put(Link.class, new ToStringRepresent());
+            addClassTag(CubeContainers.class, Tag.MAP);
+        }
+
+        public class ToStringRepresent implements Represent {
+            @Override
+            public Node representData(Object data) {
+                return representScalar(Tag.STR, data.toString());
             }
         }
-        return containerConfig;
+
+        @Override
+        protected NodeTuple representJavaBeanProperty(Object javaBean, Property property, Object propertyValue, Tag customTag) {
+            if(propertyValue == null) {
+                return null;
+            }
+            return super.representJavaBeanProperty(javaBean, property, propertyValue, customTag);
+        }
+    }
+
+    public static CubeContainers load(String content) {
+        return load(new ByteArrayInputStream(content.getBytes()));
+    }
+
+    @SuppressWarnings("unchecked")
+    public static CubeContainers load(InputStream inputStream) {
+        // TODO: Figure out how to map root Map<String, Type> objects. Workaround by mapping it to Map structure then dumping it into individual objects
+        Yaml yaml = new Yaml(new CubeConstructor());
+        Map<String, Object> rawContainers = (Map<String, Object>) yaml.load(inputStream);
+
+        CubeContainers containers = new CubeContainers();
+
+        for(Map.Entry<String, Object> rawContainerEntry : rawContainers.entrySet()) {
+            CubeContainer container = yaml.loadAs(yaml.dump(rawContainerEntry.getValue()), CubeContainer.class);
+            containers.add(rawContainerEntry.getKey(), container);
+        }
+        return applyExtendsRules(containers);
+    }
+
+    public static class CubeConstructor extends Constructor {
+        public CubeConstructor() {
+            this.yamlClassConstructors.put(NodeId.scalar, new CubeMapping());
+        }
+
+        private class CubeMapping extends Constructor.ConstructScalar {
+
+            @Override
+            public Object construct(Node node) {
+                if(node.getType() == PortBinding.class) {
+                    String value = constructScalar((ScalarNode)node).toString();
+                    return PortBinding.valueOf(value);
+                } else if(node.getType() == ExposedPort.class) {
+                    String value = constructScalar((ScalarNode)node).toString();
+                    return ExposedPort.valueOf(value);
+                } else if(node.getType() == Image.class) {
+                    String value = constructScalar((ScalarNode)node).toString();
+                    return Image.valueOf(value);
+                } else if(node.getType() == Link.class) {
+                    String value = constructScalar((ScalarNode)node).toString();
+                    return Link.valueOf(value);
+                }
+                return super.construct(node);
+            }
+        }
+    }
+
+    private static CubeContainers applyExtendsRules(CubeContainers cubeContainers) {
+
+        for(Map.Entry<String, CubeContainer> containerEntry : cubeContainers.getContainers().entrySet()) {
+            CubeContainer container = containerEntry.getValue();
+            if(container.getExtends() != null) {
+                String extendsContainer = container.getExtends();
+                if(cubeContainers.get(extendsContainer) == null) {
+                    throw new IllegalArgumentException(containerEntry.getKey() + " extends a non existing container definition " + extendsContainer);
+                }
+                CubeContainer extendedContainer = cubeContainers.get(extendsContainer);
+                container.merge(extendedContainer);
+            }
+        }
+        return cubeContainers;
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ContainerObjectUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ContainerObjectUtil.java
@@ -1,9 +1,6 @@
 package org.arquillian.cube.docker.impl.util;
 
-import org.arquillian.cube.containerobject.Cube;
-
 import java.lang.annotation.Annotation;
-import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.security.AccessController;
@@ -54,6 +51,7 @@ public class ContainerObjectUtil {
         });
     }
 
+    @SuppressWarnings("unchecked")
     private static <T> T getValue(final Annotation annotation, Method field) {
         try {
             return (T)field.invoke(annotation);

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/DockerFileUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/DockerFileUtil.java
@@ -1,10 +1,6 @@
 package org.arquillian.cube.docker.impl.util;
 
 
-import org.apache.commons.io.FileUtils;
-import org.arquillian.cube.containerobject.CubeDockerFile;
-import org.arquillian.cube.impl.util.Which;
-
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -15,6 +11,10 @@ import java.nio.file.Paths;
 import java.util.Enumeration;
 import java.util.jar.JarEntry;
 import java.util.jar.JarFile;
+
+import org.apache.commons.io.FileUtils;
+import org.arquillian.cube.containerobject.CubeDockerFile;
+import org.arquillian.cube.impl.util.Which;
 
 public class DockerFileUtil {
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/IOUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/IOUtil.java
@@ -1,8 +1,16 @@
 package org.arquillian.cube.docker.impl.util;
 
-import java.io.*;
-import java.nio.file.Files;
-import java.nio.file.Paths;
+import java.io.BufferedInputStream;
+import java.io.BufferedOutputStream;
+import java.io.BufferedReader;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.PrintStream;
+import java.io.StringWriter;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/YamlUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/YamlUtil.java
@@ -1,7 +1,6 @@
 package org.arquillian.cube.docker.impl.util;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.Map;
 
 public class YamlUtil {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
@@ -4,114 +4,35 @@ import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
-import java.util.Map;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 
-import org.arquillian.cube.docker.impl.await.AwaitStrategy;
-import org.arquillian.cube.docker.impl.await.AwaitStrategyFactory;
-import org.arquillian.cube.docker.impl.await.NativeAwaitStrategy;
-import org.arquillian.cube.docker.impl.await.PollingAwaitStrategy;
-import org.arquillian.cube.docker.impl.await.SleepingAwaitStrategy;
-import org.arquillian.cube.docker.impl.await.StaticAwaitStrategy;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.spi.Cube;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.yaml.snakeyaml.Yaml;
 
 @RunWith(MockitoJUnitRunner.class)
 public class AwaitStrategyTest {
 
-    private static final String CONTENT_WITH_STATIC_STRATEGY = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: static\n" +
-            "    ip: localhost\n" +
-            "    ports: [8080,8089]";
-
-    private static final String CONTENT_WITH_STATIC_STRATEGY_WITHOUT_DEFAULTS = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: static\n" +
-            "    ip: localhost\n" +
-            "    ports: [8080,8089]\n" +
-            "    sleepPollingTime: 200\n" +
-            "    iterations: 3";
-
-    private static final String CONTENT_WITH_STATIC_STRATEGY_WITHOUT_DEFAULTS_UNIT = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: static\n" +
-            "    ip: localhost\n" +
-            "    ports: [8080,8089]\n" +
-            "    sleepPollingTime: 200 s\n" +
-            "    iterations: 3";
-
-    private static final String CONTENT_WITH_NO_STRATEGY = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n";
-
-    private static final String CONTENT_WITH_POLLING_STRATEGY = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: polling";
-
-    private static final String CONTENT_WITH_POLLING_STRATEGY_WITHOUT_DEFAULTS = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: polling\n" +
-            "    sleepPollingTime: 200\n" +
-            "    iterations: 3";
-
-    private static final String CONTENT_WITH_NATIVE_STRATEGY = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: native";
-
-
-    private static final String CONTENT_WITH_SLEEPING_STRATEGY_WITHOUT_DEFAULTS_AND_UNIT = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: sleeping\n" +
-            "    sleepTime: 200 s\n";
-
-    private static final String CONTENT_WITH_POLLING_STRATEGY_WITHOUT_DEFAULTS_AND_UNIT = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: polling\n" +
-            "    sleepPollingTime: 200 s\n" +
-            "    iterations: 3";
-
-    private static final String CONTENT_WITH_SSCOMMAND_STRATEGY = "tomcat:\n" +
-            "  image: tutum/tomcat:7.0\n" +
-            "  exposedPorts: [8089/tcp]\n" +
-            "  await:\n" +
-            "    strategy: polling\n" +
-            "    sleepPollingTime: 200 s\n" +
-            "    iterations: 3\n" +
-            "    type: sscommand";
-
     @Mock
-    private Cube cube;
+    private Cube<?> cube;
 
     @Test
     public void should_create_static_await_strategy() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_STATIC_STRATEGY);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("static");
+        await.setIp("localhost");
+        await.setPorts(Arrays.asList(8080,8089));
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(StaticAwaitStrategy.class));
         StaticAwaitStrategy staticAwaitStrategy = (StaticAwaitStrategy)strategy;
@@ -124,12 +45,17 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_static_await_strategy_without_defaults() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_STATIC_STRATEGY_WITHOUT_DEFAULTS);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("static");
+        await.setIp("localhost");
+        await.setPorts(Arrays.asList(8080,8089));
+        await.setSleepPollingTime(200);
+        await.setIterations(3);
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(StaticAwaitStrategy.class));
         StaticAwaitStrategy staticAwaitStrategy = (StaticAwaitStrategy)strategy;
@@ -144,12 +70,17 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_static_await_strategy_without_defaults_and_units() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_STATIC_STRATEGY_WITHOUT_DEFAULTS_UNIT);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("static");
+        await.setIp("localhost");
+        await.setPorts(Arrays.asList(8080,8089));
+        await.setSleepPollingTime("200 s");
+        await.setIterations(3);
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(StaticAwaitStrategy.class));
         StaticAwaitStrategy staticAwaitStrategy = (StaticAwaitStrategy)strategy;
@@ -165,12 +96,9 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_native_await_strategy_if_no_strategy_is_provided() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_NO_STRATEGY);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        CubeContainer cubeContainer = new CubeContainer();
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
     }
@@ -178,12 +106,13 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_polling_await_strategy() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_POLLING_STRATEGY);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("polling");
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
     }
@@ -191,12 +120,15 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_polling_await_strategy_with_specific_times() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_POLLING_STRATEGY_WITHOUT_DEFAULTS);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("polling");
+        await.setSleepPollingTime(200);
+        await.setIterations(3);
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
         assertThat(((PollingAwaitStrategy)strategy).getPollIterations(), is(3));
@@ -206,12 +138,14 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_sleeping_await_strategy_with_specific_times() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_SLEEPING_STRATEGY_WITHOUT_DEFAULTS_AND_UNIT);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("sleeping");
+        await.setSleepTime("200 s");
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(SleepingAwaitStrategy.class));
         assertThat(((SleepingAwaitStrategy)strategy).getSleepTime(), is(200));
@@ -220,12 +154,15 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_polling_await_strategy_with_specific_times_and_unit() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_POLLING_STRATEGY_WITHOUT_DEFAULTS_AND_UNIT);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("polling");
+        await.setSleepPollingTime("200 s");
+        await.setIterations(3);
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
         assertThat(((PollingAwaitStrategy)strategy).getPollIterations(), is(3));
@@ -237,12 +174,16 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_polling_await_strategy_with_specific_type() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_SSCOMMAND_STRATEGY);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("polling");
+        await.setType("sscommand");
+        await.setSleepPollingTime("200 s");
+        await.setIterations(3);
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
         assertThat(((PollingAwaitStrategy)strategy).getType(), is("sscommand"));
@@ -251,12 +192,13 @@ public class AwaitStrategyTest {
     @Test
     public void should_create_native_await_strategy() {
 
-        @SuppressWarnings("unchecked")
-        Map<String, Object> content = (Map<String, Object>) new Yaml().load(CONTENT_WITH_NATIVE_STRATEGY);
-        @SuppressWarnings("unchecked")
-        Map<String, Object> tomcatConfig = (Map<String, Object>) content.get("tomcat");
+        Await await = new Await();
+        await.setStrategy("native");
 
-        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, tomcatConfig);
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(NativeAwaitStrategy.class));
     }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/BeforeStopContainerObserverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/BeforeStopContainerObserverTest.java
@@ -1,21 +1,23 @@
 package org.arquillian.cube.docker.impl.client;
 
-import static org.junit.Assert.assertThat;
 import static org.hamcrest.CoreMatchers.is;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.eq;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
 
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.docker.impl.util.ConfigUtil;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.arquillian.cube.spi.event.lifecycle.BeforeStop;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
@@ -29,28 +31,32 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-import org.yaml.snakeyaml.Yaml;
 
 @RunWith(MockitoJUnitRunner.class)
 public class BeforeStopContainerObserverTest extends AbstractManagerTestBase {
 
-
     private static final String CUBE_CONTAINER_NAME = "test";
 
     private static final String CONTAINER_COPY_CONFIGURATION =
-        "tomcat_default:\n" + "  image: tutum/tomcat:7.0\n"
-            + "  beforeStop:\n" + "    - copy:\n"
-            + "        from: /test\n" + "        to: ";
+        "tomcat_default:\n" +
+        "  image: tutum/tomcat:7.0\n" + 
+        "  beforeStop:\n" + 
+        "    - copy:\n" + 
+        "        from: /test\n" + 
+        "        to: ";
 
     private static final String CONTAINER_LOG_CONFIGURATION =
-        "tomcat_default:\n" + "  image: tutum/tomcat:7.0\n"
-            + "  beforeStop:\n" + "    - log:\n" + "        to: ";
+        "tomcat_default:\n" + 
+        "  image: tutum/tomcat:7.0\n" + 
+        "  beforeStop:\n" + 
+        "    - log:\n" + 
+        "        to: ";
 
     @Rule
     public TemporaryFolder temporaryFolder = new TemporaryFolder();
 
     @Mock
-    private Cube cube;
+    private DockerCube cube;
 
     @Mock
     private CubeRegistry registry;
@@ -73,22 +79,20 @@ public class BeforeStopContainerObserverTest extends AbstractManagerTestBase {
         bind(ApplicationScoped.class, DockerClientExecutor.class,
             dockerClientExecutor);
 
-        Mockito.when(registry.getCube(CUBE_CONTAINER_NAME)).thenReturn(
+        Mockito.when(registry.getCube(CUBE_CONTAINER_NAME, DockerCube.class)).thenReturn(
             cube);
         bind(ApplicationScoped.class, CubeRegistry.class, registry);
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldCopyFileFromContainer() throws IOException {
         File newFolder = temporaryFolder.newFolder();
         String content = CONTAINER_COPY_CONFIGURATION;
         content += newFolder.getAbsolutePath();
 
-        Map<String, Object> configuration =
-            (Map<String, Object>) new Yaml().load(content);
-        Map<String, Object> config =
-            (Map<String, Object>) configuration.get("tomcat_default");
+        CubeContainers configuration = ConfigUtil.load(content);
+        CubeContainer config = configuration.get("tomcat_default");
+
         Mockito.when(cube.configuration()).thenReturn(config);
         Mockito.when(dockerClientExecutor.getFileOrDirectoryFromContainerAsTar(eq(CUBE_CONTAINER_NAME), anyString())).thenReturn(BeforeStopContainerObserverTest.class.getResourceAsStream("/hello.tar"));
         fire(new BeforeStop(CUBE_CONTAINER_NAME));
@@ -96,7 +100,6 @@ public class BeforeStopContainerObserverTest extends AbstractManagerTestBase {
         assertThat(new File(newFolder, "hello.txt").exists(), is(true));
     }
 
-    @SuppressWarnings("unchecked")
     @Test
     public void shouldGetLogFromContainer() throws IOException {
         File newFolder = temporaryFolder.newFolder();
@@ -104,10 +107,8 @@ public class BeforeStopContainerObserverTest extends AbstractManagerTestBase {
         content += newFolder.getAbsolutePath();
         content += "mylog.log";
 
-        Map<String, Object> configuration =
-            (Map<String, Object>) new Yaml().load(content);
-        Map<String, Object> config =
-            (Map<String, Object>) configuration.get("tomcat_default");
+        CubeContainers configuration = ConfigUtil.load(content);
+        CubeContainer config = configuration.get("tomcat_default");
         Mockito.when(cube.configuration()).thenReturn(config);
         fire(new BeforeStop(CUBE_CONTAINER_NAME));
         verify(dockerClientExecutor, times(1)).copyLog(eq(CUBE_CONTAINER_NAME), eq(false), eq(false), eq(false), eq(false), eq(-1), any(OutputStream.class));

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -1,5 +1,19 @@
 package org.arquillian.cube.docker.impl.client;
 
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.endsWith;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
+
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
@@ -14,24 +28,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
-import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.io.ByteArrayOutputStream;
-import java.io.File;
-import java.io.PrintStream;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.collection.IsMapContaining.hasEntry;
-import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CubeConfiguratorTest extends AbstractManagerTestBase {
@@ -103,7 +102,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.1:22222"));
-        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm")));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(
+                File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm")));
     }
 
     @Test
@@ -114,15 +114,18 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         when(extensionDef.getExtensionProperties()).thenReturn(config);
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
-        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "name=dev")).thenReturn(new String[]{
-                "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
-                "dev    *        virtualbox   Running   tcp://192.168.0.2:222222     "
-        });
+        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "name=dev"))
+                .thenReturn(new String[] {
+                        "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
+                        "dev    *        virtualbox   Running   tcp://192.168.0.2:222222     " });
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.0.2");
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222"));
-        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines" + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
+        assertThat(config,
+                hasEntry(is(CubeDockerConfiguration.CERT_PATH),
+                        endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines"
+                                + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
 
     }
 
@@ -134,15 +137,18 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         when(extensionDef.getExtensionProperties()).thenReturn(config);
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
-        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "name=dev")).thenReturn(new String[]{
-                "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
-                "dev    *        virtualbox   Stopped   tcp://192.168.0.2:222222     "
-        });
+        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "name=dev"))
+                .thenReturn(new String[] {
+                        "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
+                        "dev    *        virtualbox   Stopped   tcp://192.168.0.2:222222     " });
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.0.2");
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222"));
-        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines" + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
+        assertThat(config,
+                hasEntry(is(CubeDockerConfiguration.CERT_PATH),
+                        endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines"
+                                + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
         verify(commandLineExecutor, times(1)).execCommand("docker-machine", "start", "dev");
     }
 
@@ -153,16 +159,20 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(extensionDef.getExtensionProperties()).thenReturn(config);
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.99.100");
-        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "state=Running")).thenReturn(new String[]{
-                "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
-                "dev    *        virtualbox   Running   tcp://192.168.99.100:2376     "
-        });
+        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "state=Running"))
+                .thenReturn(new String[] {
+                        "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
+                        "dev    *        virtualbox   Running   tcp://192.168.99.100:2376     " });
         // Docker Machine is installed
-        when(commandLineExecutor.execCommand("docker-machine")).thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
+        when(commandLineExecutor.execCommand("docker-machine"))
+                .thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.99.100:2376"));
-        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines" + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
+        assertThat(config,
+                hasEntry(is(CubeDockerConfiguration.CERT_PATH),
+                        endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines"
+                                + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_MACHINE_NAME, "dev"));
 
     }
@@ -174,21 +184,23 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(extensionDef.getExtensionProperties()).thenReturn(config);
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.99.100");
-        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "state=Running")).thenReturn(new String[]{
-                "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
-                "dev    *        virtualbox   Running   tcp://192.168.99.100:2376     ",
-                "dev2   *        virtualbox   Running   tcp://192.168.99.100:2376     "
-        });
+        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "state=Running"))
+                .thenReturn(new String[] {
+                        "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
+                        "dev    *        virtualbox   Running   tcp://192.168.99.100:2376     ",
+                        "dev2   *        virtualbox   Running   tcp://192.168.99.100:2376     " });
         when(commandLineExecutor.execCommand("boot2docker", "ip")).thenReturn("192.168.0.1");
         // Docker-Machine is installed
-        when(commandLineExecutor.execCommand("docker-machine")).thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
+        when(commandLineExecutor.execCommand("docker-machine"))
+                .thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.1:2376"));
 
     }
 
-    // Only works in case of running in MACOS or Windows since by default in these systems boot2docker is the default
+    // Only works in case of running in MACOS or Windows since by default in
+    // these systems boot2docker is the default
     @Test
     public void shouldUseDefaultsInCaseOfNotHavingDockerMachineInstalledAndNoDockerUriNorMachineName() {
         Map<String, String> config = new HashMap<>();
@@ -227,7 +239,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     }
 
     @Test
-     public void dockerUriTcpShouldBeReplacedToHttpsInCaseOfDockerMachine() {
+    public void dockerUriTcpShouldBeReplacedToHttpsInCaseOfDockerMachine() {
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
         config.put(CubeDockerConfiguration.DOCKER_MACHINE_NAME, "dev");
@@ -235,10 +247,10 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(extensionDef.getExtensionProperties()).thenReturn(config);
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.0.2");
-        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "name=dev")).thenReturn(new String[]{
-                "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
-                "dev    *        virtualbox   Running   tcp://192.168.0.2:222222     "
-        });
+        when(commandLineExecutor.execCommandAsArray("docker-machine", "ls", "--filter", "name=dev"))
+                .thenReturn(new String[] {
+                        "NAME   ACTIVE   DRIVER       STATE     URL                         SWARM",
+                        "dev    *        virtualbox   Running   tcp://192.168.0.2:222222     " });
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222"));
@@ -301,7 +313,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
             fire(new CubeConfiguration());
             assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.1:22222"));
-            assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm")));
+            assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(
+                    File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm")));
             assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_SERVER_IP, "192.168.0.1"));
         } finally {
             if (originalVar != null) {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeRegistrarTestCase.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeRegistrarTestCase.java
@@ -1,7 +1,5 @@
 package org.arquillian.cube.docker.impl.client;
 
-import static org.mockito.Mockito.mock;
-
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -9,7 +7,6 @@ import java.util.Map;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.impl.model.LocalCubeRegistry;
 import org.arquillian.cube.spi.CubeRegistry;
-import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.test.AbstractManagerTestBase;
 import org.junit.Assert;

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeSuiteLifecycleControllerTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeSuiteLifecycleControllerTest.java
@@ -3,11 +3,12 @@ package org.arquillian.cube.docker.impl.client;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.util.*;
-import java.util.regex.Pattern;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
-import org.arquillian.cube.docker.impl.client.CubeSuiteLifecycleController;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.ConnectionMode;
 import org.arquillian.cube.spi.CubeConfiguration;

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/config/ConfigParserTestCase.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/config/ConfigParserTestCase.java
@@ -1,0 +1,56 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+import java.util.Iterator;
+
+import org.arquillian.cube.docker.impl.util.ConfigUtil;
+import org.junit.Assert;
+import org.junit.Test;
+import org.yaml.snakeyaml.constructor.Constructor;
+
+public class ConfigParserTestCase {
+
+    private static final String CONTENT =
+            "tomcat:\n" +
+            "  image: tutum/tomcat:7.0\n" +
+            "  buildImage:\n" +
+            "      dockerfileLocation: src/test/resources/undertow\n" +
+            "  exposedPorts: [8089/tcp]\n" +
+            "  portBindings: [1521/tcp, 'localhost:8181->81/tcp']\n" +
+            "  await:\n" +
+            "    strategy: static\n" +
+            "    ip: localhost\n" +
+            "    ports: [8080, 8089]";
+
+    @Test
+    public void shouldBeAbleToLoadStrategy() throws Exception {
+
+        CubeContainers containers = ConfigUtil.load(CONTENT);
+        CubeContainer container = containers.get("tomcat");
+
+        Assert.assertEquals("tutum/tomcat", container.getImage().getName());
+        Assert.assertEquals("7.0", container.getImage().getTag());
+
+        Assert.assertEquals(1, container.getExposedPorts().size());
+        ExposedPort exposedPort = container.getExposedPorts().iterator().next();
+        Assert.assertEquals(8089, exposedPort.getExposed());
+        Assert.assertEquals("tcp", exposedPort.getType());
+
+        Assert.assertEquals(2, container.getPortBindings().size());
+        Iterator<PortBinding> portBindingIterator = container.getPortBindings().iterator();
+        PortBinding portBinding1 = portBindingIterator.next();
+        PortBinding portBinding2 = portBindingIterator.next();
+        Assert.assertEquals(1521, portBinding1.getExposedPort().getExposed());
+        Assert.assertEquals("tcp", portBinding1.getExposedPort().getType());
+
+        Assert.assertEquals(8181, portBinding2.getBound());
+        Assert.assertEquals("localhost", portBinding2.getHost());
+        Assert.assertEquals(81, portBinding2.getExposedPort().getExposed());
+        Assert.assertEquals("tcp", portBinding2.getExposedPort().getType());
+
+        Assert.assertEquals("static", container.getAwait().getStrategy());
+        Assert.assertEquals("localhost", container.getAwait().getIp());
+        Assert.assertEquals(2, container.getAwait().getPorts().size());
+
+        System.out.println(ConfigUtil.dump(containers));
+    }
+}

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
@@ -1,10 +1,8 @@
 package org.arquillian.cube.docker.impl.docker.compose;
 
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.hamcrest.collection.IsIterableContainingInAnyOrder.containsInAnyOrder;
-import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertThat;
 
 import java.io.IOException;
@@ -12,8 +10,11 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import java.nio.file.Paths;
 import java.util.Collection;
-import java.util.Map;
 
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CubeContainers;
+import org.arquillian.cube.docker.impl.client.config.Link;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.junit.Test;
 
 public class DockerComposeConverterTest {
@@ -24,25 +25,25 @@ public class DockerComposeConverterTest {
     URI simpleDockerCompose = DockerComposeConverterTest.class.getResource("/simple-docker-compose.yml").toURI();
     DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(simpleDockerCompose));
 
-    Map<String, Object> convert = dockerComposeConverter.convert();
-    Map<String, Object> webapp = (Map<String, Object>) convert.get("webapp");
-    assertThat(webapp, hasKey("buildImage"));
-    assertThat(webapp, hasKey("portBindings"));
-    Collection<String> ports = (Collection<String>) webapp.get("portBindings");
-    assertThat(ports, containsInAnyOrder("8000->8000"));
-    assertThat(webapp, hasKey("devices"));
-    assertThat(webapp, hasKey("volumes"));
-    Collection<String> volumes = (Collection<String>) webapp.get("volumes");
+    CubeContainers convert = dockerComposeConverter.convert();
+    CubeContainer webapp = convert.get("webapp");
+    assertThat(webapp.getBuildImage(), is(notNullValue()));
+    assertThat(webapp.getPortBindings(), is(notNullValue()));
+    Collection<PortBinding> ports = webapp.getPortBindings();
+    assertThat(ports, containsInAnyOrder(PortBinding.valueOf("8000->8000")));
+    assertThat(webapp.getDevices(), is(notNullValue()));
+    assertThat(webapp.getVolumes(), is(notNullValue()));
+    Collection<String> volumes = (Collection<String>) webapp.getVolumes();
     assertThat(volumes, containsInAnyOrder("/data"));
 
-    Map<String, Object> webapp2 = (Map<String, Object>) convert.get("webapp2");
-    assertThat(webapp2, hasKey("image"));
-    assertThat(webapp2, hasKey("portBindings"));
-    assertThat(webapp2, hasKey("links"));
-    Collection<String> links = (Collection<String>) webapp2.get("links");
-    assertThat(links, containsInAnyOrder("webapp:webapp"));
-    assertThat(webapp2, hasKey("env"));
-    Collection<String> env = (Collection<String>) webapp2.get("env");
+    CubeContainer webapp2 = convert.get("webapp2");
+    assertThat(webapp2.getImage(), is(notNullValue()));
+    assertThat(webapp2.getPortBindings(), is(notNullValue()));
+    assertThat(webapp2.getLinks(), is(notNullValue()));
+    Collection<Link> links = webapp2.getLinks();
+    assertThat(links, containsInAnyOrder(Link.valueOf("webapp:webapp")));
+    assertThat(webapp2.getEnv(), is(notNullValue()));
+    Collection<String> env = webapp2.getEnv();
     assertThat(env, containsInAnyOrder("RACK_ENV=development"));
   }
 
@@ -51,10 +52,10 @@ public class DockerComposeConverterTest {
     URI readEnvsDockerCompose = DockerComposeConverterTest.class.getResource("/read-envs-docker-compose.yml").toURI();
     DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(readEnvsDockerCompose));
 
-    Map<String, Object> convert = dockerComposeConverter.convert();
-    Map<String, Object> webapp = (Map<String, Object>) convert.get("webapp");
-    assertThat(webapp, hasKey("env"));
-    Collection<String> env = (Collection<String>) webapp.get("env");
+    CubeContainers convert = dockerComposeConverter.convert();
+    CubeContainer webapp = convert.get("webapp");
+    assertThat(webapp.getEnv(), is(notNullValue()));
+    Collection<String> env = webapp.getEnv();
     assertThat(env, containsInAnyOrder("RACK_ENV=development"));
   }
 
@@ -72,10 +73,10 @@ public class DockerComposeConverterTest {
     URI readEnvsDockerCompose = DockerComposeConverterTest.class.getResource(dockerComposeFile).toURI();
     DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(readEnvsDockerCompose));
 
-    Map<String, Object> convert = dockerComposeConverter.convert();
-    Map<String, Object> webapp = (Map<String, Object>) convert.get("webapp2");
-    assertThat(webapp, hasKey("image"));
-    final String image = (String)webapp.get("image");
+    CubeContainers convert = dockerComposeConverter.convert();
+    CubeContainer webapp = convert.get("webapp2");
+    assertThat(webapp.getImage(), is(notNullValue()));
+    final String image = webapp.getImage().toImageRef();
     assertThat(image, is(expectedImageName));
   }
 
@@ -84,13 +85,13 @@ public class DockerComposeConverterTest {
     URI readEnvsDockerCompose = DockerComposeConverterTest.class.getResource("/extends-docker-compose.yml").toURI();
     DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(readEnvsDockerCompose));
 
-    Map<String, Object> convert = dockerComposeConverter.convert();
-    Map<String, Object> webapp = (Map<String, Object>) convert.get("web");
-    assertThat(webapp, hasKey("env"));
-    Collection<String> env = (Collection<String>) webapp.get("env");
+    CubeContainers convert = dockerComposeConverter.convert();
+    CubeContainer webapp = convert.get("web");
+    assertThat(webapp.getEnv(), is(notNullValue()));
+    Collection<String> env = webapp.getEnv();
     assertThat(env, containsInAnyOrder("REDIS_HOST=redis-production.example.com"));
-    assertThat(webapp, hasKey("portBindings"));
-    Collection<String> ports = (Collection<String>) webapp.get("portBindings");
-    assertThat(ports, containsInAnyOrder("8080->8080"));
+    assertThat(webapp.getPortBindings(), is(notNullValue()));
+    Collection<PortBinding> ports = webapp.getPortBindings();
+    assertThat(ports, containsInAnyOrder(PortBinding.valueOf("8080->8080")));
   }
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/model/DockerCubeTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/model/DockerCubeTest.java
@@ -5,6 +5,7 @@ import static org.mockito.Matchers.anyString;
 
 import java.util.HashMap;
 
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.model.DockerCube;
 import org.arquillian.cube.spi.event.lifecycle.AfterCreate;
@@ -59,7 +60,7 @@ public class DockerCubeTest extends AbstractManagerTestBase {
         when(inspectContainerCmd.exec()).thenReturn(inspectContainerResponse);
         when(dockerClient.inspectContainerCmd(anyString())).thenReturn(inspectContainerCmd);
         when(executor.getDockerClient()).thenReturn(dockerClient);
-        cube = injectorInst.get().inject(new DockerCube("test", new HashMap<String, Object>(), executor));
+        cube = injectorInst.get().inject(new DockerCube("test", new CubeContainer(), executor));
     }
 
     @Test

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/AutoStartOrderUtilTestCase.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/AutoStartOrderUtilTestCase.java
@@ -1,7 +1,5 @@
 package org.arquillian.cube.docker.impl.util;
 
-import static org.mockito.Mockito.mock;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
@@ -9,8 +7,6 @@ import java.util.List;
 import java.util.Map;
 
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
-import org.arquillian.cube.docker.impl.util.AutoStartOrderUtil;
-import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.junit.Assert;
 import org.junit.Test;
 

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/ContainerObjectUtilTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/ContainerObjectUtilTest.java
@@ -1,13 +1,11 @@
 package org.arquillian.cube.docker.impl.util;
 
-import org.arquillian.cube.containerobject.Cube;
-import org.hamcrest.CoreMatchers;
-import org.junit.Test;
-
-import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.hamcrest.core.Is.is;
 import static org.junit.Assert.assertThat;
+
+import org.arquillian.cube.containerobject.Cube;
+import org.junit.Test;
 
 public class ContainerObjectUtilTest {
 

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/DockerFileUtilTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/DockerFileUtilTest.java
@@ -1,5 +1,10 @@
 package org.arquillian.cube.docker.impl.util;
 
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.net.URLClassLoader;
+
 import org.arquillian.cube.containerobject.CubeDockerFile;
 import org.hamcrest.core.Is;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -10,11 +15,6 @@ import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
-
-import java.io.File;
-import java.io.IOException;
-import java.net.URL;
-import java.net.URLClassLoader;
 
 public class DockerFileUtilTest {
 

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/DockerMachineTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/DockerMachineTest.java
@@ -1,20 +1,16 @@
 package org.arquillian.cube.docker.impl.util;
 
-import org.junit.Assert;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.mockito.Matchers;
-import org.mockito.Mock;
-import org.mockito.Mockito;
-import org.mockito.runners.MockitoJUnitRunner;
-
-import java.util.Set;
-
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
+
+import java.util.Set;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
 @RunWith(MockitoJUnitRunner.class)
 public class DockerMachineTest {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/IOUtilTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/util/IOUtilTest.java
@@ -1,15 +1,12 @@
 package org.arquillian.cube.docker.impl.util;
 
-import org.apache.commons.lang.text.StrLookup;
-import org.apache.commons.lang.text.StrSubstitutor;
-import org.junit.Assert;
-import org.junit.Test;
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
 
 import java.util.HashMap;
 import java.util.Map;
 
-import static org.hamcrest.CoreMatchers.is;
-import static org.junit.Assert.assertThat;
+import org.junit.Test;
 
 public class IOUtilTest {
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -4,9 +4,7 @@ import static org.arquillian.cube.openshift.impl.client.ResourceUtil.isRunning;
 import static org.arquillian.cube.openshift.impl.client.ResourceUtil.toBinding;
 
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.arquillian.cube.ChangeLog;
 import org.arquillian.cube.TopContainer;
@@ -17,10 +15,11 @@ import org.arquillian.cube.spi.BaseCube;
 import org.arquillian.cube.spi.Binding;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeControlException;
+import org.arquillian.cube.spi.metadata.IsBuildable;
 
 import io.fabric8.kubernetes.api.model.Pod;
 
-public class BuildablePodCube extends BaseCube {
+public class BuildablePodCube extends BaseCube<Void> {
 
     private String id;
     private Pod resource;
@@ -37,6 +36,13 @@ public class BuildablePodCube extends BaseCube {
         this.template = new Template.PodTemplate(resource);
         this.client = client;
         this.configuration = configuration;
+        addDefaultMetadata();
+    }
+
+    private void addDefaultMetadata() {
+        if(template.getRefs() != null && template.getRefs().size() > 0) {
+            addMetadata(new IsBuildable(template.getRefs().get(0).getPath()));
+        }
     }
 
     @Override
@@ -126,14 +132,8 @@ public class BuildablePodCube extends BaseCube {
     }
 
     @Override
-    public Map<String, Object> configuration() {
-        Map<String, Object> config = new HashMap<String, Object>();
-        Map<String, Object> buildImage = new HashMap<String, Object>();
-        if(template.getRefs().size() == 1) {
-            buildImage.put("dockerfileLocation", template.getRefs().get(0).getPath());
-        }
-        config.put("buildImage", buildImage);
-        return config;
+    public Void configuration() {
+        return null;
     }
 
     @Override

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
@@ -3,9 +3,7 @@ package org.arquillian.cube.openshift.impl.model;
 import static org.arquillian.cube.openshift.impl.client.ResourceUtil.toBinding;
 
 import java.io.OutputStream;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 
 import org.arquillian.cube.ChangeLog;
 import org.arquillian.cube.TopContainer;
@@ -14,12 +12,11 @@ import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.arquillian.cube.openshift.impl.client.OpenShiftClient.ResourceHolder;
 import org.arquillian.cube.spi.BaseCube;
 import org.arquillian.cube.spi.Binding;
-import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeControlException;
 
 import io.fabric8.kubernetes.api.model.Service;
 
-public class ServiceCube extends BaseCube {
+public class ServiceCube extends BaseCube<Void> {
 
     private String id;
     private Service resource;
@@ -103,8 +100,8 @@ public class ServiceCube extends BaseCube {
     }
 
     @Override
-    public Map<String, Object> configuration() {
-        return new HashMap<String, Object>();
+    public Void configuration() {
+        return null;
     }
 
     @Override

--- a/spi/src/main/java/org/arquillian/cube/spi/BaseCube.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/BaseCube.java
@@ -3,7 +3,7 @@ package org.arquillian.cube.spi;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BaseCube implements Cube {
+public abstract class BaseCube<X> implements Cube<X> {
     private Map<Class<?>, Object> metadata = new HashMap<>();
 
     @Override

--- a/spi/src/main/java/org/arquillian/cube/spi/Cube.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/Cube.java
@@ -2,12 +2,11 @@ package org.arquillian.cube.spi;
 
 import java.io.OutputStream;
 import java.util.List;
-import java.util.Map;
 
 import org.arquillian.cube.ChangeLog;
 import org.arquillian.cube.TopContainer;
 
-public interface Cube {
+public interface Cube<T> {
 
     public enum State {
         CREATED,
@@ -45,7 +44,7 @@ public interface Cube {
 
     Binding configuredBindings();
 
-    Map<String, Object> configuration();
+    T configuration();
 
     boolean hasMetadata(Class<?> type);
 

--- a/spi/src/main/java/org/arquillian/cube/spi/CubeRegistry.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/CubeRegistry.java
@@ -4,13 +4,15 @@ import java.util.List;
 
 public interface CubeRegistry {
 
-    void addCube(Cube cube);
+    void addCube(Cube<?> cube);
 
-    Cube getCube(String id);
+    Cube<?> getCube(String id);
+
+    <T extends Cube<?>> T getCube(String id, Class<T> type);
 
     void removeCube(String id);
 
-    List<Cube> getByMetadata(Class<?> metadata);
+    List<Cube<?>> getByMetadata(Class<?> metadata);
 
-    List<Cube> getCubes();
+    List<Cube<?>> getCubes();
 }

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/IsBuildable.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/IsBuildable.java
@@ -1,0 +1,14 @@
+package org.arquillian.cube.spi.metadata;
+
+public class IsBuildable {
+
+    private String templatePath;
+
+    public IsBuildable(String templatePath) {
+        this.templatePath = templatePath;
+    }
+
+    public String getTemplatePath() {
+        return templatePath;
+    }
+}


### PR DESCRIPTION
fixes #232 

One major thing left;

We used to have Map<String, Object> Cube.configuration() which now is changed to T Cube<T>.getConfiguration(). This was done to allow OpenShiftCube and DockerCube have different configuration internally. The only location where this is actually used is in Containerless Contianer. 

The problem is Containerless Container need the 'BuildImage' part of the Cube configuration, something Openshift only mimiced previously. Containerless container doesn't know about DockerCube or OpenShiftCube specifically, it only operates on Cube. 

Not sure if we should add a Cube.getBuildImage or add some common BaseCubeConfiguration they both can extend, or.. 

Anyway.. You should be able to continue building based on this branch as is, then we can merge etc when done.

Please do a quick review to make sure I didn't change/remove some logic :)