### PR TITLE
[Issue-#508] - Make possible to configure the port forwarder server bind address

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/client/container/ContainerConfigurationController.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/container/ContainerConfigurationController.java
@@ -1,15 +1,5 @@
 package org.arquillian.cube.impl.client.container;
 
-import java.beans.IntrospectionException;
-import java.beans.Introspector;
-import java.beans.PropertyDescriptor;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Map.Entry;
-import java.util.regex.Pattern;
-
 import org.arquillian.cube.impl.util.ContainerUtil;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
@@ -21,15 +11,27 @@ import org.jboss.arquillian.container.spi.ContainerRegistry;
 import org.jboss.arquillian.container.spi.event.container.BeforeSetup;
 import org.jboss.arquillian.core.api.annotation.Observes;
 
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map.Entry;
+import java.util.regex.Pattern;
+
 public class ContainerConfigurationController {
+
+    private PortAddress mappingForPort = null;
 
     private static final Pattern portPattern = Pattern.compile("(?i:.*port.*)");
     //private static final Pattern hostPattern = Pattern.compile("(?i:.*host.*)");
-    //private static final Pattern addressPattern = Pattern.compile("(?i:.*address.*)");
+    private static final Pattern addressPattern = Pattern.compile("(?i:.*address.*)");
     //private static final Pattern jmxPattern = Pattern.compile("(?i:.*jmx.*)");
 
     public void remapContainer(@Observes BeforeSetup event, CubeRegistry cubeRegistry,
-            ContainerRegistry containerRegistry) throws InstantiationException, IllegalAccessException {
+                               ContainerRegistry containerRegistry) throws InstantiationException, IllegalAccessException {
 
         Container container = ContainerUtil.getContainerByDeployableContainer(containerRegistry,
                 event.getDeployableContainer());
@@ -42,40 +44,52 @@ public class ContainerConfigurationController {
             return; // No Cube found matching Container name, not managed by Cube
         }
 
-        HasPortBindings portBindings = cube.getMetadata(HasPortBindings.class);
-        if (portBindings == null) {
+        HasPortBindings bindings = cube.getMetadata(HasPortBindings.class);
+        if (bindings == null) {
             return;
         }
 
         ContainerDef containerConfiguration = container.getContainerConfiguration();
+        //Get the port property
         List<String> portPropertiesFromArquillianConfigurationFile = filterArquillianConfigurationPropertiesByPortAttribute(containerConfiguration);
+        //Get the AddressProperty property
+        List<String> addressPropertiesFromArquillianConfigurationFile = filterArquillianConfigurationPropertiesByAddressAttribute(containerConfiguration);
 
         Class<?> configurationClass = container.getDeployableContainer().getConfigurationClass();
+        //Get the port property
         List<PropertyDescriptor> configurationClassPortFields = filterConfigurationClassPropertiesByPortAttribute(configurationClass);
+        //Get the Address property
+        List<PropertyDescriptor> configurationClassAddressFields = filterConfigurationClassPropertiesByAddressAttribute(configurationClass);
 
         Object newConfigurationInstance = configurationClass.newInstance();
 
         for (PropertyDescriptor configurationClassPortField : configurationClassPortFields) {
-            if (!portPropertiesFromArquillianConfigurationFile.contains(configurationClassPortField.getName()) && (configurationClassPortField.getPropertyType().equals(Integer.class) || configurationClassPortField.getPropertyType().equals(int.class)) ) {
+            if (!portPropertiesFromArquillianConfigurationFile.contains(configurationClassPortField.getName()) && (configurationClassPortField.getPropertyType().equals(Integer.class) || configurationClassPortField.getPropertyType().equals(int.class))) {
                 // This means that port has not configured in arquillian.xml and it will use default value.
                 // In this case is when remapping should be activated to adequate the situation according to
-                // Arquillian
-                // Cube exposed ports.
+                // Arquillian Cube exposed ports.
 
                 int containerPort = getDefaultPortFromConfigurationInstance(newConfigurationInstance,
                         configurationClass, configurationClassPortField);
 
-                PortAddress mappingForPort = null;
-                if ((mappingForPort = portBindings.getMappedAddress(containerPort)) != null) {
-                        containerConfiguration.overrideProperty(configurationClassPortField.getName(),
-                                Integer.toString(mappingForPort.getPort()));
+                if ((mappingForPort = bindings.getMappedAddress(containerPort)) != null) {
+                    containerConfiguration.overrideProperty(configurationClassPortField.getName(),
+                            Integer.toString(mappingForPort.getPort()));
                 }
+            }
+        }
+
+        for (PropertyDescriptor configurationClassAddressField : configurationClassAddressFields) {
+            if (!addressPropertiesFromArquillianConfigurationFile.contains(configurationClassAddressField.getName()) && (configurationClassAddressField.getPropertyType().equals(String.class) || configurationClassAddressField.getPropertyType().equals(String.class))) {
+                // If a property called portForwardBindAddress on openshift qualifier on arquillian.xml exists it will overrides the
+                // arquillian default|defined managementAddress with the IP address given on this property.
+                containerConfiguration.overrideProperty(configurationClassAddressField.getName(), mappingForPort.getIP());
             }
         }
     }
 
     private int getDefaultPortFromConfigurationInstance(Object configurationInstance, Class<?> configurationClass,
-            PropertyDescriptor fieldName) {
+                                                        PropertyDescriptor fieldName) {
 
         try {
             Method method = fieldName.getReadMethod();
@@ -89,7 +103,6 @@ public class ContainerConfigurationController {
         } catch (InvocationTargetException e) {
             throw new IllegalArgumentException(e);
         }
-
     }
 
     private List<String> filterArquillianConfigurationPropertiesByPortAttribute(ContainerDef containerDef) {
@@ -97,6 +110,18 @@ public class ContainerConfigurationController {
 
         for (Entry<String, String> entry : containerDef.getContainerProperties().entrySet()) {
             if (portPattern.matcher(entry.getKey()).matches()) {
+                fields.add(entry.getKey());
+            }
+        }
+
+        return fields;
+    }
+
+    private List<String> filterArquillianConfigurationPropertiesByAddressAttribute(ContainerDef containerDef) {
+        List<String> fields = new ArrayList<String>();
+
+        for (Entry<String, String> entry : containerDef.getContainerProperties().entrySet()) {
+            if (addressPattern.matcher(entry.getKey()).matches()) {
                 fields.add(entry.getKey());
             }
         }
@@ -127,4 +152,26 @@ public class ContainerConfigurationController {
         return fields;
     }
 
+    private List<PropertyDescriptor> filterConfigurationClassPropertiesByAddressAttribute(Class<?> configurationClass) {
+
+        List<PropertyDescriptor> fields = new ArrayList<PropertyDescriptor>();
+
+        try {
+            PropertyDescriptor[] propertyDescriptors = Introspector.getBeanInfo(configurationClass, Object.class)
+                    .getPropertyDescriptors();
+
+            for (PropertyDescriptor propertyDescriptor : propertyDescriptors) {
+                String propertyName = propertyDescriptor.getName();
+
+                if (addressPattern.matcher(propertyName).matches()) {
+                    fields.add(propertyDescriptor);
+                }
+            }
+
+        } catch (IntrospectionException e) {
+            throw new IllegalArgumentException(e);
+        }
+
+        return fields;
+    }
 }

--- a/core/src/test/java/org/arquillian/cube/impl/util/TestPortBindings.java
+++ b/core/src/test/java/org/arquillian/cube/impl/util/TestPortBindings.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.impl.util;
 
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -62,6 +63,11 @@ public class TestPortBindings implements HasPortBindings {
         if (mappedPorts.containsKey(targetPort)) {
             return mappedPorts.get(targetPort);
         }
+        return null;
+    }
+
+    @Override
+    public InetAddress getPortForwardBindAddress() {
         return null;
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.docker.impl.model;
 
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -311,6 +312,11 @@ public class DockerCube extends BaseCube<CubeContainer> {
             if (mappedPorts.containsKey(targetPort)) {
                 return mappedPorts.get(targetPort);
             }
+            return null;
+        }
+
+        @Override
+        public InetAddress getPortForwardBindAddress() {
             return null;
         }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -28,6 +28,7 @@ public class CubeOpenShiftConfiguration {
     private static final String DEFINITIONS = "definitions";
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String PROXIED_CONTAINER_PORTS = "proxiedContainerPorts";
+    private static final String PORT_FORWARDER_BIND_ADDRESS = "portForwardBindAddress";
 
     private final String originServer;
     private final String namespace;
@@ -36,8 +37,9 @@ public class CubeOpenShiftConfiguration {
     private final String definitionsFile;
     private final String[] autoStartContainers;
     private final Set<String> proxiedContainerPorts;
+    private final String portForwardBindAddress;
 
-    public CubeOpenShiftConfiguration(String originServer, String namespace, boolean keepAliveGitServer, String definitions, String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts) {
+    public CubeOpenShiftConfiguration(String originServer, String namespace, boolean keepAliveGitServer, String definitions, String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts, String portForwardBindAddress) {
         this.originServer = originServer;
         this.namespace = namespace;
         this.keepAliveGitServer = keepAliveGitServer;
@@ -45,6 +47,7 @@ public class CubeOpenShiftConfiguration {
         this.definitionsFile = definitionsFile;
         this.autoStartContainers = autoStartContainers;
         this.proxiedContainerPorts = proxiedContainerPorts;
+        this.portForwardBindAddress = portForwardBindAddress;
     }
 
     public String getOriginServer() {
@@ -85,6 +88,9 @@ public class CubeOpenShiftConfiguration {
         return proxiedContainerPorts;
     }
 
+    public String getPortForwardBindAddress() {
+        return portForwardBindAddress;
+    }
 
     private static String[] split(String str, String regex) {
         if (str == null || str.isEmpty()) {
@@ -104,6 +110,7 @@ public class CubeOpenShiftConfiguration {
                     .withDefinitionsFile(getStringProperty(DEFINITIONS_FILE, map, null))
                     .withAutoStartContainers(split(getStringProperty(AUTO_START_CONTAINERS, map, ""), ","))
                     .withProxiedContainerPorts(split(getStringProperty(PROXIED_CONTAINER_PORTS, map, ""), ","))
+                    .withPortForwardBindAddress(getStringProperty(PORT_FORWARDER_BIND_ADDRESS, map, "127.0.0.1"))
                     .build();
 
             if (conf.getDefinitions() == null && conf.getDefinitionsFile() == null) {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/ServiceCube.java
@@ -4,6 +4,7 @@ import static org.arquillian.cube.openshift.impl.client.ResourceUtil.toBinding;
 import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServicePort;
 
+import java.net.InetAddress;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashSet;
@@ -158,6 +159,11 @@ public class ServiceCube extends BaseCube<Void> {
             if (mappedPorts.containsKey(targetPort)) {
                 return mappedPorts.get(targetPort);
             }
+            return null;
+        }
+
+        @Override
+        public InetAddress getPortForwardBindAddress() {
             return null;
         }
 

--- a/spi/src/main/java/org/arquillian/cube/spi/metadata/HasPortBindings.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/metadata/HasPortBindings.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.spi.metadata;
 
+import java.net.InetAddress;
 import java.util.Set;
 
 /**
@@ -52,6 +53,13 @@ public interface HasPortBindings extends CubeMetadata {
     PortAddress getMappedAddress(int targetPort);
 
     /**
+     * @return the mapped address in the arquillian.xml,defined by the
+     *         portForwardBindAddress property.
+     *         If null, returns the default - 127.0.0.1.
+     */
+    InetAddress getPortForwardBindAddress();
+
+    /**
      * Port mapping for a bound port. The socket address that should be used to
      * configure network connections to the specified contianer port.
      */
@@ -90,4 +98,5 @@ public interface HasPortBindings extends CubeMetadata {
         }
         
     }
+
 }


### PR DESCRIPTION
**Fixes**: #508

Make possible to configure the port forwarder server bind address.
In that way you can run more than once instance of the port forwarder
on the same machine.