### PR TITLE
CircleCI now uses a machine with docker.

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -13,6 +13,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+machine:
+  java:
+    version: openjdk8
+  services:
+    - docker
 
 dependencies:
   override:


### PR DESCRIPTION
We need to run our tests on a machine that has at least docker available, so that @RequiresDocker is satisfied.

