### PR TITLE
changes configuring restassuerd from static code to RequestSpecBuilder

### DIFF
--- a/docker/ftest-restassured/src/test/java/org/arquillian/cube/restassured/PingPongTest.java
+++ b/docker/ftest-restassured/src/test/java/org/arquillian/cube/restassured/PingPongTest.java
@@ -1,8 +1,10 @@
 package org.arquillian.cube.restassured;
 
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import org.arquillian.cube.docker.impl.requirement.RequiresDockerMachine;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -14,9 +16,18 @@ import static org.hamcrest.CoreMatchers.equalTo;
 @RequiresDockerMachine(name = "dev")
 public class PingPongTest {
 
+    @ArquillianResource
+    RequestSpecBuilder requestSpecBuilder;
+
     @Test
     public void should_receive_ok_message() throws MalformedURLException, InterruptedException {
-        RestAssured.get().then().assertThat().body("status", equalTo("OK"));
+        RestAssured
+                .given()
+                .spec(requestSpecBuilder.build())
+                .when()
+                .get()
+                .then()
+                .assertThat().body("status", equalTo("OK"));
     }
 
 }

--- a/docker/ftest-restassured/src/test/java/org/arquillian/cube/restassured/PingPongTest.java
+++ b/docker/ftest-restassured/src/test/java/org/arquillian/cube/restassured/PingPongTest.java
@@ -23,11 +23,11 @@ public class PingPongTest {
     public void should_receive_ok_message() throws MalformedURLException, InterruptedException {
         RestAssured
                 .given()
-                .spec(requestSpecBuilder.build())
+                    .spec(requestSpecBuilder.build())
                 .when()
-                .get()
+                    .get()
                 .then()
-                .assertThat().body("status", equalTo("OK"));
+                    .assertThat().body("status", equalTo("OK"));
     }
 
 }

--- a/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RequestSpecBuilderResourceProvider.java
+++ b/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RequestSpecBuilderResourceProvider.java
@@ -1,0 +1,32 @@
+package org.arquillian.cube.docker.restassured;
+
+import io.restassured.builder.RequestSpecBuilder;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+
+public class RequestSpecBuilderResourceProvider implements ResourceProvider {
+
+    @Inject
+    private Instance<RequestSpecBuilder> requestSpecBuilderInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return RequestSpecBuilder.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+
+        RequestSpecBuilder requestSpecBuilder = requestSpecBuilderInstance.get();
+
+        if (requestSpecBuilder == null) {
+            throw new IllegalStateException("RequestSpecBuilder was not found.");
+        }
+
+        return requestSpecBuilder;
+    }
+}

--- a/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RestAssuredConfiguration.java
+++ b/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RestAssuredConfiguration.java
@@ -61,14 +61,6 @@ public class RestAssuredConfiguration {
         return baseUri;
     }
 
-    public boolean isRootPath() {
-        return rootPath != null && !rootPath.isEmpty();
-    }
-
-    public String getRootPath() {
-        return rootPath;
-    }
-
     public String[] getExclusionContainers() {
         return exclusionContainers;
     }

--- a/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RestAssuredCustomizer.java
+++ b/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RestAssuredCustomizer.java
@@ -1,9 +1,12 @@
 package org.arquillian.cube.docker.restassured;
 
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
 import org.arquillian.cube.docker.impl.util.SinglePortBindResolver;
 import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.core.api.event.ManagerStopping;
@@ -15,6 +18,10 @@ public class RestAssuredCustomizer {
 
     @Inject
     Instance<CubeDockerConfiguration> cubeDockerConfigurationInstance;
+
+    @Inject
+    @ApplicationScoped
+    InstanceProducer<RequestSpecBuilder> requestSpecBuilderInstanceProducer;
 
     /**
      * Method executed before starting a test.
@@ -28,42 +35,45 @@ public class RestAssuredCustomizer {
     public void configure(@Observes RestAssuredConfiguration restAssuredConfiguration) {
 
         CubeDockerConfiguration cubeDockerConfiguration = cubeDockerConfigurationInstance.get();
+        final RequestSpecBuilder requestSpecBuilder = new RequestSpecBuilder();
 
+        configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
+
+        requestSpecBuilderInstanceProducer.set(requestSpecBuilder);
+
+    }
+
+    void configureRequestSpecBuilder(@Observes RestAssuredConfiguration restAssuredConfiguration, CubeDockerConfiguration cubeDockerConfiguration, RequestSpecBuilder requestSpecBuilder) {
         if (restAssuredConfiguration.isBaseUriSet()) {
-            RestAssured.baseURI = restAssuredConfiguration.getBaseUri();
+            requestSpecBuilder.setBaseUri(restAssuredConfiguration.getBaseUri());
         } else {
-            RestAssured.baseURI = restAssuredConfiguration.getSchema() + "://" + cubeDockerConfiguration.getDockerServerIp();
+            requestSpecBuilder.setBaseUri(restAssuredConfiguration.getSchema() + "://" + cubeDockerConfiguration.getDockerServerIp());
         }
 
         if (restAssuredConfiguration.isPortSet()) {
-            RestAssured.port = SinglePortBindResolver.resolveBindPort(cubeDockerConfiguration,
+            requestSpecBuilder.setPort(SinglePortBindResolver.resolveBindPort(cubeDockerConfiguration,
                     restAssuredConfiguration.getPort(),
-                    restAssuredConfiguration.getExclusionContainers());
+                    restAssuredConfiguration.getExclusionContainers()));
         } else {
-            RestAssured.port = SinglePortBindResolver.resolveBindPort(cubeDockerConfiguration,
-                    restAssuredConfiguration.getExclusionContainers());
+            requestSpecBuilder.setPort(SinglePortBindResolver.resolveBindPort(cubeDockerConfiguration,
+                    restAssuredConfiguration.getExclusionContainers()));
         }
 
         if (restAssuredConfiguration.isBasePathSet()) {
-            RestAssured.basePath = restAssuredConfiguration.getBasePath();
+            requestSpecBuilder.setBasePath(restAssuredConfiguration.getBasePath());
         }
 
         if (restAssuredConfiguration.isAuthenticationSchemeSet()) {
-            RestAssured.authentication = restAssuredConfiguration.getAuthenticationScheme();
-        }
-
-        if (restAssuredConfiguration.isRootPath()) {
-            RestAssured.rootPath = restAssuredConfiguration.getRootPath();
+            requestSpecBuilder.setAuth(restAssuredConfiguration.getAuthenticationScheme());
         }
 
         if (restAssuredConfiguration.isUseRelaxedHttpsValidationSet()) {
             if (restAssuredConfiguration.isUseRelaxedHttpsValidationInAllProtocols()) {
-                RestAssured.useRelaxedHTTPSValidation();
+                requestSpecBuilder.setRelaxedHTTPSValidation();
             } else {
-                RestAssured.useRelaxedHTTPSValidation(restAssuredConfiguration.getUseRelaxedHttpsValidation());
+                requestSpecBuilder.setRelaxedHTTPSValidation(restAssuredConfiguration.getUseRelaxedHttpsValidation());
             }
         }
-
     }
 
     /**

--- a/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RestAssuredExtension.java
+++ b/docker/restassured/src/main/java/org/arquillian/cube/docker/restassured/RestAssuredExtension.java
@@ -1,12 +1,14 @@
 package org.arquillian.cube.docker.restassured;
 
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
 public class RestAssuredExtension implements LoadableExtension {
 
     @Override
     public void register(ExtensionBuilder builder) {
         builder.observer(RestAssuredConfigurator.class)
-                .observer(RestAssuredCustomizer.class);
+                .observer(RestAssuredCustomizer.class)
+                .service(ResourceProvider.class, RequestSpecBuilderResourceProvider.class);
     }
 }

--- a/docker/restassured/src/test/java/org/arquillian/cube/docker/restassured/RestAssuredCustomizerTest.java
+++ b/docker/restassured/src/test/java/org/arquillian/cube/docker/restassured/RestAssuredCustomizerTest.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.docker.restassured;
 
 import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
 import org.apache.http.conn.ssl.AllowAllHostnameVerifier;
 import org.apache.http.conn.ssl.SSLSocketFactory;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
@@ -16,6 +17,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
@@ -29,6 +31,9 @@ public class RestAssuredCustomizerTest {
     @Mock
     CubeDockerConfiguration cubeDockerConfiguration;
 
+    @Mock
+    RequestSpecBuilder requestSpecBuilder;
+
     @Before
     public void setup() {
         when(cubeDockerConfiguration.getDockerServerIp()).thenReturn("192.168.99.100");
@@ -38,127 +43,84 @@ public class RestAssuredCustomizerTest {
     @Test
     public void should_autoresolve_base_uri() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
-
         Map<String, String> conf = new HashMap<>();
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
 
-        assertThat(RestAssured.baseURI).isEqualTo("http://192.168.99.100");
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
+        verify(requestSpecBuilder).setBaseUri("http://192.168.99.100");
+
     }
 
     @Test
     public void should_autoresolve_base_uri_with_schema_if_set() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
 
         Map<String, String> conf = new HashMap<>();
         conf.put("schema", "https");
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
-
-        assertThat(RestAssured.baseURI).isEqualTo("https://192.168.99.100");
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
+        verify(requestSpecBuilder).setBaseUri("https://192.168.99.100");
     }
 
     @Test
     public void should_use_base_uri() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
 
         Map<String, String> conf = new HashMap<>();
         conf.put("baseUri", "http://localhost");
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
 
-        assertThat(RestAssured.baseURI).isEqualTo("http://localhost");
+        verify(requestSpecBuilder).setBaseUri(("http://localhost"));
     }
 
     @Test
     public void should_autoresolve_port() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
 
         Map<String, String> conf = new HashMap<>();
         conf.put("baseUri", "http://localhost");
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
 
-        assertThat(RestAssured.port).isEqualTo(8080);
+        verify(requestSpecBuilder).setPort(8080);
     }
 
     @Test
     public void should_resolve_exposed_port() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
 
         Map<String, String> conf = new HashMap<>();
         conf.put("baseUri", "http://localhost");
         conf.put("port", "80");
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
 
-        assertThat(RestAssured.port).isEqualTo(8080);
+        verify(requestSpecBuilder).setPort(8080);
     }
 
     @Test
     public void should_resolve_exposed_port_as_bind_port_if_no_definitions() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
 
         Map<String, String> conf = new HashMap<>();
         conf.put("baseUri", "http://localhost");
         conf.put("port", "8081");
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
 
-        assertThat(RestAssured.port).isEqualTo(8081);
+        verify(requestSpecBuilder).setPort(8081);
     }
 
     @Test
     public void should_set_relaxed_https_validation_in_all_protocols() {
         RestAssuredCustomizer restAssuredCustomizer = new RestAssuredCustomizer();
-        restAssuredCustomizer.cubeDockerConfigurationInstance = new Instance<CubeDockerConfiguration>() {
-            @Override
-            public CubeDockerConfiguration get() {
-                return cubeDockerConfiguration;
-            }
-        };
 
         Map<String, String> conf = new HashMap<>();
         conf.put("baseUri", "http://localhost");
@@ -166,10 +128,9 @@ public class RestAssuredCustomizerTest {
         conf.put("useRelaxedHttpsValidation", null);
 
         final RestAssuredConfiguration restAssuredConfiguration = RestAssuredConfiguration.fromMap(conf);
-        restAssuredCustomizer.configure(restAssuredConfiguration);
+        restAssuredCustomizer.configureRequestSpecBuilder(restAssuredConfiguration, cubeDockerConfiguration, requestSpecBuilder);
 
-        final SSLSocketFactory sslSocketFactory = RestAssured.config().getSSLConfig().getSSLSocketFactory();
-        assertThat(sslSocketFactory.getHostnameVerifier()).isInstanceOf(AllowAllHostnameVerifier.class);
+        verify(requestSpecBuilder).setRelaxedHTTPSValidation();
     }
 
 }

--- a/docs/restassured.adoc
+++ b/docs/restassured.adoc
@@ -23,6 +23,15 @@ RestAssured.baseURI = "http://myhost.org";
 RestAssured.port = 5000;
 ----
 
+or using RequestSpecBuilder
+
+----
+spec = new RequestSpecBuilder()
+            .setContentType(ContentType.JSON)
+            .setBaseUri("http://localhost:8080/")
+            .build();
+----
+
 === Why integration with Cube?
 
 Previous approach works but it has some problems:
@@ -31,7 +40,7 @@ Previous approach works but it has some problems:
 * Requires some development interference of the developer, if it is running in docker machine needs to set one _ip_ which might change in the future, or if running on native linux must be changed to _localhost_.
 * Any change on Rest-Assured configuration properties would make all tests fails.
 
-To fix these problems, you can use Arquillian Cube Docker RestAssured integration.
+To fix these problems, you can use Arquillian Cube Docker RestAssured integration which creates a `RequestSpecBuilder` with correct values set.
 
 === Configuration
 
@@ -78,10 +87,6 @@ By default, if your scenario is not complex you don't need to configure anything
 |basePath
 |
 |Base path (context) of the application
-
-|rootPath
-|
-|Root path property of RestAssured. http://code.google.com/p/rest-assured/wiki/Usage#Root_path
 
 |useRelaxedHttpsValidation
 |
@@ -134,12 +139,18 @@ You only need to do:
 @RunWith(Arquillian.class)
 public class PingPongTest {
 
+    @ArquillianResource
+    RequestSpecBuilder requestSpecBuilder;
+
     @Test
     public void should_receive_ok_message() throws MalformedURLException, InterruptedException {
-        RestAssured.get()
+        RestAssured
+            .given()
+            .spec(requestSpecBuilder.build())
+            .when()
+            .get()
             .then()
-                .assertThat()
-                .body("status", equalTo("OK"));
+            .assertThat().body("status", equalTo("OK"));
     }
 
 }


### PR DESCRIPTION

#### Short description of what this resolves:

Instead of configuring RestAssured using static code, now users can inject `RequestSpecBuilder` in test with docker values initialized.

#### Changes proposed in this pull request:

- RestAssured static code is not called anymore
- `RequestSpecBuilder` is injected with docker values
-


**Fixes**: #530 

