### PR TITLE
In case that user does not specify a tag, latest is used by default.

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -719,6 +719,8 @@ public class DockerClientExecutor {
             String tag = image.getTag();
             if (tag != null && !"".equals(tag)) {
                 pullImageCmd.withTag(tag);
+            } else {
+                pullImageCmd.withTag("latest");
             }
 
             pullImageCmd.exec(new PullImageResultCallback()).awaitSuccess();


### PR DESCRIPTION

#### Short description of what this resolves:

In case of not setting a tag, all tags are downloaded

#### Changes proposed in this pull request:

- if no tag is specified, latest is set by default.

**Fixes**: #523 

