### PR TITLE
Align arquillian-cube-openshift configuration with arquillian-cube-kubernetes

### DIFF
--- a/openshift/openshift/pom.xml
+++ b/openshift/openshift/pom.xml
@@ -70,6 +70,14 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.sundr</groupId>
+			<artifactId>builder-annotations</artifactId>
+			<version>0.2.8</version>
+			<scope>compile</scope>
+			<optional>true</optional>
+		</dependency>
+
+		<dependency>
 			<groupId>org.eclipse.jgit</groupId>
 			<artifactId>org.eclipse.jgit</artifactId>
 			<version>${version.jgit}</version>

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClient.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClient.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodBuilder;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.NamespacedKubernetesClient;
 import io.fabric8.openshift.api.model.Build;
 import io.fabric8.openshift.api.model.BuildConfig;

--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
         <version.junit>4.11</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
         <version.docker-java>3.0.4</version.docker-java>
-        <version.kubernetes_client>1.4.6</version.kubernetes_client>
+        <version.kubernetes_client>1.4.10</version.kubernetes_client>
         <version.snakeyaml>1.15</version.snakeyaml>
         <version.shrinkwrap_resolver>2.2.2</version.shrinkwrap_resolver>
         <version.mockito>1.10.19</version.mockito>


### PR DESCRIPTION
This pull requests makes the following changes:

- Align property names with cube-kubernetes (deprecates `originServer` in favor of `master.url`).
- Allows reading of properties from system and env ( system > env > arquillian.xml). 
- Parsing of definitions now is handled by the client instead of using jackson directly.
- Minor changes in the use of the client DSL.