### PR TITLE
resolves issue #308 by replacing platform dependant nio Paths by java…

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/Top.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/Top.java
@@ -1,43 +1,41 @@
 package org.arquillian.cube.docker.impl.util;
 
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
+import java.io.File;
 
 public class Top {
 
     static final String DOCKER_SOCK = "docker.sock";
-    static final String DOCKERINIT = ".dockerinit";
-    static final String DOCKERENV = ".dockerenv";
+    static final String DOCKERINIT  = ".dockerinit";
+    static final String DOCKERENV   = ".dockerenv";
 
     public Top() {
         super();
-        this.dockerEnvPath = Paths.get(rootDockerFile, DOCKERENV);
-        this.dockerInitPath = Paths.get(rootDockerFile, DOCKERINIT);
-        this.dockerSocketFile = Paths.get(rootDockerSocket, DOCKER_SOCK);
+        this.dockerEnvPath = new File(rootDockerFile, DOCKERENV);
+        this.dockerInitPath = new File(rootDockerFile, DOCKERINIT);
+        this.dockerSocketFile = new File(rootDockerSocket, DOCKER_SOCK);
     }
-
     public Top(String rootDockerFile, String rootDockerSocket) {
         super();
         this.rootDockerFile = rootDockerFile;
         this.rootDockerSocket = rootDockerSocket;
-        this.dockerEnvPath = Paths.get(rootDockerFile, DOCKERENV);
-        this.dockerInitPath = Paths.get(rootDockerFile, DOCKERINIT);
-        this.dockerSocketFile = Paths.get(rootDockerSocket, DOCKER_SOCK);
+        this.dockerEnvPath = new File(rootDockerFile, DOCKERENV);
+        this.dockerInitPath = new File(rootDockerFile, DOCKERINIT);
+        this.dockerSocketFile = new File(rootDockerSocket, DOCKER_SOCK);
     }
 
-    private String rootDockerFile = "/";
+
+    private String rootDockerFile   = "/";
     private String rootDockerSocket = "/var/run/";
 
-    private final Path dockerEnvPath;
-    private final Path dockerInitPath;
-    private final Path dockerSocketFile;
+    private final File dockerEnvPath;
+    private final File dockerInitPath;
+    private final File dockerSocketFile;
 
     /**
      * Checks if current code is being executed inside Docker or not.
      * @return True if code is being executed inside Docker, false otherwise.
      */
     public boolean isSpinning() {
-        return Files.exists(dockerEnvPath) && Files.exists(dockerInitPath) && Files.exists(dockerSocketFile);
+        return dockerEnvPath.exists() && dockerInitPath.exists() && dockerSocketFile.exists();
     }
 }


### PR DESCRIPTION
….io.File in Top.java

On Windows, the nio API interprets Linux absolute URL "/.dockerenv" as a server host causing
the exception: "java.nio.file.InvalidPathException: UNC path is missing sharename: /\.dockerenv".
The commit fixes the issue by using java.io.File which resolves absolute paths independently
from the operating system.