### PR TITLE
[issue #496] makes CubeConfiguratorTest more resilent to local docker…

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -71,26 +71,6 @@ public class CubeDockerConfigurationResolver {
         return config;
     }
 
-    private void adaptPortBindingToParallelRun(CubeContainer cubeContainer) {
-        final Collection<PortBinding> portBindings = cubeContainer.getPortBindings();
-        if (portBindings == null) {
-            return;
-        }
-        for (PortBinding portBinding : portBindings) {
-            final int randomPrivatePort = generateRandomPrivatePort();
-            portBinding.setBound(randomPrivatePort);
-        }
-    }
-
-    private String generateNewName(String containerName, UUID uuid) {
-        return containerName + "_" + uuid;
-    }
-
-    private int generateRandomPrivatePort() {
-        final int randomPort = random.nextInt(16383);
-        return randomPort + 49152;
-    }
-
     private Map<String, String> resolveDockerInsideDocker(Map<String, String> cubeConfiguration) {
         // if DIND_RESOLUTION property is not set, since by default is enabled, we need to go inside code.
         if (!cubeConfiguration.containsKey(CubeDockerConfiguration.DIND_RESOLUTION) || Boolean.parseBoolean(cubeConfiguration.get(CubeDockerConfiguration.DIND_RESOLUTION))) {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -484,11 +484,11 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     }
     
     private static Matcher<String> defaultDockerMachineCertPath() {
-        return pathEndsWith(".docker/machine/machines/dev");
+        return containsString(".docker/machine/machines");
     }
     
     private static Matcher<String> defaultBootToDockerCertPath() {
-        return pathEndsWith(".boot2docker/certs/boot2docker-vm");
+        return containsString(".boot2docker/certs");
     }
     
     private static Matcher<String> pathEndsWith(String suffix) {


### PR DESCRIPTION
#### Short description of what this resolves:

Tests fails if machine where running test has CERT_PATH environment variable set

#### Changes proposed in this pull request:

- make assertions more generic


**Fixes**: #496

@iocanel looks good to you? It seems now it should work regarding the environment variable value. At least for 99% of the cases where people uses the default docker machine layout (~/.docker/machine/machines).