### PR TITLE
[Issue #515] Modifies logic to show negative numbers  in human readable format.

### DIFF
--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/utils/NumberConversion.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/utils/NumberConversion.java
@@ -6,13 +6,15 @@ import org.arquillian.cube.docker.impl.util.NumberType;
 public class NumberConversion {
 
     public static String humanReadableByteCount(Long bytes, boolean decimal) {
-        int unit = decimal ? 1000 : 1024;
         if (bytes == null) bytes = 0L;
-        if (bytes < unit) return bytes + " B";
-        int exp = (int) (Math.log(bytes) / Math.log(unit));
+        String sign = bytes < 0 ? "-" : "";
+        Long absBytes = Math.abs(bytes);
+        int unit = decimal ? 1000 : 1024;
+        if (absBytes < unit) return sign + absBytes + " B";
+        int exp = (int) (Math.log(absBytes) / Math.log(unit));
         String pre = (decimal ? "kMGTPE" : "KMGTPE").charAt(exp-1) + (decimal ? "" : "i");
 
-        return String.format("%.2f %sB", bytes / Math.pow(unit, exp), pre);
+        return sign + String.format("%.2f %sB", absBytes / Math.pow(unit, exp), pre);
     }
 
     public static long convertToLong(Object number) {

--- a/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/utils/NumberConversion.java
+++ b/docker/recorder/src/main/java/org/arquillian/cube/docker/impl/client/utils/NumberConversion.java
@@ -10,11 +10,13 @@ public class NumberConversion {
         String sign = bytes < 0 ? "-" : "";
         Long absBytes = Math.abs(bytes);
         int unit = decimal ? 1000 : 1024;
-        if (absBytes < unit) return sign + absBytes + " B";
+        if (absBytes < unit) {
+            return sign + absBytes + " B";
+        }
         int exp = (int) (Math.log(absBytes) / Math.log(unit));
         String pre = (decimal ? "kMGTPE" : "KMGTPE").charAt(exp-1) + (decimal ? "" : "i");
 
-        return sign + String.format("%.2f %sB", absBytes / Math.pow(unit, exp), pre);
+        return  String.format("%s %.2f %sB", sign, absBytes / Math.pow(unit, exp), pre).trim();
     }
 
     public static long convertToLong(Object number) {

--- a/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/utils/NumberConversionTest.java
+++ b/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/utils/NumberConversionTest.java
@@ -86,6 +86,6 @@ public class NumberConversionTest {
 
     @Test
     public void should_be_possible_to_show_negative_kikibytes_in_human_readable_form(){
-        assertThat(humanReadableByteCount(NEGATIVE_ONE_KIKIBYTE, false), is("-1.00 KiB"));
+        assertThat(humanReadableByteCount(NEGATIVE_ONE_KIKIBYTE, false), is("- 1.00 KiB"));
     }
 }

--- a/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/utils/NumberConversionTest.java
+++ b/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/utils/NumberConversionTest.java
@@ -13,6 +13,8 @@ public class NumberConversionTest {
 
     private static final Long ONE_KIKIBYTE = 1024L;
 
+    private static final Long NEGATIVE_ONE_KIKIBYTE = -1024L;
+
     private static final Long ONE_TERABYTES = 1000000000000L;
 
     private static final Long HUNDRED_GIGABYTES = 100000000000L;
@@ -82,4 +84,8 @@ public class NumberConversionTest {
         assertThat(humanReadableByteCount(ONE_EXBIBYTE, false), is("1.00 EiB"));
     }
 
+    @Test
+    public void should_be_possible_to_show_negative_kikibytes_in_human_readable_form(){
+        assertThat(humanReadableByteCount(NEGATIVE_ONE_KIKIBYTE, false), is("-1.00 KiB"));
+    }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
If there is negative number in container statistics then it should show proper human readable number with sign.

#### Changes proposed in this pull request:
- Changed logic to show human readable format.

**Fixes**: #515

