### PR TITLE
introduction of dockerTlsVerify property

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
@@ -24,6 +24,7 @@ public class CubeDockerConfiguration {
     private static final String PASSWORD =  "password";
     private static final String EMAIL = "email";
     public static final String CERT_PATH = "certPath";
+    public static final String TLS_VERIFY = "tlsVerify";
     private static final String DOCKER_CONTAINERS = "dockerContainers";
     private static final String DOCKER_CONTAINERS_FILE = "dockerContainersFile";
     private static final String DOCKER_CONTAINERS_FILES = "dockerContainersFiles";
@@ -51,6 +52,7 @@ public class CubeDockerConfiguration {
     private String password;
     private String email;
     private String certPath;
+    private boolean tlsVerify;
     private String dockerServerIp;
     private DefinitionFormat definitionFormat = DefinitionFormat.CUBE;
     private boolean dockerInsideDockerResolution = true;
@@ -106,6 +108,11 @@ public class CubeDockerConfiguration {
     public String getCertPath() {
         return certPath;
     }
+
+    public boolean getTlsVerify() {
+        return tlsVerify;
+    }
+
     //this property is resolved in CubeConfigurator class.
     public String getDockerServerIp() {
         return dockerServerIp;
@@ -176,6 +183,10 @@ public class CubeDockerConfiguration {
 
         if(map.containsKey(CERT_PATH)) {
             cubeConfiguration.certPath = map.get(CERT_PATH);
+        }
+
+        if (map.containsKey(TLS_VERIFY)) {
+            cubeConfiguration.tlsVerify = Boolean.parseBoolean(map.get(TLS_VERIFY));
         }
 
         if (map.containsKey(DOCKER_REGISTRY)) {
@@ -310,6 +321,9 @@ public class CubeDockerConfiguration {
         if (certPath != null) {
             content.append("  ").append(CERT_PATH).append(" = ").append(certPath).append(SEP);
         }
+
+        content.append("  ").append(TLS_VERIFY).append(" = ").append(tlsVerify).append(SEP);
+
         if (dockerServerIp != null) {
             content.append("  ").append(DOCKER_SERVER_IP).append(" = ").append(dockerServerIp).append(SEP);
         }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -158,6 +158,8 @@ public class DockerClientExecutor {
             configBuilder.withDockerCertPath(HomeResolverUtil.resolveHomeDirectoryChar(cubeConfiguration.getCertPath()));
         }
 
+        configBuilder.withDockerTlsVerify(cubeConfiguration.getTlsVerify());
+
         this.dockerClientConfig = configBuilder.build();
         this.cubeConfiguration = cubeConfiguration;
 


### PR DESCRIPTION
@lordofthejars @aslakknutsen 

this works for me, both for machine and natively, could you test boot2docker?

It is true by default. That means that you do not need to set this when you are on Mac or Windows. In case you are on Linux, you would have to explicitly set it to false.

There are not tests for it. It would be cool if you could add them where necessary. I do not know how to deal with it.