### PR TITLE
Bump fabric8 kubernetes dependency version to 2.2.143

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/GitServer.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/GitServer.java
@@ -2,7 +2,7 @@ package org.arquillian.cube.openshift.impl.client;
 
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 
 import java.io.File;
 import java.net.URI;
@@ -17,11 +17,11 @@ public class GitServer {
 
     private static int PORT = 6768;
 
-    private KubernetesClient client;
+    private NamespacedKubernetesClient client;
     private String namespace;
     private Pod server;
 
-    public GitServer(KubernetesClient client, String namespace) {
+    public GitServer(NamespacedKubernetesClient client, String namespace) {
         this.client = client;
         this.namespace = namespace;
     }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClient.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClient.java
@@ -8,7 +8,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;
 import io.fabric8.openshift.api.model.BuildConfigBuilder;
@@ -34,7 +34,7 @@ public class OpenShiftClient {
 
     private String namespace;
 
-    private KubernetesClient kubernetes;
+    private NamespacedKubernetesClient kubernetes;
     private GitServer gitserver;
     private boolean keepAliveGitServer;
 
@@ -189,12 +189,12 @@ public class OpenShiftClient {
 		}
 	}
 
-	public KubernetesClient getClient() {
+	public NamespacedKubernetesClient getClient() {
 		return kubernetes;
 	}
 
-	public io.fabric8.openshift.client.OpenShiftClient getClientExt() {
-		return kubernetes.adapt(io.fabric8.openshift.client.OpenShiftClient.class);
+	public io.fabric8.openshift.client.NamespacedOpenShiftClient getClientExt() {
+		return kubernetes.adapt(io.fabric8.openshift.client.NamespacedOpenShiftClient.class);
 	}
 
 	private Map<String, String> getDefaultLabels() {

--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
         <version.junit>4.11</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
         <version.docker-java>3.0.0</version.docker-java>
-        <version.fabric8_kubernetes>2.2.80</version.fabric8_kubernetes>
+        <version.fabric8_kubernetes>2.2.143</version.fabric8_kubernetes>
         <version.snakeyaml>1.15</version.snakeyaml>
         <version.mockito>1.10.19</version.mockito>
         <version.descriptor.docker>1.0.0-alpha-2</version.descriptor.docker>


### PR DESCRIPTION
Changed KubernetesClient to NamespacedKubernetesClient
And OpenShiftClient to NamespacedOpenShiftClient

Because new k8s api changed the interfaces that carry
methods like inNamespace() and inAnyNamespace().

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-cube/395)
<!-- Reviewable:end -->
