### PR TITLE
Updates file path to relative path and add file entry to group entry for improved readability in reports.

### DIFF
--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironment.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironment.java
@@ -100,14 +100,18 @@ public class TakeDockerEnvironment {
         final String cubeId = beforeStop.getCubeId();
         if (cubeId != null) {
             final File logFile = new File(createContainerLogDirectory(reporterConfiguration.getRootDir()), cubeId + ".log");
+            final Path rootDir = Paths.get(reporterConfiguration.getRootDir().getName());
+            final Path relativePath = rootDir.relativize(logFile.toPath());
 
             executor.copyLog(beforeStop.getCubeId(), false, true, true, true, -1, new FileOutputStream(logFile));
 
+            GroupEntry groupEntry = new GroupEntry(cubeId + " logs");
             FileEntry fileEntry = new FileEntry();
-            fileEntry.setPath(logFile.getPath());
+            fileEntry.setPath(relativePath.toString());
             fileEntry.setType("Log");
             fileEntry.setMessage("Logs of " + cubeId + " container before stop event.");
-            propertyReportEvent.fire(new PropertyReportEvent(fileEntry));
+            groupEntry.getPropertyEntries().add(fileEntry);
+            propertyReportEvent.fire(new PropertyReportEvent(groupEntry));
         }
     }
 

--- a/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
+++ b/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
@@ -184,10 +184,13 @@ public class TakeDockerEnvironmentTest {
 
         final PropertyReportEvent propertyReportEvent = propertyReportEventArgumentCaptor.getValue();
         final PropertyEntry propertyEntry = propertyReportEvent.getPropertyEntry();
-        assertThat(propertyEntry).isInstanceOf(FileEntry.class);
+        assertThat(propertyEntry).isInstanceOf(GroupEntry.class);
 
-        FileEntry fileEntry = (FileEntry) propertyEntry;
-        assertThat(fileEntry.getPath()).isEqualTo("target/reports/logs/tomcat.log");
+        List<PropertyEntry> childEntry = propertyEntry.getPropertyEntries();
+        assertThat(childEntry).hasSize(1).extracting("class.simpleName").containsExactly("FileEntry");
+
+        FileEntry fileEntry = (FileEntry) childEntry.get(0);
+        assertThat(fileEntry.getPath()).isEqualTo("reports/logs/tomcat.log");
     }
 
     @Test

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
         <version.undertow>1.3.24.Final</version.undertow>
         <version.arquillian_spacelift>1.0.0.Alpha8</version.arquillian_spacelift>
         <version.assertj>2.5.0</version.assertj>
-        <version.arquillian.recorder>1.1.4.Final</version.arquillian.recorder>
+        <version.arquillian.recorder>1.1.5.Final</version.arquillian.recorder>
         <version.restassured>3.0.0</version.restassured>
         <version.jgit>4.5.0.201609210915-r</version.jgit>
     </properties>


### PR DESCRIPTION
#### Short description of what this resolves:

Update the file path to relative path to avoid duplication in the file path entry while rendering the file location as link in the report.
#### Changes proposed in this pull request:
- Relativize log file path for use by Recorder for generating reports. 
- Grouping file entry for better readability in generated reports.  

**Fixes**: #512 
