### PR TITLE
adds @DockerUrl annotation enrichment in URLs

### DIFF
--- a/api/src/main/java/org/arquillian/cube/DockerUrl.java
+++ b/api/src/main/java/org/arquillian/cube/DockerUrl.java
@@ -1,0 +1,26 @@
+package org.arquillian.cube;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.FIELD;
+import static java.lang.annotation.ElementType.PARAMETER;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({FIELD, PARAMETER})
+@Retention(RUNTIME)
+@Documented
+public @interface DockerUrl {
+
+   /**
+    * Sets the cube name where you want to get the exposed port. Only useful in case of not using Container Object pattern.
+    * @return Cube Name
+    */
+   String containerName();
+   int exposedPort();
+
+   String protocol() default "http";
+   String context() default "/";
+
+}

--- a/core/src/main/java/org/arquillian/cube/impl/client/CubeExtension.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/CubeExtension.java
@@ -10,6 +10,7 @@ import org.arquillian.cube.impl.client.enricher.CubeIDResourceProvider;
 import org.arquillian.cube.impl.client.enricher.CubeIpTestEnricher;
 import org.arquillian.cube.impl.client.enricher.HostIpTestEnricher;
 import org.arquillian.cube.impl.client.enricher.HostPortTestEnricher;
+import org.arquillian.cube.impl.client.enricher.StandaloneCubeUrlResourceProvider;
 import org.arquillian.cube.impl.reporter.TakeCubeInformation;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -40,7 +41,11 @@ public class CubeExtension implements LoadableExtension {
                    .observer(ContainerConfigurationController.class)
                    .observer(CubeRemoteCommandObserver.class);
             builder.service(AuxiliaryArchiveAppender.class, CubeAuxiliaryArchiveAppender.class);
+        } else {
+            // It is standalone
+            builder.service(ResourceProvider.class, StandaloneCubeUrlResourceProvider.class);
         }
+
         // Only register if container-test-impl is on classpath
         if (Validate.classExists("org.jboss.arquillian.container.test.impl.enricher.resource.OperatesOnDeploymentAwareProvider")) {
             builder.service(ResourceProvider.class, CubeIDResourceProvider.class);

--- a/core/src/main/java/org/arquillian/cube/impl/client/enricher/StandaloneCubeUrlResourceProvider.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/enricher/StandaloneCubeUrlResourceProvider.java
@@ -1,0 +1,104 @@
+package org.arquillian.cube.impl.client.enricher;
+
+import org.arquillian.cube.DockerUrl;
+import org.arquillian.cube.HostIpContext;
+import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.arquillian.cube.spi.metadata.HasPortBindings;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public class StandaloneCubeUrlResourceProvider implements ResourceProvider {
+
+   @Inject
+   Instance<HostIpContext> hostUriContext;
+
+   private static final Logger logger = Logger.getLogger(StandaloneCubeUrlResourceProvider.class.getName());
+
+   @Inject
+   Instance<CubeRegistry> cubeRegistryInstance;
+
+   @Override
+   public boolean canProvide(Class<?> aClass) {
+      return URL.class.isAssignableFrom(aClass);
+   }
+
+   @Override
+   public Object lookup(ArquillianResource arquillianResource, Annotation... annotations) {
+
+      final Optional<DockerUrl> optionalDockerUrlAnnotation = getDockerUrlAnnotation(annotations);
+      if (optionalDockerUrlAnnotation.isPresent()) {
+
+         final String host = getHost();
+
+         final DockerUrl dockerUrl = optionalDockerUrlAnnotation.get();
+         final String containerName = dockerUrl.containerName();
+
+         final int exposedPort = dockerUrl.exposedPort();
+         final int bindPort = getBindingPort(containerName, exposedPort);
+
+         if (bindPort > 0) {
+            return createUrl(host, dockerUrl, bindPort);
+         } else {
+            logger.log(Level.WARNING, String.format("There is no container with id %s.", containerName));
+         }
+
+      }
+      return null;
+   }
+
+   Object createUrl(String host, DockerUrl dockerUrl, int bindPort) {
+      try {
+         return new URL(dockerUrl.protocol(), host, bindPort, dockerUrl.context());
+      } catch (MalformedURLException e) {
+         throw new IllegalArgumentException(e);
+      }
+   }
+
+   String getHost() {
+      final HostIpContext hostIpContext = hostUriContext.get();
+      return hostIpContext.getHost();
+   }
+
+   private Optional<DockerUrl> getDockerUrlAnnotation(Annotation[] annotations) {
+
+      return Arrays.stream(annotations)
+              .filter(annotation -> DockerUrl.class.equals(annotation.annotationType()))
+              .map(annotation -> (DockerUrl) annotation)
+              .findFirst();
+
+   }
+
+   private int getBindingPort(String cubeId, int exposedPort) {
+
+      int bindPort = -1;
+
+      final Cube cube = getCube(cubeId);
+
+      if (cube != null) {
+         final HasPortBindings portBindings = (HasPortBindings) cube.getMetadata(HasPortBindings.class);
+         final HasPortBindings.PortAddress mappedAddress = portBindings.getMappedAddress(exposedPort);
+
+         if (mappedAddress != null) {
+            bindPort = mappedAddress.getPort();
+         }
+
+      }
+
+      return bindPort;
+   }
+
+   private Cube getCube(String cubeId) {
+      return cubeRegistryInstance.get().getCube(cubeId);
+   }
+}

--- a/docker/ftest-standalone-autostart/src/test/java/org/arquillian/cube/StandaloneTestCase.java
+++ b/docker/ftest-standalone-autostart/src/test/java/org/arquillian/cube/StandaloneTestCase.java
@@ -4,6 +4,7 @@ import org.arquillian.cube.docker.impl.requirement.RequiresDockerMachine;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.hamcrest.CoreMatchers;
 import org.jboss.arquillian.junit.InSequence;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -15,6 +16,8 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ArquillianConditionalRunner.class)
@@ -23,6 +26,10 @@ public class StandaloneTestCase {
 
     @HostIp
     String ip;
+
+    @DockerUrl(containerName = "pingpong", exposedPort = 8080)
+    @ArquillianResource
+    private URL url;
 
     @Test
     @InSequence(0)
@@ -34,6 +41,15 @@ public class StandaloneTestCase {
     public void shouldBeAbleToCreateAndStart() throws IOException {
         String pong = ping();
         assertThat(pong, containsString("OK"));
+    }
+
+    @Test
+    @InSequence(2)
+    public void should_be_able_to_inject_url_in_standalone() {
+        assertThat(url, is(notNullValue()));
+        assertThat(url.getProtocol(), is("http"));
+        assertThat(url.getHost(), is(ip));
+        assertThat(url.getPort(), is(8080));
     }
 
     private String ping() throws IOException {

--- a/docker/ftest-standalone-autostart/src/test/java/org/arquillian/cube/StandaloneTestCase.java
+++ b/docker/ftest-standalone-autostart/src/test/java/org/arquillian/cube/StandaloneTestCase.java
@@ -49,11 +49,11 @@ public class StandaloneTestCase {
         assertThat(url, is(notNullValue()));
         assertThat(url.getProtocol(), is("http"));
         assertThat(url.getHost(), is(ip));
-        assertThat(url.getPort(), is(8080));
+        assertThat(url.getPort(), is(80));
     }
 
     private String ping() throws IOException {
-        URL url = new URL("http://" + ip + ":8080");
+        URL url = new URL("http://" + ip + ":80");
         HttpURLConnection con = (HttpURLConnection) url.openConnection();
         con.setRequestMethod("GET");
 

--- a/docker/ftest-standalone-autostart/src/test/resources/arquillian.xml
+++ b/docker/ftest-standalone-autostart/src/test/resources/arquillian.xml
@@ -11,7 +11,7 @@
             pingpong:
               image: jonmorehouse/ping-pong
               exposedPorts: [8080/tcp]
-              portBindings: [8080->8080/tcp]
+              portBindings: [80->8080/tcp]
         </property>
     </extension>
 

--- a/docker/ftest-standalone/src/test/java/org/arquillian/cube/StandaloneTestCase.java
+++ b/docker/ftest-standalone/src/test/java/org/arquillian/cube/StandaloneTestCase.java
@@ -16,7 +16,6 @@ public class StandaloneTestCase {
     private static final String CONTAINER = "database";
 
     @ArquillianResource
-    @DockerUrl(containerName = "aaa", exposedPort = 8080)
     private CubeController cc;
 
     @Test @InSequence(0)

--- a/docker/ftest-standalone/src/test/java/org/arquillian/cube/StandaloneTestCase.java
+++ b/docker/ftest-standalone/src/test/java/org/arquillian/cube/StandaloneTestCase.java
@@ -16,6 +16,7 @@ public class StandaloneTestCase {
     private static final String CONTAINER = "database";
 
     @ArquillianResource
+    @DockerUrl(containerName = "aaa", exposedPort = 8080)
     private CubeController cc;
 
     @Test @InSequence(0)

--- a/docs/enrichers.adoc
+++ b/docs/enrichers.adoc
@@ -53,6 +53,18 @@ int tomcatPort; // gets the binding port for exposed port 8080 of container tomc
 String ip;
 ----
 
+When running Arquillian Cube with Standalone you can enrich the test with URL.
+
+[source, java]
+.DockerUrlProvider.java
+----
+@DockerUrl(containerName = "pingpong", exposedPort = 8080) // resolves bind port
+@ArquillianResource
+private URL url;
+----
+
+URL will be `http://<docker_host>:<bind_port>/`
+
 === Docker Inside Docker / Docker On Docker
 
 If you are running your tests inside your continuous integration/delivery server (for example in Jenkins) and at the same time the server is running inside Docker. Then the docker containers started for Cube are run inside a Docker container.


### PR DESCRIPTION
##### Issue Overview

Currently when running Arquillian Cube in standalone mode, you have no way to inject a URL of kind `dockerhost:portbinding/context`, you need to construct yourself by enriching test with required data and then construct the URL.

##### Expected Behaviour

```java
@DockerUrl(protocol="http", containerName = "helloworld", exposedPort = "8080", context = "/hello")
@ArquillianResource
URL url;

// Then URL would be the docker host IP + binding port of exposed port 8080 of container helloworld + context

```

##### Current Behaviour

```java
@HostIP
String ip;

@HostPort(containerName = "tomcat", value = 8080)
int tomcatPort;

@Test
public void test() {
  new URL("http", ip, tomcatPort, "hello");
}
```
**Fixes**: #553 
