### PR TITLE
Add log scanning await strategy

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -198,7 +198,7 @@ Let's see valid attributes:
 [cols="2*"]
 |===
 |serverVersion
-|Version of REST API provided by_Docker_ server. You should check on the _Docker_ site which version of REST API is shipped inside installed _Docker_ service. This field is not mandatory and if it's not set the default provided version from _docker-java_ will be used.
+|Version of REST API provided by _Docker_ server. You should check on the _Docker_ site which version of REST API is shipped inside installed _Docker_ service. This field is not mandatory and if it's not set the default provided version from _docker-java_ will be used.
 
 |serverUri
 |Uri of _Docker_ server. If the _Docker_ server is running natively on Linux then this will be an URI pointing to _localhost_ docker host but if you are using _Boot2Docker_ or a remote _Docker_ server then the URI should be changed to point to the _Docker_ remote _URI_. It can be a unix socket URI as well in case you are running _Docker_ on Linux (+unix:///var/run/docker.sock+). If the URI has `http://` or `https://` scheme, the `tlsVerify` attribute will be set by Cube to `false` or `true` respectively. Also you can read at <<automatic-resolution, this section>> about automatic resolution of serverUri parameter. Also you can use `DOCKER_HOST` java property or system environment to set this parameter.
@@ -382,6 +382,7 @@ native:: it uses *wait* command. In this case current thread is waiting until th
 polling:: in this case a polling (with _ping_ or _ss_ command) is executed for 5 seconds against all exposed ports. When communication to all exposed ports is acknowledged, the container is considered to be up. This approach is the one to be used in case of services started in foreground. By default _polling_ executes _ss_ command inside the running container to know if the server is already running. You can use a _ping_ from client by setting +type+ attribute to +ping+; Note that _ping_ only works if you are running _Docker_ daemon on +localhost+. In almost all cases the default behaviour matches all scenarios. If it is not specified, this is the default strategy.
 static:: similar to _polling_ but it uses the host ip and specified list of ports provided as configuration parameter. This can be used in case of using _Boot2Docker_.
 sleeping:: sleeps current thread for the specified amount of time. You can specify the time in seconds or milliseconds.
+log:: it looking for a specified pattern in container log to detect service startup. This can be used when there is no port to connect or connecting to the port successfully doesn't mean the service is fully initialized.
 
 By default in case you don't specify any _await_ strategy, polling with _ss_ command is used.
 
@@ -432,6 +433,26 @@ tomcat:
     sleepTime: 200 s #1
 ----
 <1> Optional parameter to configure sleeping time between poling. You can set in seconds using _s_ or miliseconds using _ms_. By default time unit is miliseconds and value 500.
+
+[source, yaml]
+.Example log
+----
+tomcat:
+  image: tutum/tomcat:7.0
+  exposedPorts: [8089/tcp]
+  await:
+    strategy: log
+    match: 'Server startup' #1
+    stdOut: true #2
+    stdErr: true #3
+    sleepPollingTime: 200 s #4
+    iterations: 3 #5
+----
+<1> Mandatory parameter to configure the pattern that signals the service started. To use regular expression just prefix the pattern with `regexp:`.
+<2> Optional parameter to enable scanning of _standard output_ log. Default is true.
+<3> Optional parameter to enable scanning of _standard error_ log. Default is false.
+<4> Optional parameter to configure sleeping time between log downloading. You can set in seconds using _s_ or miliseconds using _ms_. By default time unit is miliseconds and value 500.
+<5> Optional parameter to configure number of retries to be done. By default 10 iterations are done.
 
 === Inferring exposedPorts from portBinding
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
@@ -22,9 +22,10 @@ public class AwaitStrategyFactory {
 
             if (await.getStrategy() != null) {
 
-                String strategy = ((String) await.getStrategy()).toLowerCase();
+                String strategy = await.getStrategy().toLowerCase();
                 switch(strategy) {
                     case PollingAwaitStrategy.TAG: return new PollingAwaitStrategy(cube, dockerClientExecutor, await);
+                    case LogScanningAwaitStrategy.TAG: return new LogScanningAwaitStrategy(cube, dockerClientExecutor, await);
                     case NativeAwaitStrategy.TAG: return new NativeAwaitStrategy(cube, dockerClientExecutor);
                     case StaticAwaitStrategy.TAG: return new StaticAwaitStrategy(cube, await);
                     case SleepingAwaitStrategy.TAG: return new SleepingAwaitStrategy(cube, await);

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/LogScanningAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/LogScanningAwaitStrategy.java
@@ -1,0 +1,173 @@
+package org.arquillian.cube.docker.impl.await;
+
+import java.text.DateFormat;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
+import java.util.regex.Pattern;
+
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.util.Ping;
+import org.arquillian.cube.docker.impl.util.PingCommand;
+import org.arquillian.cube.spi.Cube;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.api.model.Info;
+import com.github.dockerjava.core.async.ResultCallbackTemplate;
+
+public class LogScanningAwaitStrategy extends SleepingAwaitStrategyBase {
+
+    public static final String TAG = "log";
+        
+    private static final String REGEXP_PREFIX = "regexp:";
+    
+    private static final int DEFAULT_POLL_ITERATIONS = 10;
+    
+    private int pollIterations = DEFAULT_POLL_ITERATIONS;
+    
+    private boolean stdOut;
+    private boolean stdErr;
+    
+    private Cube<?> cube;
+    
+    private DockerClientExecutor dockerClientExecutor;
+    
+    private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
+    
+    private final LogMatcher matcher; 
+    
+    public LogScanningAwaitStrategy(Cube<?> cube, DockerClientExecutor dockerClientExecutor, Await params) {
+        super(params.getSleepPollingTime());
+        
+        this.cube = cube;
+        this.dockerClientExecutor = dockerClientExecutor;
+        
+        if (params.getIterations() != null) {
+            this.pollIterations = params.getIterations();
+        }
+        
+        this.stdOut = params.isStdOut();
+        this.stdErr = params.isStdErr();
+
+        if (params.getMatch().startsWith(REGEXP_PREFIX)) {
+            matcher = new RegexpLogMatcher(params.getMatch().substring(REGEXP_PREFIX.length()));
+        } else {
+            matcher = new ContainsLogMatcher(params.getMatch());
+        }
+    }
+    
+    public int getPollIterations() {
+        return pollIterations;
+    }
+    
+    public boolean isStdOut() {
+        return stdOut;
+    }
+
+    public boolean isStdErr() {
+        return stdErr;
+    }
+
+    @Override
+    public boolean await() {
+        final DockerClient client = dockerClientExecutor.getDockerClient();
+        
+        Info info = client.infoCmd().exec();
+        
+        int since = parseTimestamp(info.getSystemTime());
+        
+        final LogContainerResultCallback callback = new LogContainerResultCallback(since);
+        
+        return Ping.ping(pollIterations, getSleepTime(), getTimeUnit(), new PingCommand() {
+            @Override
+            public boolean call() {
+                try {
+                    client.logContainerCmd(cube.getId())
+                            .withStdOut(stdOut).withStdErr(stdErr)
+                            .withTimestamps(true).withSince(callback.getLastTimestamp())
+                            .exec(callback).awaitCompletion();
+                }
+                catch (InterruptedException e) {
+                    // do nothing
+                }
+                
+                return callback.isFound();
+            }
+        });
+    }
+    
+    private int parseTimestamp(String s) {
+        try {
+            return (int) dateFormat.parse(s.substring(0, s.indexOf('.'))).getTime() / 1000;
+        } catch (ParseException e) {
+            throw new IllegalArgumentException("Timestamp parse failure: " + s, e);
+        }
+    }
+    
+    private class LogContainerResultCallback extends ResultCallbackTemplate<LogContainerResultCallback, Frame> {
+        
+        private int lastTimestamp;
+        
+        private boolean found;
+        
+        public LogContainerResultCallback(int since) {
+            this.lastTimestamp = since;
+        }
+        
+        public int getLastTimestamp() {
+            return lastTimestamp;
+        }
+        
+        public boolean isFound() {
+            return found;
+        }
+
+        @Override
+        public void onNext(Frame item) {
+            String line = new String(item.getPayload());
+            lastTimestamp = parseTimestamp(line);
+            
+            if (!found) {
+                found = matcher.match(line);
+            }
+        }
+    }
+    
+    private interface LogMatcher {
+        
+        boolean match(String line);
+        
+    }
+    
+    private static final class ContainsLogMatcher implements LogMatcher {
+        
+        private String substring;
+        
+        public ContainsLogMatcher(String substring) {
+            this.substring = substring;
+        }
+
+        @Override
+        public boolean match(String line) {
+            return line.contains(substring);
+        }
+        
+    }
+    
+    private static final class RegexpLogMatcher implements LogMatcher {
+        
+        private Pattern regex; 
+        
+        public RegexpLogMatcher(String pattern) {
+            regex = Pattern.compile(pattern, Pattern.DOTALL);
+        }
+
+        @Override
+        public boolean match(String line) {
+            return regex.matcher(line).matches();
+        }
+        
+    }
+    
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
@@ -4,7 +4,6 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 
 import org.arquillian.cube.docker.impl.client.config.Await;
@@ -15,20 +14,16 @@ import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.metadata.HasPortBindings;
 import org.arquillian.cube.spi.metadata.HasPortBindings.PortAddress;
 
-public class PollingAwaitStrategy implements AwaitStrategy {
+public class PollingAwaitStrategy extends SleepingAwaitStrategyBase {
 
     private static final Logger log = Logger.getLogger(PollingAwaitStrategy.class.getName());
 
     public static final String TAG = "polling";
 
     private static final int DEFAULT_POLL_ITERATIONS = 10;
-    private static final int DEFAULT_SLEEP_POLL_TIME = 500;
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
     private static final String DEFAULT_POLL_TYPE = "sscommand";
 
     private int pollIterations = DEFAULT_POLL_ITERATIONS;
-    private int sleepPollTime = DEFAULT_SLEEP_POLL_TIME;
-    private TimeUnit timeUnit = DEFAULT_TIME_UNIT;
     private String type = DEFAULT_POLL_TYPE;
 
     private DockerClientExecutor dockerClientExecutor;
@@ -36,54 +31,26 @@ public class PollingAwaitStrategy implements AwaitStrategy {
     private List<Integer> ports = null;
 
     public PollingAwaitStrategy(Cube<?> cube, DockerClientExecutor dockerClientExecutor, Await params) {
+        super(params.getSleepPollingTime());
+        
         this.cube = cube;
         this.dockerClientExecutor = dockerClientExecutor;
-        if (params.getSleepPollingTime() != null) {
-            configurePollingTime(params.getSleepPollingTime());
-        }
 
         if (params.getIterations() != null) {
             this.pollIterations = params.getIterations();
         }
 
-        if(params.getType() != null) {
+        if (params.getType() != null) {
             this.type = params.getType();
         }
 
-        if(params.getPorts() != null) {
+        if (params.getPorts() != null) {
             this.ports = params.getPorts();
-        }
-    }
-
-    private void configurePollingTime(Object sleepTime) {
-        if(sleepTime instanceof Integer) {
-            this.sleepPollTime = (Integer) sleepTime;
-        } else {
-            String sleepTimeWithUnit = ((String) sleepTime).trim();
-            if(sleepTimeWithUnit.endsWith("ms")) {
-                this.timeUnit = TimeUnit.MILLISECONDS;
-            } else {
-                if(sleepTimeWithUnit.endsWith("s")) {
-                    this.timeUnit = TimeUnit.SECONDS;
-                    this.sleepPollTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf('s')).trim());
-                } else {
-                    this.timeUnit = TimeUnit.MILLISECONDS;
-                    this.sleepPollTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf("ms")).trim());
-                }
-            }
         }
     }
 
     public int getPollIterations() {
         return pollIterations;
-    }
-
-    public int getSleepPollTime() {
-        return sleepPollTime;
-    }
-
-    public TimeUnit getTimeUnit() {
-        return timeUnit;
     }
 
     public String getType() {
@@ -114,15 +81,16 @@ public class PollingAwaitStrategy implements AwaitStrategy {
                         throw new IllegalArgumentException("Can not use polling of type " + type + " on non externally bound port " + port);
                     }
                     log.fine(String.format("Pinging host %s and port %s with type", mapping.getIP(), mapping.getPort(), this.type));
-                    if (!Ping.ping(mapping.getIP(), mapping.getPort(), this.pollIterations, this.sleepPollTime,
-                            this.timeUnit)) {
+                    if (!Ping.ping(mapping.getIP(), mapping.getPort(), this.pollIterations, this.getSleepTime(),
+                            this.getTimeUnit())) {
                         return false;
                     }
                 }
 
                 break;
                 case "sscommand": {
-                    if(!Ping.ping(dockerClientExecutor, cube.getId(), resolveCommand("ss", port), this.pollIterations, this.sleepPollTime, this.timeUnit)) {
+                    if(!Ping.ping(dockerClientExecutor, cube.getId(), resolveCommand("ss", port),
+                            this.pollIterations, this.getSleepTime(), this.getTimeUnit())) {
                         return false;
                     }
                 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepingAwaitStrategy.java
@@ -1,61 +1,25 @@
 package org.arquillian.cube.docker.impl.await;
 
-import java.util.concurrent.TimeUnit;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.spi.Cube;
 
-public class SleepingAwaitStrategy implements AwaitStrategy {
+public class SleepingAwaitStrategy extends SleepingAwaitStrategyBase {
 
     private static final Logger log = Logger.getLogger(SleepingAwaitStrategy.class.getName());
 
     public static final String TAG = "sleeping";
 
-    private static final int DEFAULT_SLEEP_TIME = 500;
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
-
-    private int sleepTime = DEFAULT_SLEEP_TIME;
-    private TimeUnit timeUnit = DEFAULT_TIME_UNIT;
-
     public SleepingAwaitStrategy(Cube<?> cube, Await params) {
-        if (params.getSleepTime() != null) {
-            configureSleepingTime(params.getSleepTime());
-        }
-    }
-
-    private void configureSleepingTime(Object sleepTime) {
-        if(sleepTime instanceof Integer) {
-            this.sleepTime = (Integer) sleepTime;
-        } else {
-            String sleepTimeWithUnit = ((String) sleepTime).trim();
-            if(sleepTimeWithUnit.endsWith("ms")) {
-                this.timeUnit = TimeUnit.MILLISECONDS;
-            } else {
-                if(sleepTimeWithUnit.endsWith("s")) {
-                    this.timeUnit = TimeUnit.SECONDS;
-                    this.sleepTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf('s')).trim());
-                } else {
-                    this.timeUnit = TimeUnit.MILLISECONDS;
-                    this.sleepTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf("ms")).trim());
-                }
-            }
-        }
-    }
-
-    public int getSleepTime() {
-        return sleepTime;
-    }
-
-    public TimeUnit getTimeUnit() {
-        return timeUnit;
+        super(params.getSleepTime());
     }
 
     @Override
     public boolean await() {
         try {
-            timeUnit.sleep(sleepTime);
+            getTimeUnit().sleep(getSleepTime());
         } catch (final InterruptedException e) {
             log.log(Level.WARNING, e.getMessage());
         }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepingAwaitStrategyBase.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepingAwaitStrategyBase.java
@@ -1,0 +1,50 @@
+package org.arquillian.cube.docker.impl.await;
+
+import java.util.concurrent.TimeUnit;
+
+public abstract class SleepingAwaitStrategyBase implements AwaitStrategy {
+
+    private static final int DEFAULT_SLEEP_TIME = 500;
+
+    private int sleepTime;
+    
+    private TimeUnit timeUnit;
+
+    protected SleepingAwaitStrategyBase(Object sleepTime) {
+        this(sleepTime, DEFAULT_SLEEP_TIME);
+    }
+    
+    protected SleepingAwaitStrategyBase(Object sleepTime, int defaultSleepTime) {
+        configureSleepingTime(sleepTime != null ? sleepTime : defaultSleepTime);
+    }
+
+    private void configureSleepingTime(Object sleepTime) {
+        if (sleepTime instanceof Integer) {
+            this.timeUnit = TimeUnit.MILLISECONDS;
+            this.sleepTime = (Integer) sleepTime;
+        } else {
+            String sleepTimeWithUnit = ((String) sleepTime).trim();
+            if (sleepTimeWithUnit.endsWith("ms")) {
+                this.timeUnit = TimeUnit.MILLISECONDS;
+                this.sleepTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf("ms")).trim());
+            }
+            else if (sleepTimeWithUnit.endsWith("s")) {
+                this.timeUnit = TimeUnit.SECONDS;
+                this.sleepTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf('s')).trim());
+            }
+            else {
+                this.timeUnit = TimeUnit.MILLISECONDS;
+                this.sleepTime = Integer.parseInt(sleepTimeWithUnit);
+            }
+        }
+    }
+
+    public int getSleepTime() {
+        return sleepTime;
+    }
+
+    public TimeUnit getTimeUnit() {
+        return timeUnit;
+    }
+
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StaticAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StaticAwaitStrategy.java
@@ -2,68 +2,38 @@ package org.arquillian.cube.docker.impl.await;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.TimeUnit;
 
 import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.docker.impl.util.Ping;
 import org.arquillian.cube.spi.Cube;
 
-public class StaticAwaitStrategy implements AwaitStrategy {
+public class StaticAwaitStrategy extends SleepingAwaitStrategyBase {
 
     public static final String TAG = "static";
 
     private static final int DEFAULT_POLL_ITERATIONS = 10;
-    private static final int DEFAULT_SLEEP_POLL_TIME = 500;
-    private static final TimeUnit DEFAULT_TIME_UNIT = TimeUnit.MILLISECONDS;
 
     private int pollIterations = DEFAULT_POLL_ITERATIONS;
-    private int sleepPollTime = DEFAULT_SLEEP_POLL_TIME;
-    private TimeUnit timeUnit = DEFAULT_TIME_UNIT;
 
     private String ip;
     private List<Integer> ports = new ArrayList<Integer>();
 
     public StaticAwaitStrategy(Cube<?> cube, Await params) {
+        super(params.getSleepPollingTime());
+        
         this.ip = params.getIp();
         this.ports.addAll(params.getPorts());
-
-        if (params.getSleepPollingTime() != null) {
-            configurePollingTime(params.getSleepPollingTime());
-        }
 
         if (params.getIterations() != null) {
             this.pollIterations = params.getIterations();
         }
     }
 
-    private void configurePollingTime(Object sleepTime) {
-        if(sleepTime instanceof Integer) {
-            this.sleepPollTime = (Integer) sleepTime;
-        } else {
-            String sleepTimeWithUnit = ((String) sleepTime).trim();
-            if(sleepTimeWithUnit.endsWith("ms")) {
-                this.timeUnit = TimeUnit.MILLISECONDS;
-            } else {
-                if(sleepTimeWithUnit.endsWith("s")) {
-                    this.timeUnit = TimeUnit.SECONDS;
-                    this.sleepPollTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf('s')).trim());
-                } else {
-                    this.timeUnit = TimeUnit.MILLISECONDS;
-                    this.sleepPollTime = Integer.parseInt(sleepTimeWithUnit.substring(0, sleepTimeWithUnit.indexOf("ms")).trim());
-                }
-            }
-        }
-    }
-
-    public TimeUnit getTimeUnit() {
-        return timeUnit;
-    }
-
     @Override
     public boolean await() {
 
         for (Integer port : this.ports) {
-            if(!Ping.ping(this.ip, port, this.pollIterations, this.sleepPollTime, TimeUnit.MILLISECONDS )) {
+            if (!Ping.ping(this.ip, port, this.pollIterations, this.getSleepTime(), this.getTimeUnit())) {
                 return false;
             }
         }
@@ -83,7 +53,4 @@ public class StaticAwaitStrategy implements AwaitStrategy {
         return pollIterations;
     }
 
-    public int getSleepPollTime() {
-        return sleepPollTime;
-    }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
@@ -17,6 +17,11 @@ public class Await {
 
     // sleeping
     private Object sleepTime;
+    
+    // log
+    private String match;
+    private boolean stdOut = true;
+    private boolean stdErr;
 
     public Await() {
     }
@@ -76,4 +81,29 @@ public class Await {
     public void setSleepTime(Object sleepTime) {
         this.sleepTime = sleepTime;
     }
+
+    public String getMatch() {
+        return match;
+    }
+
+    public void setMatch(String match) {
+        this.match = match;
+    }
+
+    public boolean isStdOut() {
+        return stdOut;
+    }
+
+    public void setStdOut(boolean stdOut) {
+        this.stdOut = stdOut;
+    }
+
+    public boolean isStdErr() {
+        return stdErr;
+    }
+
+    public void setStdErr(boolean stdErr) {
+        this.stdErr = stdErr;
+    }
+    
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/PingCommand.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/PingCommand.java
@@ -1,0 +1,7 @@
+package org.arquillian.cube.docker.impl.util;
+
+public interface PingCommand {
+    
+    boolean call();
+
+}

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
@@ -1,8 +1,8 @@
 package org.arquillian.cube.docker.impl.await;
 
+import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.instanceOf;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.hasItems;
 import static org.junit.Assert.assertThat;
 
 import java.util.Arrays;
@@ -65,7 +65,7 @@ public class AwaitStrategyTest {
         assertThat(staticAwaitStrategy.getPorts().get(0), is(8080));
         assertThat(staticAwaitStrategy.getPorts().get(1), is(8089));
         assertThat(staticAwaitStrategy.getPollIterations(), is(3));
-        assertThat(staticAwaitStrategy.getSleepPollTime(), is(200));
+        assertThat(staticAwaitStrategy.getSleepTime(), is(200));
     }
 
     @Test
@@ -90,7 +90,7 @@ public class AwaitStrategyTest {
         assertThat(staticAwaitStrategy.getPorts().get(0), is(8080));
         assertThat(staticAwaitStrategy.getPorts().get(1), is(8089));
         assertThat(staticAwaitStrategy.getPollIterations(), is(3));
-        assertThat(staticAwaitStrategy.getSleepPollTime(), is(200));
+        assertThat(staticAwaitStrategy.getSleepTime(), is(200));
         assertThat(staticAwaitStrategy.getTimeUnit(), is(TimeUnit.SECONDS));
     }
 
@@ -148,7 +148,7 @@ public class AwaitStrategyTest {
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
         assertThat(((PollingAwaitStrategy)strategy).getPollIterations(), is(3));
-        assertThat(((PollingAwaitStrategy)strategy).getSleepPollTime(), is(200));
+        assertThat(((PollingAwaitStrategy)strategy).getSleepTime(), is(200));
     }
 
     @Test
@@ -182,7 +182,7 @@ public class AwaitStrategyTest {
 
         assertThat(strategy, instanceOf(PollingAwaitStrategy.class));
         assertThat(((PollingAwaitStrategy)strategy).getPollIterations(), is(3));
-        assertThat(((PollingAwaitStrategy)strategy).getSleepPollTime(), is(200));
+        assertThat(((PollingAwaitStrategy)strategy).getSleepTime(), is(200));
         assertThat(((PollingAwaitStrategy)strategy).getTimeUnit(), is(TimeUnit.SECONDS));
         assertThat(((PollingAwaitStrategy)strategy).getType(), is("sscommand"));
     }
@@ -219,4 +219,48 @@ public class AwaitStrategyTest {
         assertThat(strategy, instanceOf(NativeAwaitStrategy.class));
     }
 
+    @Test
+    public void should_create_log_scanning_await_strategy() {
+
+        Await await = new Await();
+        await.setStrategy("log");
+        await.setMatch("STARTED");
+
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
+
+        assertThat(strategy, instanceOf(LogScanningAwaitStrategy.class));
+        assertThat(((LogScanningAwaitStrategy)strategy).getSleepTime(), is(500));
+        assertThat(((LogScanningAwaitStrategy)strategy).getTimeUnit(), is(TimeUnit.MILLISECONDS));
+        assertThat(((LogScanningAwaitStrategy)strategy).getPollIterations(), is(10));
+        assertThat(((LogScanningAwaitStrategy)strategy).isStdOut(), is(true));
+        assertThat(((LogScanningAwaitStrategy)strategy).isStdErr(), is(false));
+    }
+
+    @Test
+    public void should_create_log_scanning_await_strategy_without_defaults() {
+        
+        Await await = new Await();
+        await.setStrategy("log");
+        await.setMatch("regexp:.*STARTED.*");
+        await.setStdOut(false);
+        await.setStdErr(true);
+        await.setIterations(30);
+        await.setSleepPollingTime("2s");
+
+        CubeContainer cubeContainer = new CubeContainer();
+        cubeContainer.setAwait(await);
+
+        AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
+
+        assertThat(strategy, instanceOf(LogScanningAwaitStrategy.class));
+        assertThat(((LogScanningAwaitStrategy)strategy).getSleepTime(), is(2));
+        assertThat(((LogScanningAwaitStrategy)strategy).getTimeUnit(), is(TimeUnit.SECONDS));
+        assertThat(((LogScanningAwaitStrategy)strategy).getPollIterations(), is(30));
+        assertThat(((LogScanningAwaitStrategy)strategy).isStdOut(), is(false));
+        assertThat(((LogScanningAwaitStrategy)strategy).isStdErr(), is(true));
+    }
+    
 }


### PR DESCRIPTION
Initial implementation of a new await strategy that scans the container log for specified pattern to detect service startup. The pattern is matched to every log line. It can be a plain text or regular expression.

This strategy can be used when there is no port to ping or connect to the port successfully doesn't mean the service is fully initialized.

I've tested it only on Windows but it should work on other platforms too.

I don't know if this is sound enough to be included in Cube. I just wanted to show the idea. Any criticism are welcomed. :smile: