### PR TITLE
Update distro names

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerMachineDistro.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerMachineDistro.java
@@ -5,10 +5,9 @@ import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 
 public enum DockerMachineDistro {
 
-    LINUX(new OperatingSystemFamily[] {OperatingSystemFamily.LINUX}, "docker-machine_linux-amd64"),
-    OSX(new OperatingSystemFamily[] {OperatingSystemFamily.MAC}, "docker-machine_darwin-amd64"),
-    //WIN_32(new OperatingSystemFamily[] {OperatingSystemFamily.WINDOWS}, "docker-machine_windows-386.exe"),
-    WIN_64(new OperatingSystemFamily[] {OperatingSystemFamily.WINDOWS}, "docker-machine_windows-amd64.exe");
+    LINUX(new OperatingSystemFamily[] {OperatingSystemFamily.LINUX}, "docker-machine-Linux-x86_64"),
+    OSX(new OperatingSystemFamily[] {OperatingSystemFamily.MAC}, "docker-machine-Darwin-x86_64"),
+    WIN_64(new OperatingSystemFamily[] {OperatingSystemFamily.WINDOWS}, "docker-machine-Windows-x86_64.exe");
 
     private OperatingSystemFamily[] osFamily;
 


### PR DESCRIPTION
From version 0.5.6 to 0.6.0, distribution packages have changed.

See gh-296