### PR TITLE
increase idle timeout for port forwarder

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/PortForwarder.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/PortForwarder.java
@@ -74,7 +74,7 @@ public final class PortForwarder implements Closeable {
                     .set(Options.TCP_NODELAY, true)
                     .set(Options.KEEP_ALIVE, true)
                     .set(Options.SSL_PROTOCOL, "TLS")
-                    .set(UndertowOptions.IDLE_TIMEOUT, 60000)
+                    .set(UndertowOptions.IDLE_TIMEOUT, 1200000)
                     //.set(Options.CORK, true)
                     .getMap();
             // XXX: hard-coding trust all certs


### PR DESCRIPTION
Some environments may take a long time to come up (e.g. s2i build) and the http connection for the port forwarder was being timed out.