### PR TITLE
Add support for the f-m-p version 3.x.

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResouceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResouceLocator.java
@@ -7,24 +7,23 @@ import java.net.URL;
 public class DefaultKubernetesResouceLocator implements KubernetesResourceLocator {
 
     private static final String ROOT = "/";
-    private static final String RESOURCE_NAME = "kubernetes";
+    private static final String[] RESOURCE_NAMES = new String[] { "kubernetes", "META-INF/fabric8/kubernetes" };
     private static final String[] ALLOWED_SUFFIXES = {".json", ".yml", ".yaml"};
-
 
     @Override
     public URL locate() {
         for (String suffix : ALLOWED_SUFFIXES) {
-            URL candidate = getResource(RESOURCE_NAME + suffix);
-            if (candidate != null) {
-                return candidate;
+            for (String resource : RESOURCE_NAMES) {
+                URL candidate = getResource(resource + suffix);
+                if (candidate != null) {
+                    return candidate;
+                }
             }
         }
         return null;
     }
 
-
     URL getResource(String resource) {
         return KubernetesResourceLocator.class.getResource(resource.startsWith(ROOT) ? resource : ROOT + resource);
     }
-
 }


### PR DESCRIPTION
The fabric8-maven-plugin in version 3.x generates and stores kubernetes/openshift resources in a different directory.

It would be awesome if we also looked there, when we are trying to discover kubernetes/openshift resources.