### PR TITLE
[Issue #506] Put reporting parameters like IO, network, disk usage into a table form

### DIFF
--- a/docker/ftest/pom.xml
+++ b/docker/ftest/pom.xml
@@ -14,8 +14,6 @@
         <version.tomcat>1.0.0.CR7</version.tomcat>
         <version.wildfly>8.2.0.Final</version.wildfly>
         <version.arquillian_tck>1.0.0.Alpha1</version.arquillian_tck>
-        <docker.api.version>1.12</docker.api.version>
-        <docker.api.url>tcp://localhost:2375</docker.api.url>
     </properties>
 
     <dependencyManagement>

--- a/docker/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/docker/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -91,10 +91,4 @@ public class CubeControllerTest {
         assertThat(changesOnFilesystem.size() > 0, is(true));
     }
 
-    @Test
-    public void should_copy_files_from_container(@ArquillianResource CubeController cubeController, @ArquillianResource CubeID cubeID) throws IOException {
-        File newFolder = folder.newFolder();
-        cubeController.copyFileDirectoryFromContainer(cubeID, "/tomcat/logs", newFolder.getAbsolutePath());
-        //needs manual inspection on /tmp/.... because this test is executed on server side but the files are copied in client side. 
-    }
 }

--- a/docker/ftest/src/test/java/org/arquillian/cube/servlet/HelloWorldServletTest.java
+++ b/docker/ftest/src/test/java/org/arquillian/cube/servlet/HelloWorldServletTest.java
@@ -87,15 +87,6 @@ public class HelloWorldServletTest {
     }
 
     @Test
-    public void should_copy_files_from_container(@ArquillianResource CubeController cubeController, @ArquillianResource CubeID cubeID) throws IOException {
-        File newFolder = folder.newFolder();
-        cubeController.copyFileDirectoryFromContainer(cubeID, "/tomcat/logs", newFolder.getAbsolutePath());
-        File logFolder = newFolder.listFiles()[0];
-        assertThat(logFolder, notNullValue());
-        assertThat(logFolder.listFiles().length > 0, is(true));
-    }
-
-    @Test
     public void should_enrich_test_with_docker_client(@ArquillianResource CubeController cubeController) {
         assertThat(cubeController, notNullValue());
     }

--- a/docker/ftest/src/test/resources/arquillian.xml
+++ b/docker/ftest/src/test/resources/arquillian.xml
@@ -8,8 +8,6 @@
    RMI is a difficult protocol to configure :(.    -->
 
     <extension qualifier="docker">
-        <property name="serverVersion">${docker.api.version}</property>
-        <property name="serverUri">${docker.api.url}</property>
         <property name="autoStartContainers">${arquillian.cube.autostart}</property>
         <property name="definitionFormat">CUBE</property>
         <property name="dockerContainers">

--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/ContainerStatsBuilder.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/ContainerStatsBuilder.java
@@ -10,27 +10,31 @@ import java.util.Map;
 
 public class ContainerStatsBuilder {
 
-    public static Map<String, Map<String, ?>> getStats(Statistics statistics, Boolean decimal) {
+    public static void getStats(Statistics statistics, CubeStatistics stats) {
 
-        Map<String, Map<String, ?>> stats = new LinkedHashMap<>();
         if (statistics != null){
-            Map<String, Map<String, String>> networks = extractNetworksStats(statistics.getNetworks(), decimal);
-            Map<String, String> memory = extractMemoryStats(statistics.getMemoryStats(), decimal, "usage", "max_usage", "limit");
-            Map<String, String> blkio = extractIORW(statistics.getBlkioStats(), decimal);
-            stats.put("network", networks);
-            stats.put("memory", memory);
-            stats.put("block I/O", blkio);
+
+            Map<String, Long> blkio = extractIORW(statistics.getBlkioStats());
+            Map<String, Long> memory = extractMemoryStats(statistics.getMemoryStats(), "usage", "max_usage", "limit");
+
+            stats.setIoBytesRead(blkio.get("ioBytesRead"));
+            stats.setIoBytesWrite(blkio.get("ioBytesWrite"));
+
+            stats.setMaxUsage(memory.get("max_usage"));
+            stats.setUsage(memory.get("usage"));
+            stats.setLimit(memory.get("limit"));
+
+            stats.setNetworks(extractNetworksStats(statistics.getNetworks()));
         }
-        return stats;
     }
 
-    private static Map<String, Map<String, String>> extractNetworksStats(Map<String, Object> map, boolean decimal) {
-        Map<String, Map<String, String>> nwStatsForEachNICAndTotal = new LinkedHashMap<>();
+    private static Map<String, Map<String, Long>> extractNetworksStats(Map<String, Object> map) {
+        Map<String, Map<String, Long>> nwStatsForEachNICAndTotal = new LinkedHashMap<>();
         if (map != null) {
             long totalRxBytes = 0, totalTxBytes = 0;
 
             for (Map.Entry<String, Object> entry: map.entrySet()) {
-                Map<String, String> nwStats = new LinkedHashMap<>();
+                Map<String, Long> nwStats = new LinkedHashMap<>();
                 String adapterName = entry.getKey();
                 if (entry.getValue() instanceof LinkedHashMap) {
 
@@ -39,8 +43,8 @@ public class ContainerStatsBuilder {
                     long rxBytes = NumberConversion.convertToLong(adapter.get("rx_bytes"));
                     long txBytes = NumberConversion.convertToLong(adapter.get("tx_bytes"));
 
-                    nwStats.put("rx_bytes", NumberConversion.humanReadableByteCount(rxBytes, decimal));
-                    nwStats.put("tx_bytes", NumberConversion.humanReadableByteCount(txBytes, decimal));
+                    nwStats.put("rx_bytes", rxBytes);
+                    nwStats.put("tx_bytes", txBytes);
                     nwStatsForEachNICAndTotal.put(adapterName, nwStats);
 
                     totalRxBytes += rxBytes;
@@ -48,17 +52,17 @@ public class ContainerStatsBuilder {
                 }
             }
 
-            Map<String, String> total = new LinkedHashMap<>();
+            Map<String, Long> total = new LinkedHashMap<>();
 
-            total.put("rx_bytes", NumberConversion.humanReadableByteCount(totalRxBytes, decimal));
-            total.put("tx_bytes", NumberConversion.humanReadableByteCount(totalTxBytes, decimal));
+            total.put("rx_bytes", totalRxBytes);
+            total.put("tx_bytes", totalTxBytes);
             nwStatsForEachNICAndTotal.put("Total", total);
         }
         return nwStatsForEachNICAndTotal;
     }
 
-    private static Map<String, String> extractIORW(Map<String, Object> blkioStats, Boolean decimal) {
-        Map<String, String> blkrwStats = new LinkedHashMap<>();
+    private static Map<String, Long> extractIORW(Map<String, Object> blkioStats) {
+        Map<String, Long> blkrwStats = new LinkedHashMap<>();
         if (blkioStats != null && !blkioStats.isEmpty()) {
             List<LinkedHashMap> bios = (ArrayList<LinkedHashMap>) blkioStats.get("io_service_bytes_recursive");
             long read = 0, write = 0;
@@ -76,18 +80,18 @@ public class ContainerStatsBuilder {
                     }
                 }
             }
-            blkrwStats.put("I/O Bytes Read", NumberConversion.humanReadableByteCount(read, decimal));
-            blkrwStats.put("I/O Bytes Write", NumberConversion.humanReadableByteCount(write, decimal));
+            blkrwStats.put("ioBytesRead", read);
+            blkrwStats.put("ioBytesWrite", write);
         }
         return blkrwStats;
     }
 
-    private static Map<String, String> extractMemoryStats(Map<String, Object> map, boolean decimal, String... fields) {
-        Map<String, String> memory = new LinkedHashMap<>();
+    private static Map<String, Long> extractMemoryStats(Map<String, Object> map, String... fields) {
+        Map<String, Long> memory = new LinkedHashMap<>();
         if (map != null) {
             for (String field: fields) {
                 long usage = NumberConversion.convertToLong(map.get(field));
-                memory.put(field, NumberConversion.humanReadableByteCount(usage, decimal));
+                memory.put(field, usage);
             }
         }
         return memory;

--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/ContainerStatsBuilder.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/ContainerStatsBuilder.java
@@ -17,8 +17,8 @@ public class ContainerStatsBuilder {
             Map<String, Long> blkio = extractIORW(statistics.getBlkioStats());
             Map<String, Long> memory = extractMemoryStats(statistics.getMemoryStats(), "usage", "max_usage", "limit");
 
-            stats.setIoBytesRead(blkio.get("ioBytesRead"));
-            stats.setIoBytesWrite(blkio.get("ioBytesWrite"));
+            stats.setIoBytesRead(blkio.get("io_bytes_read"));
+            stats.setIoBytesWrite(blkio.get("io_bytes_write"));
 
             stats.setMaxUsage(memory.get("max_usage"));
             stats.setUsage(memory.get("usage"));
@@ -80,8 +80,8 @@ public class ContainerStatsBuilder {
                     }
                 }
             }
-            blkrwStats.put("ioBytesRead", read);
-            blkrwStats.put("ioBytesWrite", write);
+            blkrwStats.put("io_bytes_read", read);
+            blkrwStats.put("io_bytes_write", write);
         }
         return blkrwStats;
     }

--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/CubeStatistics.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/CubeStatistics.java
@@ -1,0 +1,79 @@
+package org.arquillian.cube.docker.impl.client.reporter;
+
+import java.util.Map;
+
+public class CubeStatistics {
+
+    private Long rxBytes;
+    private Long txBytes;
+    private Long ioBytesRead;
+    private Long ioBytesWrite;
+    private Long usage;
+    private Long maxUsage;
+    private Long limit;
+    private Map<String, Map<String, Long>> networks;
+
+    public Long getIoBytesRead() {
+        return ioBytesRead;
+    }
+
+    public void setIoBytesRead(Long ioBytesRead) {
+        this.ioBytesRead = ioBytesRead;
+    }
+
+    public Long getIoBytesWrite() {
+        return ioBytesWrite;
+    }
+
+    public void setIoBytesWrite(Long ioBytesWrite) {
+        this.ioBytesWrite = ioBytesWrite;
+    }
+
+    public Long getRxBytes() {
+        return rxBytes;
+    }
+
+    public void setRxBytes(Long rxBytes) {
+        this.rxBytes = rxBytes;
+    }
+
+    public Long getTxBytes() {
+        return txBytes;
+    }
+
+    public void setTxBytes(Long txBytes) {
+        this.txBytes = txBytes;
+    }
+
+    public Long getUsage() {
+        return usage;
+    }
+
+    public void setUsage(Long usage) {
+        this.usage = usage;
+    }
+
+    public Long getMaxUsage() {
+        return maxUsage;
+    }
+
+    public void setMaxUsage(Long maxUsage) {
+        this.maxUsage = maxUsage;
+    }
+
+    public Long getLimit() {
+        return limit;
+    }
+
+    public void setLimit(Long limit) {
+        this.limit = limit;
+    }
+
+    public Map<String, Map<String, Long>> getNetworks() {
+        return networks;
+    }
+
+    public void setNetworks(Map<String, Map<String, Long>> networks) {
+        this.networks = networks;
+    }
+}

--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironment.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironment.java
@@ -104,17 +104,10 @@ public class TakeDockerEnvironment {
             executor.copyLog(beforeStop.getCubeId(), false, true, true, true, -1, new FileOutputStream(logFile));
 
             FileEntry fileEntry = new FileEntry();
-
-            final Path rootDir = Paths.get(reporterConfiguration.getRootDir().getName());
-            final Path relativize = rootDir.relativize(logFile.toPath());
-
-            GroupEntry entry = new GroupEntry(cubeId + "Logs");
-
-            fileEntry.setPath(relativize.toString());
+            fileEntry.setPath(logFile.getPath());
             fileEntry.setType("Log");
             fileEntry.setMessage("Logs of " + cubeId + " container before stop event.");
-            entry.getPropertyEntries().add(fileEntry);
-            propertyReportEvent.fire(new PropertyReportEvent(entry));
+            propertyReportEvent.fire(new PropertyReportEvent(fileEntry));
         }
     }
 
@@ -123,7 +116,7 @@ public class TakeDockerEnvironment {
         GroupEntry groupEntry = new GroupEntry("IO statistics");
         TableEntry tableEntry = new TableEntry();
 
-        tableEntry.getTableHead().getRow().addCells(new TableCellEntry("io_bytes_read", 3, 1), new TableCellEntry("io_bytes_wite", 3, 1));
+        tableEntry.getTableHead().getRow().addCells(new TableCellEntry("io_bytes_read", 3, 1), new TableCellEntry("io_bytes_write", 3, 1));
         tableEntry.getTableBody().addRows(new TableRowEntry(), new TableRowEntry());
 
         addCellsHeader(tableEntry.getTableBody().getRows().get(0), 2);
@@ -144,7 +137,7 @@ public class TakeDockerEnvironment {
 
         TableEntry tableEntry = new TableEntry();
 
-        tableEntry.getTableHead().getRow().addCells(new TableCellEntry("usage", 3, 1), new TableCellEntry("max_usage", 3, 1), new TableCellEntry("Limit"));
+        tableEntry.getTableHead().getRow().addCells(new TableCellEntry("usage", 3, 1), new TableCellEntry("max_usage", 3, 1), new TableCellEntry("limit"));
         tableEntry.getTableBody().addRows(new TableRowEntry(), new TableRowEntry());
         addCellsHeader(tableEntry.getTableBody().getRows().get(0), 2);
 

--- a/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
+++ b/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
@@ -108,6 +108,7 @@ public class TakeDockerEnvironmentTest {
 
         Map<String, String> configuration = new HashMap<>();
         configuration.put(CubeDockerConfiguration.DOCKER_CONTAINERS, MULTIPLE_PORT_BINDING_SCENARIO);
+        configuration.put("definitionFormat", DefinitionFormat.CUBE.name());
 
         takeDockerEnvironment.reportDockerEnvironment(new AfterAutoStart(), CubeDockerConfiguration.fromMap(configuration, null), dockerClientExecutor, new ReporterConfiguration());
 
@@ -119,7 +120,7 @@ public class TakeDockerEnvironmentTest {
 
         GroupEntry parent = (GroupEntry) propertyEntry;
         final List<PropertyEntry> rootEntries = parent.getPropertyEntries();
-        assertThat(rootEntries).hasSize(2);
+        assertThat(rootEntries).hasSize(3);
 
         final PropertyEntry propertyDockerInfoEntry = rootEntries.get(0);
         assertThat(propertyDockerInfoEntry).isInstanceOf(GroupEntry.class);
@@ -247,7 +248,7 @@ public class TakeDockerEnvironmentTest {
         TableEntry tableEntry = (TableEntry) entryList.get(0);
 
         assertThat(tableEntry).extracting("tableHead").extracting("row").flatExtracting("cells").
-                hasSize(3).containsExactly(new TableCellEntry("usage", 3, 1), new TableCellEntry("max_usage", 3, 1), new TableCellEntry("Limit"));
+                hasSize(3).containsExactly(new TableCellEntry("usage", 3, 1), new TableCellEntry("max_usage", 3, 1), new TableCellEntry("limit"));
 
         assertThat(tableEntry).extracting("tableBody").flatExtracting("rows").hasSize(2);
         TableRowEntry rowEntry = tableEntry.getTableBody().getRows().get(1);
@@ -279,7 +280,7 @@ public class TakeDockerEnvironmentTest {
         TableEntry tableEntry = (TableEntry) entryList.get(0);
 
         assertThat(tableEntry).extracting("tableHead").extracting("row").flatExtracting("cells").
-                hasSize(2).containsExactly(new TableCellEntry("io_bytes_read", 3, 1), new TableCellEntry("io_bytes_wite", 3, 1));
+                hasSize(2).containsExactly(new TableCellEntry("io_bytes_read", 3, 1), new TableCellEntry("io_bytes_write", 3, 1));
 
         assertThat(tableEntry).extracting("tableBody").flatExtracting("rows").hasSize(2);
         TableRowEntry rowEntry = tableEntry.getTableBody().getRows().get(1);


### PR DESCRIPTION
#### Short description of what this resolves:
Putting reporting parameters like IO, network, disk usage into a table form.
e.g.
 | rx_bytes  |
 | before | After | use |
 | 10 | 12 | 2 |
#### Changes proposed in this pull request:
-  Reporting statistics only after method with format shown above.
- Some cleanup of remoteAPI, serverURI from ftest module.



**Fixes**: #506 