### PR TITLE
#442: AbstractKubernetesResourceProvider now uses reflection to read …

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/AbstractKubernetesResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/AbstractKubernetesResourceProvider.java
@@ -8,8 +8,14 @@ import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
 import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 
 public abstract class AbstractKubernetesResourceProvider implements ResourceProvider {
+
+    private static final String JAVAX_INJECT_NAMED = "javax.inject.Named";
+    private static final String VALUE = "value";
+    private static final Object[] NO_ARGS = new Object[0];
 
     @Inject
     private Instance<KubernetesClient> client;
@@ -19,11 +25,33 @@ public abstract class AbstractKubernetesResourceProvider implements ResourceProv
 
     protected String getName(Annotation... qualifiers) {
         for (Annotation annotation : qualifiers) {
+            Class<? extends Annotation> type = annotation.annotationType();
             if (annotation instanceof Named) {
                 return ((Named) annotation).value();
+            } else if (type.getName().equals(JAVAX_INJECT_NAMED)) {
+                return getAnnotationValue(annotation);
             }
         }
         return null;
+    }
+
+    /**
+     * Get the value() from the specified annotation using reflection.
+     * @param annotation    The annotation.
+     * @return
+     */
+    private String getAnnotationValue(Annotation annotation) {
+        Class<? extends Annotation> type = annotation.annotationType();
+        try {
+            Method method = type.getDeclaredMethod(VALUE);
+            return String.valueOf(method.invoke(annotation, NO_ARGS));
+        } catch (NoSuchMethodException e) {
+            return null;
+        } catch (InvocationTargetException e) {
+            return null;
+        } catch (IllegalAccessException e) {
+            return null;
+        }
     }
 
     protected KubernetesClient getClient() {


### PR DESCRIPTION
…the @Named annotation so that it works with 3rd party annotations too (i.e. javax.inject.Named).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arquillian/arquillian-cube/443)
<!-- Reviewable:end -->
