### PR TITLE
Allow custom mapping between container ID and cube ID (#451)

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/client/container/ContainerConfigurationController.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/container/ContainerConfigurationController.java
@@ -37,7 +37,7 @@ public class ContainerConfigurationController {
             return;
         }
 
-        Cube<?> cube = cubeRegistry.getCube(container.getName());
+        Cube<?> cube = cubeRegistry.getCube(ContainerUtil.getCubeIDForContainer(container));
         if (cube == null) {
             return; // No Cube found matching Container name, not managed by Cube
         }

--- a/core/src/main/java/org/arquillian/cube/impl/client/container/CubeContainerLifecycleController.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/container/CubeContainerLifecycleController.java
@@ -32,7 +32,7 @@ public class CubeContainerLifecycleController {
             return;
         }
 
-        Cube<?> cube = cubeRegistry.getCube(container.getName());
+        Cube<?> cube = cubeRegistry.getCube(ContainerUtil.getCubeIDForContainer(container));
         if (cube == null) {
             return; // No Cube found matching Container name, not managed by Cube
         }
@@ -62,7 +62,7 @@ public class CubeContainerLifecycleController {
             return;
         }
 
-        Cube<?> cube = cubeRegistry.getCube(container.getName());
+        Cube<?> cube = cubeRegistry.getCube(ContainerUtil.getCubeIDForContainer(container));
         if (cube == null) {
             return; // No Cube found matching Container name, not managed by Cube
         }

--- a/core/src/main/java/org/arquillian/cube/impl/client/container/CubeRemoteCommandObserver.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/container/CubeRemoteCommandObserver.java
@@ -13,6 +13,7 @@ import org.arquillian.cube.impl.client.container.remote.command.DestroyCubeComma
 import org.arquillian.cube.impl.client.container.remote.command.StartCubeCommand;
 import org.arquillian.cube.impl.client.container.remote.command.StopCubeCommand;
 import org.arquillian.cube.impl.client.container.remote.command.TopCommand;
+import org.arquillian.cube.impl.util.ContainerUtil;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.container.spi.Container;
@@ -74,9 +75,9 @@ public class CubeRemoteCommandObserver {
         if(cubeRegistry == null) {
             throw new IllegalStateException("No CubeRegistry found in context, can't perform CubeID injection");
         }
-        Cube<?> cube = cubeRegistry.getCube(container.getName());
+        Cube<?> cube = cubeRegistry.getCube(ContainerUtil.getCubeIDForContainer(container));
         if(cube == null) {
-            throw new IllegalStateException("No Cube found mapped to current Container: " + container.getName());
+            throw new IllegalStateException(String.format("No Cube found mapped to current Container[%s] with CubeID[%s]", container.getName(), ContainerUtil.getCubeIDForContainer(container)));
         }
         command.setResult(cube.getId());
     }

--- a/core/src/main/java/org/arquillian/cube/impl/client/container/ProtocolMetadataUpdater.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/container/ProtocolMetadataUpdater.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.impl.client.container;
 
+import org.arquillian.cube.impl.util.ContainerUtil;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.arquillian.cube.spi.metadata.HasPortBindings;
@@ -26,7 +27,7 @@ public class ProtocolMetadataUpdater {
         boolean updated = false;
 
         try {
-            Cube<?> cube = registry.getCube(container.getName());
+            Cube<?> cube = registry.getCube(ContainerUtil.getCubeIDForContainer(container));
             if(cube == null) {
                 return;
             }

--- a/core/src/main/java/org/arquillian/cube/impl/client/enricher/CubeIDResourceProvider.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/enricher/CubeIDResourceProvider.java
@@ -3,6 +3,7 @@ package org.arquillian.cube.impl.client.enricher;
 import java.lang.annotation.Annotation;
 
 import org.arquillian.cube.CubeID;
+import org.arquillian.cube.impl.util.ContainerUtil;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.container.spi.Container;
@@ -34,9 +35,9 @@ public class CubeIDResourceProvider extends OperatesOnDeploymentAwareProvider {
         if(cubeRegistry == null) {
             throw new IllegalStateException("No CubeRegistry found in context, can't perform CubeID injection");
         }
-        Cube<?> cube = cubeRegistry.getCube(container.getName());
+        Cube<?> cube = cubeRegistry.getCube(ContainerUtil.getCubeIDForContainer(container));
         if(cube == null) {
-            throw new IllegalStateException("No Cube found mapped to current Container: " + container.getName());
+            throw new IllegalStateException(String.format("No Cube found mapped to current Container[%s] with CubeID[%s]", container.getName(), ContainerUtil.getCubeIDForContainer(container)));
         }
         return new CubeID(cube.getId());
     }

--- a/core/src/main/java/org/arquillian/cube/impl/util/ContainerUtil.java
+++ b/core/src/main/java/org/arquillian/cube/impl/util/ContainerUtil.java
@@ -1,5 +1,7 @@
 package org.arquillian.cube.impl.util;
 
+import java.util.Map;
+
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
@@ -15,4 +17,23 @@ public class ContainerUtil {
         return null;
     }
 
+    /**
+     * Returns the cube ID for the container. By default, this is the container
+     * name, but can be overridden by the user in the container properties, e.g.
+     * <code>&lt;cubeId&gt;pod-name&lt;/cubeId&gt;</code>.
+     * 
+     * @param container the arquillian container
+     * @return the cube ID for the specified container
+     */
+    public static String getCubeIDForContainer(Container container) {
+        final String cubeID;
+        final Map<String, String> containerProperties = container.getContainerConfiguration().getContainerProperties();
+        if (containerProperties == null) {
+            // test cases may not mock entire hierarchy
+            cubeID = null;
+        } else {
+            cubeID = containerProperties.get("cubeId");
+        }
+        return cubeID == null ? container.getName() : cubeID;
+    }
 }

--- a/core/src/test/java/org/arquillian/cube/impl/client/container/CubeContainerLifecycleControllerTest.java
+++ b/core/src/test/java/org/arquillian/cube/impl/client/container/CubeContainerLifecycleControllerTest.java
@@ -3,6 +3,7 @@ package org.arquillian.cube.impl.client.container;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +18,7 @@ import org.arquillian.cube.spi.event.DestroyCube;
 import org.arquillian.cube.spi.event.PreRunningCube;
 import org.arquillian.cube.spi.event.StartCube;
 import org.arquillian.cube.spi.event.StopCube;
+import org.jboss.arquillian.config.descriptor.api.ContainerDef;
 import org.jboss.arquillian.container.spi.Container;
 import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.jboss.arquillian.container.spi.client.container.DeployableContainer;
@@ -48,6 +50,9 @@ public class CubeContainerLifecycleControllerTest extends AbstractManagerTestBas
     @Mock
     private Container container;
 
+    @Mock
+    private ContainerDef containerDef;
+
     @SuppressWarnings("rawtypes")
     @Mock
     private DeployableContainer deployableContainer;
@@ -67,6 +72,8 @@ public class CubeContainerLifecycleControllerTest extends AbstractManagerTestBas
         when(cube.getId()).thenReturn(CUBE_ID);
         when(container.getName()).thenReturn(CUBE_ID);
         when(container.getDeployableContainer()).thenReturn(deployableContainer);
+        when(container.getContainerConfiguration()).thenReturn(containerDef);
+        when(containerDef.getContainerProperties()).thenReturn(Collections.EMPTY_MAP);
         when(containerRegistry.getContainers()).thenReturn(Arrays.asList(container));
         registry = new LocalCubeRegistry();
         registry.addCube(cube);
@@ -158,5 +165,16 @@ public class CubeContainerLifecycleControllerTest extends AbstractManagerTestBas
         fire(new AfterStop(deployableContainer));
         assertEventFired(StopCube.class, 0);
         assertEventFired(DestroyCube.class, 0);
+    }
+
+    @Test
+    public void shouldUseOverriddenCubeId() {
+        Map<String, String> containerConfig = new HashMap<String, String>();
+        containerConfig.put("cubeId", CUBE_ID);
+
+        when(container.getName()).thenReturn(MISSING_CUBE_ID);
+        when(containerDef.getContainerProperties()).thenReturn(containerConfig);
+
+        shouldCreateAndStartCubeDuringBeforeStart();
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerAutoStartConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerAutoStartConfigurator.java
@@ -5,6 +5,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
+import org.arquillian.cube.impl.util.ContainerUtil;
 import org.arquillian.cube.spi.AutoStartParser;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.container.spi.Container;
@@ -40,7 +41,7 @@ public class CubeDockerAutoStartConfigurator {
         List<String> containerNames = new ArrayList<>();
 
         for (Container container : containers) {
-            containerNames.add(container.getName());
+            containerNames.add(ContainerUtil.getCubeIDForContainer(container));
         }
 
         return containerNames;

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/container/DockerServerIPConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/container/DockerServerIPConfigurator.java
@@ -41,7 +41,7 @@ public class DockerServerIPConfigurator {
         if (container == null) {
             return;
         }
-        Cube<?> cube = cubeRegistry.getCube(container.getName());
+        Cube<?> cube = cubeRegistry.getCube(org.arquillian.cube.impl.util.ContainerUtil.getCubeIDForContainer(container));
         if (cube == null) {
             return; // No Cube found matching Container name, not managed by Cube
         }


### PR DESCRIPTION
This is now supported by adding a "cubeId" property to the container config, e.g:

<property name="cubeId">alternativeId</property>