### PR TITLE
Move special Cube methods to Metadata Objects

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/model/LocalCubeRegistry.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/LocalCubeRegistry.java
@@ -6,6 +6,7 @@ import java.util.List;
 
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
+import org.arquillian.cube.spi.metadata.CubeMetadata;
 
 public class LocalCubeRegistry implements CubeRegistry {
 
@@ -31,7 +32,7 @@ public class LocalCubeRegistry implements CubeRegistry {
     }
 
     @Override
-    public List<Cube<?>> getByMetadata(Class<?> metadata) {
+    public List<Cube<?>> getByMetadata(Class<? extends CubeMetadata> metadata) {
         List<Cube<?>> cubes = new ArrayList<>();
         for (Cube<?> cube : this.cubes) {
             if (cube.hasMetadata(metadata)) {

--- a/core/src/test/java/org/arquillian/cube/impl/client/CubeMetadataTest.java
+++ b/core/src/test/java/org/arquillian/cube/impl/client/CubeMetadataTest.java
@@ -1,0 +1,96 @@
+package org.arquillian.cube.impl.client;
+
+import org.arquillian.cube.spi.BaseCube;
+import org.arquillian.cube.spi.Binding;
+import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeControlException;
+import org.arquillian.cube.spi.metadata.CubeMetadata;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CubeMetadataTest {
+
+    @Test
+    public void shouldReportCorrectStateOfMetadata() {
+        Cube<?> cube = new TestCube();
+        cube.addMetadata(TestMetadata.class, new TestMetadataImpl());
+
+        Assert.assertTrue(cube.hasMetadata(TestMetadata.class));
+    }
+
+    @Test
+    public void shouldGetCorrectMetadata() {
+        Cube<?> cube = new TestCube();
+        cube.addMetadata(TestMetadata.class, new TestMetadataImpl());
+
+        TestMetadata metadata = cube.getMetadata(TestMetadata.class);
+
+        Assert.assertTrue(metadata instanceof TestMetadataImpl);
+    }
+
+    private static class TestMetadataImpl implements TestMetadata {
+
+        @Override
+        public String get() {
+            return "A";
+        }
+
+    }
+
+    private static interface TestMetadata extends CubeMetadata {
+        String get();
+    }
+
+    private static class TestCube extends BaseCube<Void> {
+
+        @Override
+        public org.arquillian.cube.spi.Cube.State state() {
+            return null;
+        }
+
+        @Override
+        public String getId() {
+            return null;
+        }
+
+        @Override
+        public void create() throws CubeControlException {
+        }
+
+        @Override
+        public void start() throws CubeControlException {
+        }
+
+        @Override
+        public void stop() throws CubeControlException {
+        }
+
+        @Override
+        public void destroy() throws CubeControlException {
+        }
+
+        @Override
+        public boolean isRunningOnRemote() {
+            return false;
+        }
+
+        @Override
+        public void changeToPreRunning() {
+        }
+
+        @Override
+        public Binding bindings() {
+            return null;
+        }
+
+        @Override
+        public Binding configuredBindings() {
+            return null;
+        }
+
+        @Override
+        public Void configuration() {
+            return null;
+        }
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
@@ -258,7 +258,7 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
     private org.arquillian.cube.spi.Cube<?> createCubeFromDockerfile(String cubeName, String[] portBinding, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, File dockerfileLocation, Class<?> testClass) {
         CubeContainer configuration = createConfigurationFromDockerfie(portBinding, links, cubeContainerClazzAnnotation, dockerfileLocation);
         DockerCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
-        newCube.addMetadata(new IsContainerObject(testClass));
+        newCube.addMetadata(IsContainerObject.class, new IsContainerObject(testClass));
         injectorInstance.get().inject(newCube);
         return newCube;
     }
@@ -266,7 +266,7 @@ public class CubeContainerObjectTestEnricher implements TestEnricher {
     private org.arquillian.cube.spi.Cube<?> createCubeFromImage(String cubeName, String[] portBinding, Set<String> links, Image image, File dockerfileLocation, Class<?> testClass) {
         final CubeContainer configuration = createConfigurationFromImage(portBinding, links, image, dockerfileLocation);
         DockerCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
-        newCube.addMetadata(new IsContainerObject(testClass));
+        newCube.addMetadata(IsContainerObject.class, new IsContainerObject(testClass));
         injectorInstance.get().inject(newCube);
         return newCube;
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/ChangesOnFilesystem.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/ChangesOnFilesystem.java
@@ -1,0 +1,24 @@
+package org.arquillian.cube.docker.impl.client.metadata;
+
+import java.util.List;
+
+import org.arquillian.cube.ChangeLog;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.spi.metadata.CanSeeChangesOnFilesystem;
+
+public class ChangesOnFilesystem implements CanSeeChangesOnFilesystem {
+
+    private String cubeId;
+    private DockerClientExecutor executor;
+
+    public ChangesOnFilesystem(String cubeId, DockerClientExecutor executor) {
+        this.cubeId = cubeId;
+        this.executor = executor;
+    }
+
+    @Override
+    public List<ChangeLog> changes() {
+        return executor.inspectChangesOnContainerFilesystem(cubeId);
+    }
+
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/CopyFromContainer.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/CopyFromContainer.java
@@ -1,0 +1,52 @@
+package org.arquillian.cube.docker.impl.client.metadata;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.util.IOUtil;
+import org.arquillian.cube.spi.metadata.CanCopyFromContainer;
+
+public class CopyFromContainer implements CanCopyFromContainer {
+
+    private String cubeId;
+    private DockerClientExecutor executor;
+
+    public CopyFromContainer(String cubeId, DockerClientExecutor executor) {
+        this.cubeId = cubeId;
+        this.executor = executor;
+    }
+
+    @Override
+    public void copyDirectory(String from, String to) {
+        InputStream response = executor.getFileOrDirectoryFromContainerAsTar(cubeId, from);
+
+        Path toPath = Paths.get(to);
+        File toPathFile = toPath.toFile();
+
+        if(toPathFile.exists() && toPathFile.isFile()) {
+            throw new IllegalArgumentException(String.format("%s parameter should be a directory in copy operation but you set an already existing file not a directory. Check %s in your local directory because currently is a file.", "to", toPath.normalize().toString()));
+        }
+
+        try {
+            Files.createDirectories(toPath);
+            IOUtil.untar(response, toPathFile);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    @Override
+    public void copyLog(boolean follow, boolean stdout, boolean stderr, boolean timestamps, int tail, OutputStream outputStream) {
+        try {
+            executor.copyLog(cubeId, follow, stdout, stderr, timestamps, tail, outputStream);
+        } catch (IOException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/GetTop.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/GetTop.java
@@ -1,0 +1,21 @@
+package org.arquillian.cube.docker.impl.client.metadata;
+
+import org.arquillian.cube.TopContainer;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.spi.metadata.CanSeeTop;
+
+public class GetTop implements CanSeeTop {
+
+    private String cubeId;
+    private DockerClientExecutor executor;
+
+    public GetTop(String cubeId, DockerClientExecutor executor) {
+        this.cubeId = cubeId;
+        this.executor = executor;
+    }
+
+    @Override
+    public TopContainer top() {
+        return executor.top(cubeId);
+    }
+}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -3,11 +3,8 @@ package org.arquillian.cube.openshift.impl.model;
 import static org.arquillian.cube.openshift.impl.client.ResourceUtil.isRunning;
 import static org.arquillian.cube.openshift.impl.client.ResourceUtil.toBinding;
 
-import java.io.OutputStream;
 import java.util.List;
 
-import org.arquillian.cube.ChangeLog;
-import org.arquillian.cube.TopContainer;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
 import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.arquillian.cube.openshift.impl.client.OpenShiftClient.ResourceHolder;
@@ -41,7 +38,7 @@ public class BuildablePodCube extends BaseCube<Void> {
 
     private void addDefaultMetadata() {
         if(template.getRefs() != null && template.getRefs().size() > 0) {
-            addMetadata(new IsBuildable(template.getRefs().get(0).getPath()));
+            addMetadata(IsBuildable.class, new IsBuildable(template.getRefs().get(0).getPath()));
         }
     }
 
@@ -133,31 +130,6 @@ public class BuildablePodCube extends BaseCube<Void> {
 
     @Override
     public Void configuration() {
-        return null;
-    }
-
-    @Override
-    public List<ChangeLog> changesOnFilesystem(String cubeId) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public void copyFileDirectoryFromContainer(String cubeId, String from, String to) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void copyLog(String cubeId, boolean follow, boolean stdout, boolean stderr, boolean timestamps, int tail,
-            OutputStream outputStream) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public TopContainer top(String cubeId) {
-        // TODO Auto-generated method stub
         return null;
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
@@ -103,29 +103,4 @@ public class ServiceCube extends BaseCube<Void> {
     public Void configuration() {
         return null;
     }
-
-    @Override
-    public List<ChangeLog> changesOnFilesystem(String cubeId) {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public void copyFileDirectoryFromContainer(String cubeId, String from, String to) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public void copyLog(String cubeId, boolean follow, boolean stdout, boolean stderr, boolean timestamps, int tail,
-            OutputStream outputStream) {
-        // TODO Auto-generated method stub
-
-    }
-
-    @Override
-    public TopContainer top(String cubeId) {
-        // TODO Auto-generated method stub
-        return null;
-    }
 }

--- a/spi/src/main/java/org/arquillian/cube/spi/BaseCube.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/BaseCube.java
@@ -3,21 +3,24 @@ package org.arquillian.cube.spi;
 import java.util.HashMap;
 import java.util.Map;
 
-public abstract class BaseCube<X> implements Cube<X> {
-    private Map<Class<?>, Object> metadata = new HashMap<>();
+import org.arquillian.cube.spi.metadata.CubeMetadata;
+
+public abstract class BaseCube<T> implements Cube<T> {
+    private Map<Class<? extends CubeMetadata>, Object> metadata = new HashMap<>();
 
     @Override
-    public boolean hasMetadata(Class<?> type) {
+    public <X extends CubeMetadata> boolean hasMetadata(Class<X> type) {
         return metadata.containsKey(type);
     }
 
     @Override
-    public void addMetadata(Object type) {
-        metadata.put(type.getClass(), type);
+    public <X extends CubeMetadata> void addMetadata(Class<X> type, X impl) {
+        metadata.put(type, impl);
     }
 
     @Override
-    public <T> T getMetadata(Class<T> type) {
-        return (T) metadata.get(type);
+    @SuppressWarnings("unchecked")
+    public <X extends CubeMetadata> X getMetadata(Class<X> type) {
+        return (X) metadata.get(type);
     }
 }

--- a/spi/src/main/java/org/arquillian/cube/spi/Cube.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/Cube.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.arquillian.cube.ChangeLog;
 import org.arquillian.cube.TopContainer;
+import org.arquillian.cube.spi.metadata.CubeMetadata;
 
 public interface Cube<T> {
 
@@ -46,17 +47,9 @@ public interface Cube<T> {
 
     T configuration();
 
-    boolean hasMetadata(Class<?> type);
+    <X extends CubeMetadata> boolean hasMetadata(Class<X> type);
 
-    void addMetadata(Object type);
+    <X extends CubeMetadata> void addMetadata(Class<X> type, X impl);
 
-    <T> T getMetadata(Class<T> type);
-
-    List<ChangeLog> changesOnFilesystem(String cubeId);
-
-    void copyFileDirectoryFromContainer(String cubeId, String from, String to);
-
-    void copyLog(String cubeId, boolean follow, boolean stdout, boolean stderr, boolean timestamps, int tail, OutputStream outputStream);
-    
-    TopContainer top(String cubeId);
+    <X extends CubeMetadata> X getMetadata(Class<X> type);
 }

--- a/spi/src/main/java/org/arquillian/cube/spi/CubeRegistry.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/CubeRegistry.java
@@ -2,6 +2,8 @@ package org.arquillian.cube.spi;
 
 import java.util.List;
 
+import org.arquillian.cube.spi.metadata.CubeMetadata;
+
 public interface CubeRegistry {
 
     void addCube(Cube<?> cube);
@@ -12,7 +14,7 @@ public interface CubeRegistry {
 
     void removeCube(String id);
 
-    List<Cube<?>> getByMetadata(Class<?> metadata);
+    List<Cube<?>> getByMetadata(Class<? extends CubeMetadata> metadata);
 
     List<Cube<?>> getCubes();
 }

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/CanCopyFromContainer.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/CanCopyFromContainer.java
@@ -1,0 +1,10 @@
+package org.arquillian.cube.spi.metadata;
+
+import java.io.OutputStream;
+
+public interface CanCopyFromContainer extends CubeMetadata {
+
+    void copyDirectory(String from, String to);
+
+    void copyLog(boolean follow, boolean stdout, boolean stderr, boolean timestamps, int tail, OutputStream outputStream);
+}

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/CanSeeChangesOnFilesystem.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/CanSeeChangesOnFilesystem.java
@@ -1,0 +1,10 @@
+package org.arquillian.cube.spi.metadata;
+
+import java.util.List;
+
+import org.arquillian.cube.ChangeLog;
+
+public interface CanSeeChangesOnFilesystem extends CubeMetadata {
+
+    List<ChangeLog> changes();
+}

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/CanSeeTop.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/CanSeeTop.java
@@ -1,0 +1,8 @@
+package org.arquillian.cube.spi.metadata;
+
+import org.arquillian.cube.TopContainer;
+
+public interface CanSeeTop extends CubeMetadata {
+
+    TopContainer top();
+}

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/CubeMetadata.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/CubeMetadata.java
@@ -1,0 +1,5 @@
+package org.arquillian.cube.spi.metadata;
+
+public interface CubeMetadata {
+
+}

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/IsBuildable.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/IsBuildable.java
@@ -1,6 +1,6 @@
 package org.arquillian.cube.spi.metadata;
 
-public class IsBuildable {
+public class IsBuildable implements CubeMetadata {
 
     private String templatePath;
 

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/IsContainerObject.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/IsContainerObject.java
@@ -1,6 +1,6 @@
 package org.arquillian.cube.spi.metadata;
 
-public class IsContainerObject {
+public class IsContainerObject implements CubeMetadata {
 
     private Class<?> testClass;
 


### PR DESCRIPTION
* Introduce CubeMetadata interface to bind all Metadata objects

Update Cube interface:

    <X extends CubeMetadata> boolean hasMetadata(Class<X> type);
    <X extends CubeMetadata> void addMetadata(Class<X> type, X impl);
    <X extends CubeMetadata> X getMetadata(Class<X> type);

Move the following methods from the Cube interface:

* copyFileDirectoryFromContainer
* changesOnFilesystem
* copyLog
* top

To the new Metadata objects:

* CanCopyFileDirectoryFromContainer (impl CopyFileDirectoryFromContainer)
* CanSeeChangesOnFilesystem (impl ChangesOnFilesystem)
* CanCopyLog (impl CopyLog)
* CanSeeTop (impl GetTop)

fixes #246
fixes #247