### PR TITLE
Add support for predefined Polling ports

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
@@ -1,6 +1,8 @@
 package org.arquillian.cube.docker.impl.await;
 
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
@@ -31,6 +33,7 @@ public class PollingAwaitStrategy implements AwaitStrategy {
 
     private DockerClientExecutor dockerClientExecutor;
     private Cube<?> cube;
+    private List<Integer> ports = null;
 
     public PollingAwaitStrategy(Cube<?> cube, DockerClientExecutor dockerClientExecutor, Await params) {
         this.cube = cube;
@@ -45,6 +48,10 @@ public class PollingAwaitStrategy implements AwaitStrategy {
 
         if(params.getType() != null) {
             this.type = params.getType();
+        }
+
+        if(params.getPorts() != null) {
+            this.ports = params.getPorts();
         }
     }
 
@@ -83,6 +90,10 @@ public class PollingAwaitStrategy implements AwaitStrategy {
         return type;
     }
 
+    public List<Integer> getPorts() {
+        return ports;
+    }
+
     @Override
     public boolean await() {
         HasPortBindings portBindings = cube.getMetadata(HasPortBindings.class);
@@ -91,7 +102,11 @@ public class PollingAwaitStrategy implements AwaitStrategy {
             return true;
         }
 
-        for (Integer port : portBindings.getBoundPorts()) {
+        Collection<Integer> pingPorts = this.ports;
+        if(ports == null) {
+            pingPorts = portBindings.getBoundPorts();
+        }
+        for (Integer port : pingPorts) {
             switch(this.type) {
                 case "ping": {
                     PortAddress mapping = portBindings.getMappedAddress(port);

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.docker.impl.await;
 
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -115,6 +116,21 @@ public class AwaitStrategyTest {
         AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
+    }
+
+    @Test
+    public void should_create_polling_await_strategy_with_specific_port() {
+
+        Await await = new Await();
+        await.setStrategy("polling");
+        await.setPorts(Arrays.asList(80));
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
+
+        assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
+        assertThat(((PollingAwaitStrategy)strategy).getPorts(), hasItems(80));
     }
 
     @Test


### PR DESCRIPTION
In some cases the Container might bind ports that are not
listened to by the started process during startup.

Allow PollingStrategy to take a list of Ports to override
the configured ports.