### PR TITLE
[issue #502] Log Strategy works with countdownlatch instead of polling.

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/LogScanningAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/LogScanningAwaitStrategy.java
@@ -1,52 +1,41 @@
 package org.arquillian.cube.docker.impl.await;
 
-import java.text.DateFormat;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.regex.Pattern;
-
-import org.arquillian.cube.docker.impl.client.config.Await;
-import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.docker.impl.util.Ping;
-import org.arquillian.cube.docker.impl.util.PingCommand;
-import org.arquillian.cube.spi.Cube;
-
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Frame;
-import com.github.dockerjava.api.model.Info;
 import com.github.dockerjava.core.async.ResultCallbackTemplate;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.spi.Cube;
+
+import java.io.IOException;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.regex.Pattern;
 
 public class LogScanningAwaitStrategy extends SleepingAwaitStrategyBase {
 
     public static final String TAG = "log";
-        
+
     private static final String REGEXP_PREFIX = "regexp:";
-    
-    private static final int DEFAULT_POLL_ITERATIONS = 10;
-    
-    private int pollIterations = DEFAULT_POLL_ITERATIONS;
-    
+    private static final int DEFAULT_TIME_OUT = 15;
+
+    private int timeout = DEFAULT_TIME_OUT;
+
     private boolean stdOut;
     private boolean stdErr;
-    
+
     private Cube<?> cube;
-    
+
     private DockerClientExecutor dockerClientExecutor;
-    
-    private final DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss");
-    
-    private final LogMatcher matcher; 
-    
+
+    private final LogMatcher matcher;
+
     public LogScanningAwaitStrategy(Cube<?> cube, DockerClientExecutor dockerClientExecutor, Await params) {
         super(params.getSleepPollingTime());
-        
+
         this.cube = cube;
         this.dockerClientExecutor = dockerClientExecutor;
-        
-        if (params.getIterations() != null) {
-            this.pollIterations = params.getIterations();
-        }
-        
+
         this.stdOut = params.isStdOut();
         this.stdErr = params.isStdErr();
 
@@ -55,12 +44,17 @@ public class LogScanningAwaitStrategy extends SleepingAwaitStrategyBase {
         } else {
             matcher = new ContainsLogMatcher(params.getMatch());
         }
+
+        if (params.getTimeout() != null) {
+            this.timeout = params.getTimeout();
+        }
+
     }
-    
-    public int getPollIterations() {
-        return pollIterations;
+
+    public int getTimeout() {
+        return timeout;
     }
-    
+
     public boolean isStdOut() {
         return stdOut;
     }
@@ -72,78 +66,57 @@ public class LogScanningAwaitStrategy extends SleepingAwaitStrategyBase {
     @Override
     public boolean await() {
         final DockerClient client = dockerClientExecutor.getDockerClient();
-        
-        Info info = client.infoCmd().exec();
-        
-        int since = parseTimestamp(info.getSystemTime());
-        
-        final LogContainerResultCallback callback = new LogContainerResultCallback(since);
-        
-        return Ping.ping(pollIterations, getSleepTime(), getTimeUnit(), new PingCommand() {
-            @Override
-            public boolean call() {
-                try {
-                    client.logContainerCmd(cube.getId())
-                            .withStdOut(stdOut).withStdErr(stdErr)
-                            .withTimestamps(true).withSince(callback.getLastTimestamp())
-                            .exec(callback).awaitCompletion();
-                }
-                catch (InterruptedException e) {
-                    // do nothing
-                }
-                
-                return callback.isFound();
+        final CountDownLatch containerUp = new CountDownLatch(1);
+
+        try (final LogContainerResultCallback callback = new LogContainerResultCallback(containerUp)) {
+            try {
+
+                client.logContainerCmd(cube.getId())
+                        .withStdErr(true)
+                        .withStdOut(true)
+                        .withFollowStream(true)
+                        .exec(callback);
+
+                boolean result = containerUp.await(this.timeout, TimeUnit.SECONDS);
+                return result;
+            } catch (InterruptedException e) {
+                return false;
             }
-        });
-    }
-    
-    private int parseTimestamp(String s) {
-        try {
-            return (int) dateFormat.parse(s.substring(0, s.indexOf('.'))).getTime() / 1000;
-        } catch (ParseException e) {
-            throw new IllegalArgumentException("Timestamp parse failure: " + s, e);
+        } catch (IOException e) {
+
+            return false;
         }
+
     }
-    
+
     private class LogContainerResultCallback extends ResultCallbackTemplate<LogContainerResultCallback, Frame> {
-        
-        private int lastTimestamp;
-        
-        private boolean found;
-        
-        public LogContainerResultCallback(int since) {
-            this.lastTimestamp = since;
-        }
-        
-        public int getLastTimestamp() {
-            return lastTimestamp;
-        }
-        
-        public boolean isFound() {
-            return found;
+
+        private CountDownLatch containerUp;
+
+        public LogContainerResultCallback(CountDownLatch containerUp) {
+            this.containerUp = containerUp;
         }
 
         @Override
         public void onNext(Frame item) {
             String line = new String(item.getPayload());
-            lastTimestamp = parseTimestamp(line);
-            
-            if (!found) {
-                found = matcher.match(line);
+
+            if (matcher.match(line)) {
+                this.containerUp.countDown();
             }
         }
     }
-    
+
     private interface LogMatcher {
-        
+
         boolean match(String line);
-        
+
     }
-    
+
     private static final class ContainsLogMatcher implements LogMatcher {
-        
+
         private String substring;
-        
+
         public ContainsLogMatcher(String substring) {
             this.substring = substring;
         }
@@ -152,13 +125,13 @@ public class LogScanningAwaitStrategy extends SleepingAwaitStrategyBase {
         public boolean match(String line) {
             return line.contains(substring);
         }
-        
+
     }
-    
+
     private static final class RegexpLogMatcher implements LogMatcher {
-        
-        private Pattern regex; 
-        
+
+        private Pattern regex;
+
         public RegexpLogMatcher(String pattern) {
             regex = Pattern.compile(pattern, Pattern.DOTALL);
         }
@@ -167,7 +140,7 @@ public class LogScanningAwaitStrategy extends SleepingAwaitStrategyBase {
         public boolean match(String line) {
             return regex.matcher(line).matches();
         }
-        
+
     }
-    
+
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
@@ -32,7 +32,7 @@ public class Await {
     private Map<String, Object> headers;
     private String url;
 
-    //waitforit
+    //waitforit and log
     private Integer timeout = 15;
 
     public Await() {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
@@ -286,9 +286,10 @@ public class AwaitStrategyTest {
         AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(LogScanningAwaitStrategy.class));
-        assertThat(((LogScanningAwaitStrategy)strategy).getTimeout(), is(15));
-        assertThat(((LogScanningAwaitStrategy)strategy).isStdOut(), is(true));
-        assertThat(((LogScanningAwaitStrategy)strategy).isStdErr(), is(false));
+        final LogScanningAwaitStrategy log = (LogScanningAwaitStrategy) strategy;
+        assertThat(log.getTimeout(), is(15));
+        assertThat(log.isStdOut(), is(true));
+        assertThat(log.isStdErr(), is(false));
     }
 
     @Test
@@ -307,9 +308,10 @@ public class AwaitStrategyTest {
         AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(LogScanningAwaitStrategy.class));
-        assertThat(((LogScanningAwaitStrategy)strategy).getTimeout(), is(20));
-        assertThat(((LogScanningAwaitStrategy)strategy).isStdOut(), is(false));
-        assertThat(((LogScanningAwaitStrategy)strategy).isStdErr(), is(true));
+        final LogScanningAwaitStrategy log = (LogScanningAwaitStrategy) strategy;
+        assertThat(log.getTimeout(), is(20));
+        assertThat(log.isStdOut(), is(false));
+        assertThat(log.isStdErr(), is(true));
     }
 
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
@@ -286,9 +286,7 @@ public class AwaitStrategyTest {
         AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(LogScanningAwaitStrategy.class));
-        assertThat(((LogScanningAwaitStrategy)strategy).getSleepTime(), is(500));
-        assertThat(((LogScanningAwaitStrategy)strategy).getTimeUnit(), is(TimeUnit.MILLISECONDS));
-        assertThat(((LogScanningAwaitStrategy)strategy).getPollIterations(), is(10));
+        assertThat(((LogScanningAwaitStrategy)strategy).getTimeout(), is(15));
         assertThat(((LogScanningAwaitStrategy)strategy).isStdOut(), is(true));
         assertThat(((LogScanningAwaitStrategy)strategy).isStdErr(), is(false));
     }
@@ -301,8 +299,7 @@ public class AwaitStrategyTest {
         await.setMatch("regexp:.*STARTED.*");
         await.setStdOut(false);
         await.setStdErr(true);
-        await.setIterations(30);
-        await.setSleepPollingTime("2s");
+        await.setTimeout(20);
 
         CubeContainer cubeContainer = new CubeContainer();
         cubeContainer.setAwait(await);
@@ -310,9 +307,7 @@ public class AwaitStrategyTest {
         AwaitStrategy strategy = AwaitStrategyFactory.create(null, cube, cubeContainer);
 
         assertThat(strategy, instanceOf(LogScanningAwaitStrategy.class));
-        assertThat(((LogScanningAwaitStrategy)strategy).getSleepTime(), is(2));
-        assertThat(((LogScanningAwaitStrategy)strategy).getTimeUnit(), is(TimeUnit.SECONDS));
-        assertThat(((LogScanningAwaitStrategy)strategy).getPollIterations(), is(30));
+        assertThat(((LogScanningAwaitStrategy)strategy).getTimeout(), is(20));
         assertThat(((LogScanningAwaitStrategy)strategy).isStdOut(), is(false));
         assertThat(((LogScanningAwaitStrategy)strategy).isStdErr(), is(true));
     }

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -307,14 +307,12 @@ tomcat:
     match: 'Server startup' # <1>
     stdOut: true # <2>
     stdErr: true # <3>
-    sleepPollingTime: 200 s # <4>
-    iterations: 3 # <5>
+    timeout: 15 # <4>
 ----
 <1> Mandatory parameter to configure the pattern that signals the service started. To use regular expression just prefix the pattern with `regexp:`.
 <2> Optional parameter to enable scanning of _standard output_ log. Default is true.
 <3> Optional parameter to enable scanning of _standard error_ log. Default is false.
-<4> Optional parameter to configure sleeping time between log downloading. You can set in seconds using _s_ or miliseconds using _ms_. By default time unit is miliseconds and value 500.
-<5> Optional parameter to configure number of retries to be done. By default 10 iterations are done.
+<4> Optional parameter to configure timeout. It is expressed in seconds and by default is 15.
 
 [source, yaml]
 .Example http


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes log await strategy issue #502 

#### Changes proposed in this pull request:

- Change `LogScanningAwaitStrategy` to use an asynchronous way instead of polling. Basically when the container log contains the expected value, it unblocks the thread. With this approach we can add inspect log line by line instead as a batch, which causes some problems in some containers.

**Fixes**: #502 

