### PR TITLE
Expose Container internal IP in HasPortBindings

### DIFF
--- a/core/src/test/java/org/arquillian/cube/impl/util/TestPortBindings.java
+++ b/core/src/test/java/org/arquillian/cube/impl/util/TestPortBindings.java
@@ -43,6 +43,11 @@ public class TestPortBindings implements HasPortBindings {
     }
 
     @Override
+    public String getInternalIP() {
+        return null;
+    }
+
+    @Override
     public Set<Integer> getContainerPorts() {
         return Collections.unmodifiableSet(containerPorts);
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
@@ -211,6 +211,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
         private final Set<Integer> containerPorts;
         private final Set<Integer> boundPorts;
         private String containerIP;
+        private String internalIP;
 
         private PortBindings() {
             this.mappedPorts = new HashMap<Integer, PortAddress>();
@@ -239,6 +240,11 @@ public class DockerCube extends BaseCube<CubeContainer> {
         }
 
         @Override
+        public String getInternalIP() {
+            return internalIP;
+        }
+
+        @Override
         public Set<Integer> getContainerPorts() {
             return Collections.unmodifiableSet(containerPorts);
         }
@@ -262,6 +268,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
         private synchronized void containerStarted() {
             final Binding bindings = bindings();
             containerIP = bindings.getIP();
+            internalIP = bindings.getInternalIP();
             for (PortBinding portBinding : bindings.getPortBindings()) {
                 final int exposedPort = portBinding.getExposedPort();
                 final Integer boundPort = portBinding.getBindingPort();

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/BindingUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/BindingUtil.java
@@ -8,6 +8,7 @@ import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.Binding;
 
 import com.github.dockerjava.api.command.InspectContainerResponse;
+import com.github.dockerjava.api.command.InspectContainerResponse.NetworkSettings;
 import com.github.dockerjava.api.model.ContainerConfig;
 import com.github.dockerjava.api.model.ExposedPort;
 import com.github.dockerjava.api.model.HostConfig;
@@ -23,7 +24,13 @@ public final class BindingUtil {
         InspectContainerResponse inspectResponse = executor.getDockerClient().inspectContainerCmd( cubeId ).exec();
 
         String dockerIp = getDockerServerIp(executor);
-        Binding binding = new Binding(dockerIp);
+        String inernalIp = null;
+        NetworkSettings networkSettings = inspectResponse.getNetworkSettings();
+        if(networkSettings != null) {
+            inernalIp = networkSettings.getIpAddress();
+        }
+
+        Binding binding = new Binding(dockerIp, inernalIp);
 
         HostConfig hostConfig = inspectResponse.getHostConfig();
         if(hostConfig.getPortBindings() != null) {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -248,6 +248,11 @@ public class BuildablePodCube extends BaseCube<Void> {
         }
 
         @Override
+        public String getInternalIP() {
+            return null;
+        }
+
+        @Override
         public Set<Integer> getContainerPorts() {
             return Collections.unmodifiableSet(containerPorts);
         }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
@@ -138,6 +138,11 @@ public class ServiceCube extends BaseCube<Void> {
         }
 
         @Override
+        public String getInternalIP() {
+            return null;
+        }
+
+        @Override
         public Set<Integer> getContainerPorts() {
             return Collections.unmodifiableSet(containerPorts);
         }

--- a/spi/src/main/java/org/arquillian/cube/spi/Binding.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/Binding.java
@@ -9,8 +9,15 @@ public class Binding {
 
     public Set<PortBinding> bindings;
 
+    private String internalIp;
+
     public Binding(String ip) {
+        this(ip, null);
+    }
+
+    public Binding(String ip, String internalIp) {
         this.ip = ip;
+        this.internalIp = internalIp;
         this.bindings = new HashSet<PortBinding>();
     }
 
@@ -32,6 +39,10 @@ public class Binding {
         }
 
         return null;
+    }
+
+    public String getInternalIP() {
+        return internalIp;
     }
 
     /**

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/HasPortBindings.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/HasPortBindings.java
@@ -28,6 +28,12 @@ public interface HasPortBindings extends CubeMetadata {
     String getContainerIP();
 
     /**
+     * @return the container's internal IP address, may be null if the container has not
+     *         been bound to an IP. The internal ip is as seen by the Host or other containers.
+     */
+    String getInternalIP();
+
+    /**
      * @return list of configured container ports.
      */
     Set<Integer> getContainerPorts();


### PR DESCRIPTION
Allow to see options for Container to Container communication from the client
side.