### PR TITLE
[issue #499] Copy waitforit script to /tmp and fallback strategy

### DIFF
--- a/docker/docker/src/main/resources/org/arquillian/cube/docker/impl/await/wait-for-it-sh.sh
+++ b/docker/docker/src/main/resources/org/arquillian/cube/docker/impl/await/wait-for-it-sh.sh
@@ -1,0 +1,165 @@
+#!/usr/bin/env sh
+#   Use this script to test if a given TCP host/port are available
+
+set -e
+
+cmdname=$(basename "$0")
+
+echoerr() {
+    if [ "$QUIET" -ne 1 ]; then
+        printf "%s\n" "$*" 1>&2;
+    fi
+}
+
+usage()
+{
+    exitcode="$1"
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit "$exitcode"
+}
+
+wait_for()
+{
+    if [ "$TIMEOUT" -gt 0 ]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while true
+    do
+        nc -z "$HOST" "$PORT" >/dev/null 2>&1
+        result=$?
+        if [ $result -eq 0 ]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [ "$QUIET" -eq 1 ]; then
+        timeout "$TIMEOUT" "$0" -q -child "$HOST":"$PORT" -t "$TIMEOUT" &
+    else
+        timeout "$TIMEOUT" "$0" --child "$HOST":"$PORT" -t "$TIMEOUT" &
+    fi
+    PID=$!
+    trap 'kill -INT -$PID' INT
+    wait $PID
+    RESULT=$?
+    if [ $RESULT -ne 0 ]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+TIMEOUT=15
+STRICT=0
+CHILD=0
+QUIET=0
+# process arguments
+while [ $# -gt 0 ]
+do
+    case "$1" in
+        *:* )
+        HOST=$(printf "%s\n" "$1"| cut -d : -f 1)
+        PORT=$(printf "%s\n" "$1"| cut -d : -f 2)
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [ "$HOST" = "" ]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST=$(printf "%s" "$1" | cut -d = -f 2)
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [ "$PORT" = "" ]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [ "$TIMEOUT" = "" ]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        break
+        ;;
+        --help)
+        usage 0
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage 1
+        ;;
+    esac
+done
+
+if [ "$HOST" = "" -o "$PORT" = "" ]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage 2
+fi
+
+if [ $CHILD -gt 0 ]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [ "$TIMEOUT" -gt 0 ]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [ "$*" != "" ]; then
+    if [ $RESULT -ne 0 -a $STRICT -eq 1 ]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec "$@"
+else
+    exit $RESULT
+fi

--- a/docker/docker/src/main/resources/org/arquillian/cube/docker/impl/await/wait-for-it.sh
+++ b/docker/docker/src/main/resources/org/arquillian/cube/docker/impl/await/wait-for-it.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+#   Use this script to test if a given TCP host/port are available
+
+cmdname=$(basename $0)
+
+echoerr() { if [[ $QUIET -ne 1 ]]; then echo "$@" 1>&2; fi }
+
+usage()
+{
+    cat << USAGE >&2
+Usage:
+    $cmdname host:port [-s] [-t timeout] [-- command args]
+    -h HOST | --host=HOST       Host or IP under test
+    -p PORT | --port=PORT       TCP port under test
+                                Alternatively, you specify the host and port as host:port
+    -s | --strict               Only execute subcommand if the test succeeds
+    -q | --quiet                Don't output any status messages
+    -t TIMEOUT | --timeout=TIMEOUT
+                                Timeout in seconds, zero for no timeout
+    -- COMMAND ARGS             Execute command with args after the test finishes
+USAGE
+    exit 1
+}
+
+wait_for()
+{
+    if [[ $TIMEOUT -gt 0 ]]; then
+        echoerr "$cmdname: waiting $TIMEOUT seconds for $HOST:$PORT"
+    else
+        echoerr "$cmdname: waiting for $HOST:$PORT without a timeout"
+    fi
+    start_ts=$(date +%s)
+    while :
+    do
+        (echo > /dev/tcp/$HOST/$PORT) >/dev/null 2>&1
+        result=$?
+        if [[ $result -eq 0 ]]; then
+            end_ts=$(date +%s)
+            echoerr "$cmdname: $HOST:$PORT is available after $((end_ts - start_ts)) seconds"
+            break
+        fi
+        sleep 1
+    done
+    return $result
+}
+
+wait_for_wrapper()
+{
+    # In order to support SIGINT during timeout: http://unix.stackexchange.com/a/57692
+    if [[ $QUIET -eq 1 ]]; then
+        timeout $TIMEOUT $0 --quiet --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    else
+        timeout $TIMEOUT $0 --child --host=$HOST --port=$PORT --timeout=$TIMEOUT &
+    fi
+    PID=$!
+    trap "kill -INT -$PID" INT
+    wait $PID
+    RESULT=$?
+    if [[ $RESULT -ne 0 ]]; then
+        echoerr "$cmdname: timeout occurred after waiting $TIMEOUT seconds for $HOST:$PORT"
+    fi
+    return $RESULT
+}
+
+# process arguments
+while [[ $# -gt 0 ]]
+do
+    case "$1" in
+        *:* )
+        hostport=(${1//:/ })
+        HOST=${hostport[0]}
+        PORT=${hostport[1]}
+        shift 1
+        ;;
+        --child)
+        CHILD=1
+        shift 1
+        ;;
+        -q | --quiet)
+        QUIET=1
+        shift 1
+        ;;
+        -s | --strict)
+        STRICT=1
+        shift 1
+        ;;
+        -h)
+        HOST="$2"
+        if [[ $HOST == "" ]]; then break; fi
+        shift 2
+        ;;
+        --host=*)
+        HOST="${1#*=}"
+        shift 1
+        ;;
+        -p)
+        PORT="$2"
+        if [[ $PORT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --port=*)
+        PORT="${1#*=}"
+        shift 1
+        ;;
+        -t)
+        TIMEOUT="$2"
+        if [[ $TIMEOUT == "" ]]; then break; fi
+        shift 2
+        ;;
+        --timeout=*)
+        TIMEOUT="${1#*=}"
+        shift 1
+        ;;
+        --)
+        shift
+        CLI="$@"
+        break
+        ;;
+        --help)
+        usage
+        ;;
+        *)
+        echoerr "Unknown argument: $1"
+        usage
+        ;;
+    esac
+done
+
+if [[ "$HOST" == "" || "$PORT" == "" ]]; then
+    echoerr "Error: you need to provide a host and port to test."
+    usage
+fi
+
+TIMEOUT=${TIMEOUT:-15}
+STRICT=${STRICT:-0}
+CHILD=${CHILD:-0}
+QUIET=${QUIET:-0}
+
+if [[ $CHILD -gt 0 ]]; then
+    wait_for
+    RESULT=$?
+    exit $RESULT
+else
+    if [[ $TIMEOUT -gt 0 ]]; then
+        wait_for_wrapper
+        RESULT=$?
+    else
+        wait_for
+        RESULT=$?
+    fi
+fi
+
+if [[ $CLI != "" ]]; then
+    if [[ $RESULT -ne 0 && $STRICT -eq 1 ]]; then
+        echoerr "$cmdname: strict mode, refusing to execute subprocess"
+        exit $RESULT
+    fi
+    exec $CLI
+else
+    exit $RESULT
+fi

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -239,14 +239,17 @@ To avoid executing tests before the services are ready, you can set which await 
 Currently next await strategies are supported:
 
 native:: it uses *wait* command. In this case current thread is waiting until the _Docker_ server notifies that has started. In case of foreground services this is not the approach to be used.
-polling:: in this case a polling (with _ping_ or _ss_ command) is executed for 5 seconds against all exposed ports. When communication to all exposed ports is acknowledged, the container is considered to be up. This approach is the one to be used in case of services started in foreground. By default _polling_ executes _ss_ command inside the running container to know if the server is already running. You can use a _ping_ from client by setting +type+ attribute to +ping+; Note that _ping_ only works if you are running _Docker_ daemon on +localhost+. You can also use `wait-for-it` script which is automatically downloaded, copied inside container and executed inside it. To do it you need to set `type` property to `waitforit`. In almost all cases the default behaviour matches all scenarios. If it is not specified, this is the default strategy.
+polling:: in this case a polling (with _ping_ or _ss_ command) is executed for 5 seconds against all exposed ports. When communication to all exposed ports is acknowledged, the container is considered to be up. This approach is the one to be used in case of services started in foreground. By default _polling_ executes _ss_ command inside the running container to know if the server is already running.
+Also you can use a _ping_ strategy from client by setting +type+ attribute to +ping+; Note that _ping_ only works if you are running _Docker_ daemon on +localhost+.
+You can also use `wait-for-it` script which is automatically downloaded, copied inside container and executed inside it. To do it you need to set `type` property to `waitforit`. In almost all cases the default behaviour matches all scenarios. If it is not specified, this is the default strategy.
+By default if you use _ss_ strategy but ss command is not installed into the container it fallsback automatically to waitforit strategy.
 static:: similar to _polling_ but it uses the host ip and specified list of ports provided as configuration parameter. This can be used in case of using _Boot2Docker_.
 sleeping:: sleeps current thread for the specified amount of time. You can specify the time in seconds or milliseconds.
 log:: it looking for a specified pattern in container log to detect service startup. This can be used when there is no port to connect or connecting to the port successfully doesn't mean the service is fully initialized.
 http:: polls through a configured http endpoint checking for http response code and optionally the answer content or headers.
 <fullyqualifiedclassname>:: if you specify a fully qualified class name, Arquillian Cube will instantiate the given class. In this way you can implement your own await strategies. There are two rules to follow, the first one is that class must implement `AwaitStrategy` and the second one is that one default constructor must be provided. Optionally you can add fields/setters for types `Cube`, `DockerClientExecutor` or `Await` to inject them into the await strategy.
 
-By default in case you don't specify any _await_ strategy, polling with _ss_ command is used.
+By default in case you don't specify any _await_ strategy, polling with _ss_ command is used with automatic fallback to _wait-fo_it_ strategy.
 
 [source, yaml]
 .Example native

--- a/spi/src/main/java/org/arquillian/cube/spi/CubeOutput.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/CubeOutput.java
@@ -1,0 +1,21 @@
+package org.arquillian.cube.spi;
+
+public class CubeOutput {
+
+    private String standard;
+    private String error;
+
+    public CubeOutput(String standard, String error) {
+        this.standard = standard;
+        this.error = error;
+    }
+
+    public String getStandard() {
+        return standard;
+    }
+
+    public String getError() {
+        return error;
+    }
+}
+

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/CanExecuteProcessInContainer.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/CanExecuteProcessInContainer.java
@@ -1,21 +1,23 @@
 package org.arquillian.cube.spi.metadata;
 
+import org.arquillian.cube.spi.CubeOutput;
+
 public interface CanExecuteProcessInContainer extends CubeMetadata {
 
     ExecResult exec(String...command);
 
     public static class ExecResult {
-        private String output;
+        private CubeOutput output;
         private boolean isRunning;
         private int exitCode;
 
-        public ExecResult(String output, boolean isRunning, int exitCode) {
+        public ExecResult(CubeOutput output, boolean isRunning, int exitCode) {
             this.output = output;
             this.isRunning = isRunning;
             this.exitCode = exitCode;
         }
 
-        public String getOutput() {
+        public CubeOutput getOutput() {
             return output;
         }
 


### PR DESCRIPTION
This PR fixes #499 bug and improves how ping works by:

1. Copying Wait-For-It script from classpath location and not downloading from internet, so in cases of not having internet connection or for future customizations we don't relay on external site
2. Copy `wait-for-it` to `/tmp` to avoid any workspace problem inside docker containers.
3. Implementing fallback strategy so if _ss_ is not found in the container it automatically changes ping strategy to _wait-for-it_.