### PR TITLE
Add a config option "ignoreCleanup" to keep resources when exiting

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -20,6 +20,7 @@ public class CubeOpenShiftConfiguration {
     private static final String DEFINITIONS = "definitions";
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String PROXIED_COTNAINER_PORTS = "proxiedContainerPorts";
+    private static final String IGNORE_CLEANUP = "ignoreCleanup";
 
     private String originServer;
     private String namespace;
@@ -28,6 +29,7 @@ public class CubeOpenShiftConfiguration {
     private String definitionsFile;
     private String[] autoStartContainers;
     private Set<String> proxiedContainerPorts;
+    private boolean ignoreCleanup = false;
 
     public String getOriginServer() {
         return originServer;
@@ -39,6 +41,10 @@ public class CubeOpenShiftConfiguration {
 
     public boolean shouldKeepAliveGitServer() {
         return keepAliveGitServer;
+    }
+
+    public boolean shouldIgnoreCleanup() {
+        return ignoreCleanup;
     }
 
     public String[] getAutoStartContainers() {
@@ -64,6 +70,9 @@ public class CubeOpenShiftConfiguration {
         conf.definitionsFile = config.get(DEFINITIONS_FILE);
         if (config.containsKey(KEEP_ALIVE_GIT_SERVER)) {
             conf.keepAliveGitServer = Boolean.parseBoolean(config.get(KEEP_ALIVE_GIT_SERVER));
+        }
+        if (config.containsKey(IGNORE_CLEANUP)) {
+            conf.ignoreCleanup = Boolean.parseBoolean(config.get(IGNORE_CLEANUP));
         }
         if (config.containsKey(AUTO_START_CONTAINERS)) {
             conf.autoStartContainers = config.get(AUTO_START_CONTAINERS).split(",");

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -125,7 +125,11 @@ public class BuildablePodCube extends BaseCube<Void> {
     public void stop() throws CubeControlException {
         try {
             lifecycle.fire(new BeforeStop(id));
-            client.destroy(holder.getPod());
+            if (configuration.shouldIgnoreCleanup()) {
+                System.out.println("Not deleting any pod upon request");
+            } else {
+                client.destroy(holder.getPod());
+            }
             try {
                 portBindings.podStopped();
             } catch (Exception e) {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
@@ -70,7 +70,11 @@ public class ServiceCube extends BaseCube<Void> {
     @Override
     public void stop() throws CubeControlException {
         try {
-            client.destroy(resource);
+            if (configuration.shouldIgnoreCleanup()) {
+                System.out.println("Not deleting any service upon request");
+            } else {
+                client.destroy(resource);
+            }
             this.state = State.STOPPED;
         } catch (Exception e) {
             this.state = State.STOP_FAILED;


### PR DESCRIPTION
Sometimes, mainly when debugging, it's useful to keep pods around
in order to take a closer look at them, their logs, their state, etc.