### PR TITLE
Restore ability to connect Docker server without TLS

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -201,7 +201,7 @@ Let's see valid attributes:
 |Version of REST API provided by_Docker_ server. You should check on the _Docker_ site which version of REST API is shipped inside installed _Docker_ service. This field is not mandatory and if it's not set the default provided version from _docker-java_ will be used.
 
 |serverUri
-|Uri of _Docker_ server. If the _Docker_ server is running natively on Linux then this will be an URI pointing to _localhost_ docker host but if you are using _Boot2Docker_ or a remote _Docker_ server then the URI should be changed to point to the _Docker_ remote _URI_. It can be a unix socket URI as well in case you are running _Docker_ on Linux (+unix:///var/run/docker.sock+). Also you can read at <<automatic-resolution, this section>> about automatic resolution of serverUri parameter. Also you can use `DOCKER_HOST` java property or system environment to set this parameter.
+|Uri of _Docker_ server. If the _Docker_ server is running natively on Linux then this will be an URI pointing to _localhost_ docker host but if you are using _Boot2Docker_ or a remote _Docker_ server then the URI should be changed to point to the _Docker_ remote _URI_. It can be a unix socket URI as well in case you are running _Docker_ on Linux (+unix:///var/run/docker.sock+). If the URI has `http://` or `https://` scheme, the `tlsVerify` attribute will be set by Cube to `false` or `true` respectively. Also you can read at <<automatic-resolution, this section>> about automatic resolution of serverUri parameter. Also you can use `DOCKER_HOST` java property or system environment to set this parameter.
 
 |dockerRegistry
 |Sets the location of Docker registry. Default value is the official _Docker_ registry located at https://registry.hub.docker.com
@@ -230,8 +230,11 @@ Let's see valid attributes:
 |autoStartContainers
 |Cube will normally start a _Docker_ container when it has the same name as an active _Arquillian_ container and all the containers defined as links to this container, so basically _Cube_ resolves all the container depdendencies as well e.g. a database where the application saves data, or mail server where application sends an email. That works for things that are _DeployableContainer_'s. For any other container services that might not have a link to the _DeployableContainer_, e.g. a monitor, you can use the _autoStartContainers_ option to define which _Docker_ containers to automatically start up. The option takes a comma separated list of _Docker_ container ids. e.g. _monitor_. *Arquillian Cube* will attempt to start the containers in parallel if possible as well as start any linked containers. Also if you need to start several images, instead of adding them as CSV, you can use a regular expression by prefixing with `regexp:`, for example setting the property to `regexp:a(.*)` would start all container ids starting with _a_.
 
+|tlsVerify
+|Boolean to set if Cube should connect to Docker server with TLS. This attribute will be ignored if `serverUri` attribute starts with `http://` or `https://`.
+
 |certPath
-|Path where certificates are stored. If you are not using _https_ protocol this parameter is not required. This parameter accepts starting with ~ as home directory
+|Path where certificates are stored. If you are not using _https_ protocol this parameter is not required. This parameter accepts starting with ~ as home directory.
 
 |boot2dockerPath
 |Sets the full location (and program name) of _boot2docker_. For example +/opt/boot2dockerhome/boot2docker+.
@@ -568,13 +571,13 @@ This parameter is not mandatory and in case you don't set it, _Arquillian Cube_ 
 |unix:///var/run/docker.sock
 
 |Windows
-|https://dockerHost:2376
+|tcp://dockerHost:2376
 
 |MacOS
-|https://dockerHost:2376
+|tcp://dockerHost:2376
 
 |Docker Machine
-|https://dockerHost:2376
+|tcp://dockerHost:2376
 |===
 
 [[boot2docker]]

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -1,15 +1,18 @@
 package org.arquillian.cube.docker.impl.client;
 
 import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.endsWith;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
+import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.ByteArrayOutputStream;
-import java.io.File;
 import java.io.PrintStream;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -22,6 +25,8 @@ import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.spi.CubeConfiguration;
+import org.hamcrest.Matcher;
+import org.hamcrest.core.StringEndsWith;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
@@ -32,9 +37,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CubeConfiguratorTest extends AbstractManagerTestBase {
@@ -50,8 +52,10 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
     @Mock
     ArquillianDescriptor arquillianDescriptor;
+    
     @Mock
     ExtensionDef extensionDef;
+    
     @Mock
     Top top;
 
@@ -82,7 +86,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     @Test
     public void shouldNotChangeServerUriInCaseODockerInsideDockerIfItIsDisabled() {
         Map<String, String> config = new HashMap<>();
-        config.put(CubeDockerConfiguration.DOCKER_URI, "https://dockerHost:22222");
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
         config.put(CubeDockerConfiguration.DIND_RESOLUTION, "false");
 
         when(extensionDef.getExtensionProperties()).thenReturn(config);
@@ -92,28 +96,27 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(top.isSpinning()).thenReturn(true);
 
         fire(new CubeConfiguration());
-        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.1:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.1:22222"));
     }
 
     @Test
     public void shouldUseBoot2DockerIfDockerHostIsSetOnServerURIByDefault() {
         Map<String, String> config = new HashMap<>();
-        config.put(CubeDockerConfiguration.DOCKER_URI, "https://dockerHost:22222");
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
 
         when(extensionDef.getExtensionProperties()).thenReturn(config);
         when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
         when(commandLineExecutor.execCommand("boot2docker", "ip")).thenReturn("192.168.0.1");
 
         fire(new CubeConfiguration());
-        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.1:22222"));
-        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(
-                File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm")));
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.1:22222"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultBootToDockerCertPath()));
     }
 
     @Test
     public void shouldUseDockerMachineIfDockerHostIsSetOnServerURIAndMachineNameIsSet() {
         Map<String, String> config = new HashMap<>();
-        config.put(CubeDockerConfiguration.DOCKER_URI, "https://dockerHost:22222");
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
         config.put(CubeDockerConfiguration.DOCKER_MACHINE_NAME, "dev");
 
         when(extensionDef.getExtensionProperties()).thenReturn(config);
@@ -125,18 +128,14 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.0.2");
 
         fire(new CubeConfiguration());
-        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222"));
-        assertThat(config,
-                hasEntry(is(CubeDockerConfiguration.CERT_PATH),
-                        endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines"
-                                + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
-
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultDockerMachineCertPath()));
     }
 
     @Test
     public void shouldStartDockerMachineIfItIsStoppedAndMachineNameIsSet() {
         Map<String, String> config = new HashMap<>();
-        config.put(CubeDockerConfiguration.DOCKER_URI, "https://dockerHost:22222");
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
         config.put(CubeDockerConfiguration.DOCKER_MACHINE_NAME, "dev");
 
         when(extensionDef.getExtensionProperties()).thenReturn(config);
@@ -148,11 +147,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(commandLineExecutor.execCommand("docker-machine", "ip", "dev")).thenReturn("192.168.0.2");
 
         fire(new CubeConfiguration());
-        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222"));
-        assertThat(config,
-                hasEntry(is(CubeDockerConfiguration.CERT_PATH),
-                        endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines"
-                                + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultDockerMachineCertPath()));
         verify(commandLineExecutor, times(1)).execCommand("docker-machine", "start", "dev");
     }
 
@@ -173,12 +169,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.99.100:2376"));
-        assertThat(config,
-                hasEntry(is(CubeDockerConfiguration.CERT_PATH),
-                        endsWith(File.separator + ".docker" + File.separator + "machine" + File.separator + "machines"
-                                + File.separator + config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME))));
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_MACHINE_NAME, "dev"));
-
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultDockerMachineCertPath()));
     }
 
     // Only works in case of running in MACOS or Windows since by default in
@@ -251,7 +243,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     }
 
     @Test
-    public void dockerUriTcpShouldBeReplacedToHttpsInCaseOfDockerMachine() {
+    public void tlsVerifyShouldBeTrueInCaseOfDockerMachine() {
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
         config.put(CubeDockerConfiguration.DOCKER_MACHINE_NAME, "dev");
@@ -266,10 +258,12 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "true"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultDockerMachineCertPath()));
     }
 
     @Test
-    public void dockerUriTcpShouldBeReplacedToHttpInCaseOfSingleHost() {
+    public void tlsVerifyShouldBeTrueInCaseOfNotSetAndDockerHostTagNotPresent() {
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222");
 
@@ -278,10 +272,43 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "true"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultBootToDockerCertPath()));
+    }
+    
+    @Test
+    public void tlsVerifyShouldBeTrueInCaseOfSetToFalseAndDockerHostTagNotPresent() {
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222");
+        config.put(CubeDockerConfiguration.TLS_VERIFY, "false");
+
+        when(extensionDef.getExtensionProperties()).thenReturn(config);
+        when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
+
+        fire(new CubeConfiguration());
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "false"));
+        assertThat(config, not(hasKey(CubeDockerConfiguration.CERT_PATH)));
     }
 
     @Test
-    public void dockerUriTcpShouldBeReplacedToHttpsInCaseOfDockerHostTagPresent() {
+    public void tlsVerifyShouldBeFalseInCaseOfSetToFalseAndDockerHostTagPresent() {
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
+        config.put(CubeDockerConfiguration.TLS_VERIFY, "false");
+
+        when(extensionDef.getExtensionProperties()).thenReturn(config);
+        when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
+        when(commandLineExecutor.execCommand("boot2docker", "ip")).thenReturn("192.168.0.2");
+
+        fire(new CubeConfiguration());
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "false"));
+        assertThat(config, not(hasKey(CubeDockerConfiguration.CERT_PATH)));
+    }
+
+    @Test
+    public void tlsVerifyShouldBeTrueInCaseOfNotSetAndDockerHostTagPresent() {
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
 
@@ -291,10 +318,12 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "true"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultBootToDockerCertPath()));
     }
 
     @Test
-    public void dockerUriTcpShouldBeReplacedToHttpsInCaseOfCertPathPresent() {
+    public void tlsVerifyShouldBeTrueInCaseOfCertPathPresent() {
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
         config.put(CubeDockerConfiguration.CERT_PATH, "~/.ssh");
@@ -305,6 +334,66 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "true"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), pathEndsWith(".ssh")));
+    }
+
+    @Test
+    public void tlsVerifyShouldBeTrueInCaseOfHttpsServerUri() {
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222");
+
+        when(extensionDef.getExtensionProperties()).thenReturn(config);
+        when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
+
+        fire(new CubeConfiguration());
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "true"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultBootToDockerCertPath()));
+    }
+
+    @Test
+    public void tlsVerifyShouldBeTrueInCaseOfSetToFalseAndHttpsServerUri() {
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.2:22222");
+        config.put(CubeDockerConfiguration.TLS_VERIFY, "false");
+
+        when(extensionDef.getExtensionProperties()).thenReturn(config);
+        when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
+
+        fire(new CubeConfiguration());
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "true"));
+        assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultBootToDockerCertPath()));
+    }
+
+    @Test
+    public void tlsVerifyShouldBeFalseInCaseOfHttpServerUri() throws Exception {
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "http://192.168.0.2:22222");
+        
+        when(extensionDef.getExtensionProperties()).thenReturn(config);
+        when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
+        
+        fire(new CubeConfiguration());
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "false"));
+        assertThat(config, not(hasKey(CubeDockerConfiguration.CERT_PATH)));
+    }
+    
+    @Test
+    public void tlsVerifyShouldBeFalseInCaseOfSetToTrueAndHttpServerUri() {
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "http://192.168.0.2:22222");
+        config.put(CubeDockerConfiguration.TLS_VERIFY, "true");
+
+        when(extensionDef.getExtensionProperties()).thenReturn(config);
+        when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
+
+        fire(new CubeConfiguration());
+        assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.2:22222"));
+        assertThat(config, hasEntry(CubeDockerConfiguration.TLS_VERIFY, "false"));
+        assertThat(config, not(hasKey(CubeDockerConfiguration.CERT_PATH)));
     }
 
     @Test
@@ -314,7 +403,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
             System.setProperty(CubeDockerConfigurator.DOCKER_HOST, "tcp://127.0.0.1:22222");
 
             Map<String, String> config = new HashMap<>();
-            config.put(CubeDockerConfiguration.DOCKER_URI, "https://dockerHost:22222");
+            config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://dockerHost:22222");
 
             when(extensionDef.getExtensionProperties()).thenReturn(config);
             when(arquillianDescriptor.extension("docker")).thenReturn(extensionDef);
@@ -324,9 +413,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
             when(commandLineExecutor.execCommand("boot2docker", "ip")).thenReturn("192.168.0.1");
 
             fire(new CubeConfiguration());
-            assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "https://192.168.0.1:22222"));
-            assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), endsWith(
-                    File.separator + ".boot2docker" + File.separator + "certs" + File.separator + "boot2docker-vm")));
+            assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.1:22222"));
+            assertThat(config, hasEntry(is(CubeDockerConfiguration.CERT_PATH), defaultBootToDockerCertPath()));
             assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_SERVER_IP, "192.168.0.1"));
         } finally {
             if (originalVar != null) {
@@ -358,4 +446,30 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         System.setOut(old);
         assertThat(baos.toString(), containsString("CubeDockerConfiguration:"));
     }
+    
+    private static Matcher<String> defaultDockerMachineCertPath() {
+        return pathEndsWith(".docker/machine/machines/dev");
+    }
+    
+    private static Matcher<String> defaultBootToDockerCertPath() {
+        return pathEndsWith(".boot2docker/certs/boot2docker-vm");
+    }
+    
+    private static Matcher<String> pathEndsWith(String suffix) {
+        return new PathStringEndsWithMatcher(suffix);
+    }
+    
+    private static class PathStringEndsWithMatcher extends StringEndsWith {
+
+        public PathStringEndsWithMatcher(String suffix) {
+            super(suffix);
+        }
+        
+        @Override
+        protected boolean evalSubstringOf(String s) {
+            return Paths.get(s).endsWith(substring);
+        }
+        
+    }
+
 }


### PR DESCRIPTION
With upgraded to docker-java 3.0.0-RC3 (PR #295) Cube doesn't accept `http://` and `https://` in `serverUri` parameter anymore. PR #325 added `tlsVerify` parameter but value set by user in arquillian.xml file is overwritten via automatic resolution. The net result is that you can't connect to remote Docker host without TLS.

This PR brings back http and https scheme support and allow manual setting of tlsVerify attribute as well. (Of course tcp and unix schemes remain supported.)

In case the serverUri has http or https scheme, the tlsVerify attribute is set automatically to false or true respectively. Also the URI schema is changed to `tcp://` to make docker-java happy.
