### PR TITLE
Added CountLatch to use it for StatsCmd.

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StatsLogsResultCallback.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StatsLogsResultCallback.java
@@ -3,12 +3,15 @@ package org.arquillian.cube.docker.impl.await;
 import com.github.dockerjava.api.model.Statistics;
 import com.github.dockerjava.core.async.ResultCallbackTemplate;
 
+import java.util.concurrent.CountDownLatch;
 
 public class StatsLogsResultCallback extends ResultCallbackTemplate<StatsLogsResultCallback, Statistics> {
 
-    private Statistics statistics = null;
+    private Statistics statistics;
+    private CountDownLatch countDownLatch;
 
-    public StatsLogsResultCallback() {
+    public StatsLogsResultCallback(CountDownLatch countDownLatch) {
+        this.countDownLatch = countDownLatch;
     }
 
     @Override
@@ -17,6 +20,7 @@ public class StatsLogsResultCallback extends ResultCallbackTemplate<StatsLogsRes
             this.statistics = statistics;
             this.onComplete();
         }
+        this.countDownLatch.countDown();
     }
 
     public Statistics getStatistics() {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -506,7 +506,7 @@ public class DockerClientExecutor {
             StatsLogsResultCallback statslogs = new StatsLogsResultCallback(countDownLatch);
             try {
                 StatsLogsResultCallback statscallback = statsCmd.exec(statslogs);
-                countDownLatch.await(3, TimeUnit.SECONDS);
+                countDownLatch.await(5, TimeUnit.SECONDS);
                 statscallback.close();
             } catch (InterruptedException e) {
                 throw new IOException(e);


### PR DESCRIPTION
#### Short description of what this resolves:
Only tomcat container is stopping other thread execution even if call `onComplete()` event in StatsLogsResultCallback when you have added recorder dependency in your class path.

#### Changes proposed in this pull request:
- Added CountDownLatch for StatsLogsResultCallback So even if after onComplete event is stopping execution of other thread, it'll timeout after timeout period.

**Fixes**: #519 
