### PR TITLE
Adds tcp scheme on tls_verify resolution

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -1,7 +1,5 @@
 package org.arquillian.cube.docker.impl.client;
 
-import org.arquillian.cube.docker.impl.client.config.CubeContainer;
-import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.arquillian.cube.docker.impl.util.AbstractCliInternetAddressResolver;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
@@ -19,11 +17,9 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.util.Collection;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.UUID;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
@@ -210,7 +206,7 @@ public class CubeDockerConfigurationResolver {
         URI serverUri = URI.create(config.get(CubeDockerConfiguration.DOCKER_URI));
         String scheme = serverUri.getScheme();
 
-        if (scheme.equals(HTTP_SCHEME) || scheme.equals(HTTPS_SCHEME)) {
+        if (scheme.equals(HTTP_SCHEME) || scheme.equals(HTTPS_SCHEME) || scheme.equals(TCP_SCHEME)) {
             config.put(CubeDockerConfiguration.TLS_VERIFY, Boolean.toString(scheme.equals(HTTPS_SCHEME)));
 
             try {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
@@ -1,0 +1,50 @@
+package org.arquillian.cube.docker.impl.client;
+
+import org.arquillian.cube.docker.impl.util.Boot2Docker;
+import org.arquillian.cube.docker.impl.util.DockerMachine;
+import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.Top;
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.junit.Assert.assertThat;
+
+public class CubeDockerConfigurationResolverTest {
+
+    @Test
+    public void shouldNotSetTlsVerifyForTcpSchemeOnOSX() {
+        CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
+                new DockerMachine(null),
+                new Boot2Docker(null),
+                OperatingSystemFamily.MAC);
+
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://localhost:2376");
+
+        Map<String, String> resolvedConfig = resolver.resolve(config);
+
+        assertThat(Boolean.valueOf(resolvedConfig.get(CubeDockerConfiguration.TLS_VERIFY)), is(false));
+        assertThat(resolvedConfig.get(CubeDockerConfiguration.CERT_PATH), is(nullValue()));
+    }
+
+    @Test
+    public void shouldNotSetTlsVerifyForTcpSchemeOnLinux() {
+        CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
+                new DockerMachine(null),
+                new Boot2Docker(null),
+                OperatingSystemFamily.LINUX);
+
+        Map<String, String> config = new HashMap<>();
+        config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://localhost:2376");
+
+        Map<String, String> resolvedConfig = resolver.resolve(config);
+
+        assertThat(Boolean.valueOf(resolvedConfig.get(CubeDockerConfiguration.TLS_VERIFY)), is(false));
+        assertThat(resolvedConfig.get(CubeDockerConfiguration.CERT_PATH), is(nullValue()));
+    }
+
+}


### PR DESCRIPTION

#### Short description of what this resolves:

If docker host scheme is set to TCP, then TLS_VERIFY is set to true when it shouldn't.

#### Changes proposed in this pull request:

- Add TCP scheme in logic in charge of deciding if TLS should be used or not.

**Fixes**: #525 

