### PR TITLE
Remove docker-server-stub dependency

### DIFF
--- a/docker/docker/pom.xml
+++ b/docker/docker/pom.xml
@@ -61,12 +61,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.arquillian.cube</groupId>
-            <artifactId>docker-server-stub</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.jboss.arquillian.junit</groupId>
             <artifactId>arquillian-junit-container</artifactId>
             <scope>test</scope>


### PR DESCRIPTION
docker-server-stub artifact no longer exist.

See gh-239