### PR TITLE
Allows creating cubes from container objects programmatically

### DIFF
--- a/api/src/main/java/org/arquillian/cube/ContainerObjectConfiguration.java
+++ b/api/src/main/java/org/arquillian/cube/ContainerObjectConfiguration.java
@@ -1,0 +1,22 @@
+package org.arquillian.cube;
+
+/**
+ * Configuration options that can be overridden at the moment of creating a new instance of a container object.
+ * All options in this class can also be set with annotations for container objects referenced as fields
+ *
+ * @author <a href="mailto:rivasdiaz@gmail.com">Ramon Rivas</a>
+ */
+public interface ContainerObjectConfiguration {
+
+    String getContainerName();
+
+    String[] getPortBindings();
+
+    int[] getAwaitPorts();
+
+    String[] getEnvironmentVariables();
+
+    String[] getVolumes();
+
+    String[] getLinks();
+}

--- a/api/src/main/java/org/arquillian/cube/ContainerObjectFactory.java
+++ b/api/src/main/java/org/arquillian/cube/ContainerObjectFactory.java
@@ -1,0 +1,32 @@
+package org.arquillian.cube;
+
+/**
+ * Factory to instantiate container objects
+ *
+ * @author <a href="mailto:rivasdiaz@gmail.com">Ramon Rivas</a>
+ */
+public interface ContainerObjectFactory {
+
+    /**
+     * Creates an instance of the container object. It also creates and starts a cube defined by the container object
+     * class. Some configuration can be overridden by passing an additional ContainerObjectConfiguration instance.
+     *
+     * @param containerObjectClass type of the container object to instantiate. Required
+     * @param configuration if not null, allows specifying some configuration parameters. Optional (can be null)
+     * @param <T> type of the container object
+     * @return the newly created container object
+     */
+    <T> T createContainerObject(Class<T> containerObjectClass, ContainerObjectConfiguration configuration);
+
+    /**
+     * Creates an instance of the container object. It also creates and starts a cube defined by the container object
+     * class. Some configuration can be overridden by passing an additional ContainerObjectConfiguration instance.
+     *
+     * @param containerObjectClass type of the container object to instantiate. Required
+     * @param configuration if not null, allows specifying some configuration parameters. Optional (can be null)
+     * @param containerObjectContainer if not null, marks this object as the container of the created container object. Optional (can be null)
+     * @param <T> type of the container object
+     * @return the newly created container object
+     */
+    <T> T createContainerObject(Class<T> containerObjectClass, ContainerObjectConfiguration configuration, Object containerObjectContainer);
+}

--- a/api/src/main/java/org/arquillian/cube/ContainerObjectFactory.java
+++ b/api/src/main/java/org/arquillian/cube/ContainerObjectFactory.java
@@ -9,10 +9,20 @@ public interface ContainerObjectFactory {
 
     /**
      * Creates an instance of the container object. It also creates and starts a cube defined by the container object
+     * class.
+     *
+     * @param containerObjectClass type of the container object to instantiate
+     * @param <T> type of the container object
+     * @return the newly created container object
+     */
+    <T> T createContainerObject(Class<T> containerObjectClass);
+
+    /**
+     * Creates an instance of the container object. It also creates and starts a cube defined by the container object
      * class. Some configuration can be overridden by passing an additional ContainerObjectConfiguration instance.
      *
-     * @param containerObjectClass type of the container object to instantiate. Required
-     * @param configuration if not null, allows specifying some configuration parameters. Optional (can be null)
+     * @param containerObjectClass type of the container object to instantiate
+     * @param configuration allows specifying some configuration parameters
      * @param <T> type of the container object
      * @return the newly created container object
      */
@@ -22,9 +32,9 @@ public interface ContainerObjectFactory {
      * Creates an instance of the container object. It also creates and starts a cube defined by the container object
      * class. Some configuration can be overridden by passing an additional ContainerObjectConfiguration instance.
      *
-     * @param containerObjectClass type of the container object to instantiate. Required
-     * @param configuration if not null, allows specifying some configuration parameters. Optional (can be null)
-     * @param containerObjectContainer if not null, marks this object as the container of the created container object. Optional (can be null)
+     * @param containerObjectClass type of the container object to instantiate
+     * @param configuration if not null, allows specifying some configuration parameters
+     * @param containerObjectContainer marks this object as the container of the created container object
      * @param <T> type of the container object
      * @return the newly created container object
      */

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/ContainerObjectFactoryRegistrar.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/ContainerObjectFactoryRegistrar.java
@@ -1,0 +1,25 @@
+package org.arquillian.cube.docker.impl.client;
+
+import org.arquillian.cube.ContainerObjectFactory;
+import org.arquillian.cube.docker.impl.client.containerobject.DockerContainerObjectFactory;
+import org.arquillian.cube.spi.CubeConfiguration;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+public class ContainerObjectFactoryRegistrar {
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<ContainerObjectFactory> producer;
+
+    @Inject
+    private Instance<Injector> injector;
+
+    public void createClientCubeController(@Observes CubeConfiguration event) {
+        producer.set(injector.get().inject(new DockerContainerObjectFactory()));
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.docker.impl.client;
 
 import org.arquillian.cube.docker.impl.client.container.DockerServerIPConfigurator;
 import org.arquillian.cube.docker.impl.client.containerobject.AfterClassContainerObjectObserver;
+import org.arquillian.cube.docker.impl.client.containerobject.ContainerObjectFactoryProvider;
 import org.arquillian.cube.docker.impl.client.containerobject.CubeContainerObjectTestEnricher;
 import org.arquillian.cube.docker.impl.client.enricher.CubeResourceProvider;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -25,9 +26,11 @@ public class CubeDockerExtension implements LoadableExtension {
                .observer(StopDockerMachineAfterSuiteObserver.class)
                .observer(NetworkRegistrar.class)
                .observer(NetworkLifecycleController.class)
+               .observer(ContainerObjectFactoryRegistrar.class)
                .observer(DockerImageController.class);
 
         builder.service(ResourceProvider.class, CubeResourceProvider.class);
+        builder.service(ResourceProvider.class, ContainerObjectFactoryProvider.class);
         builder.service(TestEnricher.class, CubeContainerObjectTestEnricher.class);
 
         // Arquillian Container integration

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/ContainerObjectFactoryProvider.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/ContainerObjectFactoryProvider.java
@@ -1,0 +1,28 @@
+package org.arquillian.cube.docker.impl.client.containerobject;
+
+import java.lang.annotation.Annotation;
+import java.util.Optional;
+
+import org.arquillian.cube.ContainerObjectFactory;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+public class ContainerObjectFactoryProvider implements ResourceProvider {
+
+    @Inject
+    private Instance<ContainerObjectFactory> instance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return ContainerObjectFactory.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        return Optional.ofNullable(instance.get())
+                .orElseThrow(() -> new IllegalStateException(
+                        String.format("%s was not found.", ContainerObjectFactory.class.getSimpleName())));
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectConfiguration.java
@@ -27,6 +27,10 @@ public class CubeContainerObjectConfiguration implements ContainerObjectConfigur
         return configuration;
     }
 
+    public static CubeContainerObjectConfiguration empty() {
+        return new CubeContainerObjectConfiguration(null);
+    }
+
     @Override
     public String getContainerName() {
         return configuration.getContainerName();

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectConfiguration.java
@@ -1,0 +1,71 @@
+package org.arquillian.cube.docker.impl.client.containerobject;
+
+import java.util.Optional;
+
+import org.arquillian.cube.ContainerObjectConfiguration;
+import org.arquillian.cube.docker.impl.await.PollingAwaitStrategy;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.Link;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
+
+/**
+ * This implementation of {@link ContainerObjectConfiguration} is a bridge to {@link CubeContainer}
+ * Clients of this class are encouraged to access the internal {@link CubeContainer} for additional options
+ *
+ * @author <a href="mailto:rivasdiaz@gmail.com">Ramon Rivas</a>
+ */
+public class CubeContainerObjectConfiguration implements ContainerObjectConfiguration {
+
+    private final CubeContainer configuration;
+
+    public CubeContainerObjectConfiguration(CubeContainer configuration) {
+        this.configuration = configuration;
+    }
+
+    public CubeContainer getCubeContainerConfiguration() {
+        return configuration;
+    }
+
+    @Override
+    public String getContainerName() {
+        return configuration.getContainerName();
+    }
+
+    @Override
+    public String[] getPortBindings() {
+        return Optional.ofNullable(configuration.getPortBindings())
+                .map(links -> links.stream().map(PortBinding::toString).toArray(String[]::new))
+                .orElse(null);
+    }
+
+    @Override
+    public int[] getAwaitPorts() {
+        return Optional.ofNullable(configuration.getAwait())
+                .filter(await -> await.getStrategy().equals(PollingAwaitStrategy.TAG))
+                .map(Await::getPorts)
+                .map(ports -> ports.stream().mapToInt(Integer::intValue).toArray())
+                .orElse(null);
+    }
+
+    @Override
+    public String[] getEnvironmentVariables() {
+        return Optional.ofNullable(configuration.getEnv())
+                .map(env -> env.stream().toArray(String[]::new))
+                .orElse(null);
+    }
+
+    @Override
+    public String[] getVolumes() {
+        return Optional.ofNullable(configuration.getVolumes())
+                .map(volumes -> volumes.stream().toArray(String[]::new))
+                .orElse(null);
+    }
+
+    @Override
+    public String[] getLinks() {
+        return Optional.ofNullable(configuration.getLinks())
+                .map(links -> links.stream().map(Link::toString).toArray(String[]::new))
+                .orElse(null);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricher.java
@@ -1,451 +1,130 @@
 package org.arquillian.cube.docker.impl.client.containerobject;
 
-
-import java.io.File;
-import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 
 import org.apache.commons.lang3.ArrayUtils;
-import org.arquillian.cube.CubeController;
-import org.arquillian.cube.CubeIp;
+import org.arquillian.cube.ContainerObjectConfiguration;
+import org.arquillian.cube.ContainerObjectFactory;
 import org.arquillian.cube.containerobject.Cube;
-import org.arquillian.cube.containerobject.CubeDockerFile;
-import org.arquillian.cube.HostPort;
 import org.arquillian.cube.containerobject.Environment;
-import org.arquillian.cube.containerobject.Image;
 import org.arquillian.cube.containerobject.Link;
 import org.arquillian.cube.containerobject.Volume;
 import org.arquillian.cube.docker.impl.await.PollingAwaitStrategy;
 import org.arquillian.cube.docker.impl.client.config.Await;
-import org.arquillian.cube.docker.impl.client.config.BuildImage;
 import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.client.config.PortBinding;
-import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.docker.impl.model.DockerCube;
-import org.arquillian.cube.docker.impl.util.ContainerObjectUtil;
-import org.arquillian.cube.docker.impl.util.DockerFileUtil;
-import org.arquillian.cube.impl.client.enricher.HostPortTestEnricher;
 import org.arquillian.cube.impl.util.ReflectionUtil;
-import org.arquillian.cube.spi.CubeRegistry;
-import org.arquillian.cube.spi.metadata.HasPortBindings;
-import org.arquillian.cube.spi.metadata.HasPortBindings.PortAddress;
-import org.arquillian.cube.spi.metadata.IsContainerObject;
-import org.jboss.arquillian.core.api.Injector;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.core.spi.ServiceLoader;
 import org.jboss.arquillian.test.spi.TestEnricher;
-import org.jboss.shrinkwrap.api.Archive;
-import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
 
 public class CubeContainerObjectTestEnricher implements TestEnricher {
 
     private static final Logger logger = Logger.getLogger(CubeContainerObjectTestEnricher.class.getName());
 
-    @Inject Instance<CubeRegistry> cubeRegistryInstance;
-    @Inject Instance<ServiceLoader> serviceLoader;
-    @Inject Instance<CubeController> cubeControllerInstance;
-    @Inject Instance<DockerClientExecutor> dockerClientExecutorInstance;
-    @Inject Instance<Injector> injectorInstance;
+    @Inject Instance<ContainerObjectFactory> containerObjectFactoryInstance;
 
     @Override
     public void enrich(Object testCase) {
-        enrichAndReturnLinks(testCase);
-    }
-
-    private Set<String> enrichAndReturnLinks(Object testCase) {
         List<Field> cubeFields = ReflectionUtil.getFieldsWithAnnotation(testCase.getClass(), Cube.class);
-        Set<String> links = new HashSet<>();
         if (cubeFields.size() > 0) {
             for (Field cubeField : cubeFields) {
                 try {
                     logger.fine(String.format("Creating Container Object for field %s", cubeField.getName()));
-                    links.add(enrichField(testCase, cubeField));
+                    enrichField(testCase, cubeField);
                 } catch (IllegalAccessException e) {
-                    throw new IllegalArgumentException(e);
-                } catch (IOException e) {
-                    throw new IllegalArgumentException(e);
-                } catch (InvocationTargetException e) {
                     throw new IllegalArgumentException(e);
                 }
             }
         }
-
-        return links;
     }
 
-    /**
-     *
-     * @param testCase
-     * @param field
-     * @return returns the name of the cube if this cube would be linked by its parent, or null
-     * @throws IllegalAccessException
-     * @throws IOException
-     * @throws InvocationTargetException
-     */
-    private String enrichField(Object testCase, Field field) throws IllegalAccessException, IOException, InvocationTargetException {
+    private void enrichField(Object testCase, Field field) throws IllegalAccessException {
         final Object cubeContainerObject = field.get(testCase);
         if (cubeContainerObject == null) {
-            final Cube cubeAnnotation = field.getAnnotation(Cube.class);
 
             final Class<?> cubeContainerClazz = field.getType();
 
-            //First we check if this ContainerObject is defining a @CubeDockerFile in static method
-            final List<Method> methodsWithCubeDockerFile = ReflectionUtil.getMethodsWithAnnotation(cubeContainerClazz, CubeDockerFile.class);
-
-            if (methodsWithCubeDockerFile.size() > 1 ) {
-                throw new IllegalArgumentException(
-                        String.format("More than one %s annotation found and only one was expected. Methods where %s was found are; %s", CubeDockerFile.class.getSimpleName(), CubeDockerFile.class.getSimpleName(), methodsWithCubeDockerFile));
-            }
-
-            // User has defined @CubeDockerfile and @Image
-            if ((methodsWithCubeDockerFile.size() == 1 || cubeContainerClazz.isAnnotationPresent(CubeDockerFile.class)) && cubeContainerClazz.isAnnotationPresent(Image.class)) {
-                throw new IllegalArgumentException(String.format("Container Object %s has defined %s annotation and %s annotation together.", cubeContainerClazz.getSimpleName(), Image.class.getSimpleName(), CubeDockerFile.class.getSimpleName()));
-            }
-
-            File output = null;
-            boolean imageSet = false;
-            CubeDockerFile cubeContainerClazzAnnotation = null;
-            final String cubeName = getCubeName(cubeAnnotation, cubeContainerClazz);
-            // @Dockerfile is defined as static method
-            if(methodsWithCubeDockerFile.size() == 1) {
-                Method annotatedMethodWithCubeDockerFile = methodsWithCubeDockerFile.get(0);
-                cubeContainerClazzAnnotation = annotatedMethodWithCubeDockerFile.getAnnotation(CubeDockerFile.class);
-                final Object archive = annotatedMethodWithCubeDockerFile.invoke(null, new Object[0]);
-                if (archive instanceof Archive) {
-                    Archive<?> genericArchive = (Archive<?>) archive;
-                    output = createTemporalDirectoryForCopyingDockerfile(cubeContainerClazz, cubeName);
-                    logger.finer(String.format("Created %s directory for storing contents of %s cube.", output, cubeName));
-                    genericArchive.as(ExplodedExporter.class).exportExplodedInto(output);
-                }
-
-            } else {
-                // @Dockerfile is defined at class level
-                if (cubeContainerClazz.isAnnotationPresent(CubeDockerFile.class)) {
-                    cubeContainerClazzAnnotation = cubeContainerClazz.getAnnotation(CubeDockerFile.class);
-
-                    //Copy Dockerfile and all contains of the same directory in a known directory.
-                    output = createTemporalDirectoryForCopyingDockerfile(cubeContainerClazz, cubeName);
-                    logger.finer(String.format("Created %s directory for storing contents of %s cube.", output, cubeName));
-
-                    DockerFileUtil.copyDockerfileDirectory(cubeContainerClazz, cubeContainerClazzAnnotation, output);
-                } else {
-                    // If there is no annotation
-                    if (!cubeContainerClazz.isAnnotationPresent(Image.class)) {
-                        throw new IllegalArgumentException(String.format("Test class %s has a ContainerObject %s that is not annotated with %s or %s annotation.", testCase.getClass().getName(), cubeContainerClazz.getName(), CubeDockerFile.class.getSimpleName(), Image.class.getSimpleName()));
-                    }
-                    // We have set the image
-                    imageSet = true;
-                }
-            }
-
-            //Creates ContainerObject
-            final Object containerObjectInstance = ReflectionUtil.newInstance(cubeContainerClazz.getName(), new Class[0], new Class[0], cubeContainerClazz);
-            enrichContainerObject(containerObjectInstance);
+            final ContainerObjectConfiguration configuration = extractConfigFrom(field);
+            final Object containerObjectInstance = containerObjectFactoryInstance.get().createContainerObject(cubeContainerClazz, configuration, testCase);
             field.set(testCase, containerObjectInstance);
-
-            // Get all fields annotated with @Cube (means they are inner containers).
-            // Then call recursively enrich method again.
-            // To reuse the same logic we call the enrich method but instead of passing a testcase class, we pass the container object instance
-            final Set<String> links = enrichAndReturnLinks(containerObjectInstance);
-
-            //Starts the cube.
-            // Since it is called after the enrichment they will be created in correct order
-
-            //Creates Cube and Registers into the Cube Registry
-            final String[] cubePortBinding = getPortBindings(cubeAnnotation, cubeContainerClazz);
-            final int[] awaitPorts = getAwaitPorts(cubeAnnotation, cubeContainerClazz);
-            final Environment[] environmentVariables = getEnvironmentAnnotations(field, cubeContainerClazz);
-            final Volume[] volumeAnnotations = getVolumeAnnotations(field, cubeContainerClazz);
-            org.arquillian.cube.spi.Cube<?> cube;
-            if (imageSet) {
-                cube = createCubeFromImage(cubeName, cubePortBinding, ArrayUtils.toObject(awaitPorts), links, cubeContainerClazz.getAnnotation(Image.class), environmentVariables, volumeAnnotations, output, testCase.getClass());
-            } else {
-                cube = createCubeFromDockerfile(cubeName, cubePortBinding, ArrayUtils.toObject(awaitPorts), links, cubeContainerClazzAnnotation, environmentVariables, volumeAnnotations, output, testCase.getClass());
-            }
-
-            logger.finer(String.format("Created Cube with name %s and configuration %s", cubeName, cube.configuration()));
-            cubeRegistryInstance.get().addCube(cube);
-
-            CubeController cubeController = cubeControllerInstance.get();
-            cubeController.create(cubeName);
-            cubeController.start(cubeName);
-
-            // It is not a native Arquillian Enricher to avoid to be used wrongly in a none container object.
-            // Since it is only has sense in case of container object that it is running one container in the scope.
-            // Moreover it has no much sense to get this information in case of not using container object pattern.
-            enrichHostPort(containerObjectInstance, cube);
-            enrichCubeIp(containerObjectInstance, cube);
-
-            return link(field, cubeName);
         }
-        return null;
-    }
-
-    private void enrichCubeIp(Object containerObjectInstance, org.arquillian.cube.spi.Cube<?> cube) throws IllegalAccessException {
-        final List<Field> fieldsWithCubeIp = ReflectionUtil.getFieldsWithAnnotation(containerObjectInstance.getClass(), CubeIp.class);
-        if (fieldsWithCubeIp.isEmpty()) {
-            return;
-        }
-
-        final HasPortBindings portBindings = cube.getMetadata(HasPortBindings.class);
-        if (portBindings == null) {
-            throw new IllegalArgumentException(String.format("Container Object %s contains fields annotated with %s but no ports are exposed by the container", containerObjectInstance.getClass().getSimpleName(), CubeIp.class.getSimpleName()));
-        }
-
-        for (Field field: fieldsWithCubeIp) {
-            final CubeIp cubeIp = field.getAnnotation(CubeIp.class);
-            boolean cubeIpInternal = cubeIp.internal();
-            String cubeIpValue = (cubeIpInternal) ? portBindings.getInternalIP() : portBindings.getContainerIP();
-            field.set(containerObjectInstance, cubeIpValue);
-        }
-    }
-
-    private void enrichHostPort(Object containerObjectInstance, org.arquillian.cube.spi.Cube<?> cube) throws IllegalAccessException {
-        final List<Field> fieldsWithHostPort = ReflectionUtil.getFieldsWithAnnotation(containerObjectInstance.getClass(), HostPort.class);
-        if (fieldsWithHostPort.isEmpty()) {
-            return;
-        }
-
-        final HasPortBindings portBindings = cube.getMetadata(HasPortBindings.class);
-        if (portBindings == null) {
-            throw new IllegalArgumentException(String.format("Container Object %s contains fields annotated with %s but no ports are exposed by the container", containerObjectInstance.getClass().getSimpleName(), HostPort.class.getSimpleName()));
-        }
-
-        for ( Field field : fieldsWithHostPort) {
-            final HostPort hostPort = field.getAnnotation(HostPort.class);
-            int hostPortValue = hostPort.value();
-            if (hostPortValue > 0) {
-                final PortAddress bindingForExposedPort = portBindings.getMappedAddress(hostPortValue);
-                if (bindingForExposedPort != null) {
-                    field.set(containerObjectInstance, bindingForExposedPort.getPort());
-                } else {
-                    throw new IllegalArgumentException(String.format("Container Object %s contains field %s annotated with %s but exposed port %s is not exposed on container object.", containerObjectInstance.getClass().getSimpleName(), field.getName(), HostPort.class.getSimpleName(), hostPortValue));
-                }
-            } else {
-                throw new IllegalArgumentException(String.format("Container Object %s contains field %s annotated with %s but do not specify any exposed port", containerObjectInstance.getClass().getSimpleName(), field.getName(), HostPort.class.getSimpleName()));
-            }
-        }
-    }
-
-    private String link(Field field, String cubeName) {
-        if (field.isAnnotationPresent(Link.class)) {
-            return field.getAnnotation(Link.class).value();
-        } else {
-            return cubeName + ":" + cubeName;
-        }
-    }
-
-
-    private Volume[] getVolumeAnnotations(Field field, Class<?> cubeContainerClass) {
-        final List<Volume> volumes = new ArrayList<>();
-
-        if (field.isAnnotationPresent(Volume.class)) {
-            Collections.addAll(volumes, field.getAnnotationsByType(Volume.class));
-        }
-
-        volumes.addAll((Collection<? extends Volume>) ContainerObjectUtil.getAllAnnotations(cubeContainerClass, Volume.class));
-
-        return volumes.toArray(new Volume[volumes.size()]);
-
-    }
-
-    private Environment[] getEnvironmentAnnotations(Field field, Class<?> cubeContainerClass) {
-        final List<Environment> environments = new ArrayList<>();
-
-        if (field.isAnnotationPresent(Environment.class)) {
-            Collections.addAll(environments, field.getAnnotationsByType(Environment.class));
-        }
-
-        environments.addAll((Collection<? extends Environment>) ContainerObjectUtil.getAllAnnotations(cubeContainerClass, Environment.class));
-
-        return environments.toArray(new Environment[environments.size()]);
-    }
-
-
-    private String getCubeName(Cube fieldAnnotation, Class<?> cubeContainerClass) {
-        final String cubeName = fieldAnnotation.value();
-        if (!Cube.DEFAULT_VALUE.equals(cubeName)) {
-            // We have found a valid cube name
-            return cubeName;
-        } else {
-            // Needs to check if container object or one of his parents contains a Cube
-            final String value = ContainerObjectUtil.getTopCubeAttribute(cubeContainerClass, "value", Cube.class, Cube.DEFAULT_VALUE);
-            if (value != null && !Cube.DEFAULT_VALUE.equals(value)) {
-                //We got the cubeName in containerobject
-                return value;
-            } else {
-                //No override so we need to use the default logic
-                return cubeContainerClass.getSimpleName();
-            }
-        }
-    }
-
-    private String[] getPortBindings(Cube fieldAnnotation, Class<?> cubeContainerClass) {
-        final String[] portBindings = fieldAnnotation.portBinding();
-        if (!Arrays.equals(portBindings, Cube.DEFAULT_PORT_BINDING)) {
-            //We found the port binding
-            return portBindings;
-        } else {
-            final String[] portBinding = ContainerObjectUtil.getTopCubeAttribute(cubeContainerClass, "portBinding", Cube.class, Cube.DEFAULT_PORT_BINDING);
-            if (portBinding != null && !Arrays.equals(portBinding, Cube.DEFAULT_PORT_BINDING)) {
-                // Container Object or one of his parents has a Cube with portBinding definition.
-                return portBinding;
-            }
-        }
-        return Cube.DEFAULT_PORT_BINDING;
-    }
-
-    private int[] getAwaitPorts(Cube fieldAnnotation, Class<?> cubeContainerClass) {
-        final int[] awaitPorts = fieldAnnotation.awaitPorts();
-
-        if (!Arrays.equals(awaitPorts, Cube.DEFAULT_AWAIT_PORT_BINDING)) {
-            // We found the await
-            return awaitPorts;
-        } else {
-            final int[] awaitPort = ContainerObjectUtil.getTopCubeAttribute(cubeContainerClass, "awaitPorts", Cube.class, Cube.DEFAULT_AWAIT_PORT_BINDING);
-
-            if (awaitPort != null && !Arrays.equals(awaitPort, Cube.DEFAULT_AWAIT_PORT_BINDING)) {
-                // Container Object or one of his parents has a Cube with await definition
-                return awaitPort;
-            }
-        }
-
-        return Cube.DEFAULT_AWAIT_PORT_BINDING;
-    }
-
-    private void enrichContainerObject(Object containerObjectInstance) {
-        final Collection<TestEnricher> testEnrichers = serviceLoader.get().all(TestEnricher.class);
-        for (TestEnricher testEnricher : testEnrichers) {
-            //To avoid recursive.
-            if (testEnricher != this && ! (testEnricher instanceof HostPortTestEnricher)) {
-                testEnricher.enrich(containerObjectInstance);
-            }
-        }
-    }
-
-
-    private org.arquillian.cube.spi.Cube<?> createCubeFromDockerfile(String cubeName, String[] portBinding, Integer[] awaitPorts, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, Environment[] environments, Volume[] volumeAnnotations, File dockerfileLocation, Class<?> testClass) {
-        CubeContainer configuration = createConfigurationFromDockerfie(portBinding, awaitPorts, links, cubeContainerClazzAnnotation, dockerfileLocation, environments, volumeAnnotations);
-        DockerCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
-        newCube.addMetadata(IsContainerObject.class, new IsContainerObject(testClass));
-        injectorInstance.get().inject(newCube);
-        return newCube;
-    }
-
-    private org.arquillian.cube.spi.Cube<?> createCubeFromImage(String cubeName, String[] portBinding, Integer[] awaitPorts, Set<String> links, Image image, Environment[] environment, Volume[] volumeAnnotations, File dockerfileLocation, Class<?> testClass) {
-        final CubeContainer configuration = createConfigurationFromImage(portBinding, awaitPorts, links, image, dockerfileLocation, environment, volumeAnnotations);
-        DockerCube newCube = new DockerCube(cubeName, configuration, dockerClientExecutorInstance.get());
-        newCube.addMetadata(IsContainerObject.class, new IsContainerObject(testClass));
-        injectorInstance.get().inject(newCube);
-        return newCube;
-    }
-
-    private CubeContainer createConfigurationFromDockerfie(String[] portBinding, Integer[] awaitPorts, Set<String> links, CubeDockerFile cubeContainerClazzAnnotation, File dockerfileLocation, Environment[] environments, Volume[] volumeAnnotations) {
-        CubeContainer configuration = new CubeContainer();
-
-        List<PortBinding> bindings = new ArrayList<PortBinding>();
-        for(String binding : portBinding) {
-            bindings.add(PortBinding.valueOf(binding));
-        }
-        configuration.setPortBindings(bindings);
-
-        if (links.size() > 0) {
-            configuration.setLinks(org.arquillian.cube.docker.impl.client.config.Link.valuesOf(links));
-        }
-
-        if (environments != null ) {
-            final List<String> collectEnvironments = Arrays.stream(environments)
-                    .map(environment -> environment.key() + "=" + environment.value())
-                    .collect(Collectors.toList());
-            configuration.setEnv(collectEnvironments);
-        }
-
-        if (volumeAnnotations != null) {
-            final List<String> collectVolumes = Arrays.stream(volumeAnnotations)
-                    .map(volume -> volume.hostPath() + ":" + volume.containerPath() + ":rw")
-                    .collect(Collectors.toList());
-            configuration.setBinds(collectVolumes);
-        }
-
-        BuildImage dockerfileConfiguration = new BuildImage(
-                dockerfileLocation.getAbsolutePath(),
-                null,
-                cubeContainerClazzAnnotation.nocache(),
-                cubeContainerClazzAnnotation.remove());
-
-        configuration.setBuildImage(dockerfileConfiguration);
-
-        final Await await = createAwait(awaitPorts);
-        configuration.setAwait(await);
-
-        return configuration;
-    }
-
-    private Await createAwait(Integer[] awaitPorts) {
-        final Await await = new Await();
-        await.setPorts(Arrays.asList(awaitPorts));
-        await.setStrategy(PollingAwaitStrategy.TAG);
-        return await;
-    }
-
-    private CubeContainer createConfigurationFromImage(String[] portBinding, Integer[] awaitPorts, Set<String> links, Image image, File dockerfileLocation, Environment[] environments, Volume[] volumeAnnotations) {
-        CubeContainer configuration = new CubeContainer();
-
-        List<PortBinding> bindings = new ArrayList<PortBinding>();
-        for(String binding : portBinding) {
-            bindings.add(PortBinding.valueOf(binding));
-        }
-        configuration.setPortBindings(bindings);
-
-        if (links.size() > 0) {
-            configuration.setLinks(org.arquillian.cube.docker.impl.client.config.Link.valuesOf(links));
-        }
-
-        if (environments != null ) {
-            final List<String> collectEnvironments = Arrays.stream(environments)
-                    .map(environment -> environment.key() + "=" + environment.value())
-                    .collect(Collectors.toList());
-            configuration.setEnv(collectEnvironments);
-        }
-
-        if (volumeAnnotations != null) {
-            final List<String> collectVolumes = Arrays.stream(volumeAnnotations)
-                    .map(volume -> volume.hostPath() + ":" + volume.containerPath() + ":rw")
-                    .collect(Collectors.toList());
-            configuration.setBinds(collectVolumes);
-        }
-
-        configuration.setImage(org.arquillian.cube.docker.impl.client.config.Image.valueOf(image.value()));
-
-        final Await await = createAwait(awaitPorts);
-        configuration.setAwait(await);
-        return configuration;
-    }
-
-    private File createTemporalDirectoryForCopyingDockerfile(Class<?> cubeContainerClazz, String id) throws IOException {
-        File dir = File.createTempFile(cubeContainerClazz.getSimpleName(), id);
-        dir.delete();
-        if (!dir.mkdirs()) {
-            throw new IllegalArgumentException("Temp Dir for storing Dockerfile contents could not be created.");
-        }
-        dir.deleteOnExit();
-        return dir;
     }
 
     @Override
     public Object[] resolve(Method method) {
         return new Object[0];
+    }
+
+    private static ContainerObjectConfiguration extractConfigFrom(Field field) {
+        return new CubeContainerObjectConfiguration(extractCubeContainerFrom(field));
+    }
+
+    private static CubeContainer extractCubeContainerFrom(Field field) {
+        final CubeContainer cubeContainer = new CubeContainer();
+
+        final Cube cubeAnnotation = field.getAnnotation(Cube.class);
+        if (cubeAnnotation == null) {
+            throw new IllegalArgumentException(String.format("Field %s requires to be annotated with %s annotation", field.getName(), Cube.class.getSimpleName()));
+        }
+
+        // cubeName from Cube::value()
+        final String cubeName = cubeAnnotation.value();
+        if (cubeName != null && !Cube.DEFAULT_VALUE.equals(cubeName)) {
+            cubeContainer.setContainerName(cubeName);
+        }
+
+        // port bindings from Cube::portBinding()
+        final String[] portBindingsFromAnnotation = cubeAnnotation.portBinding();
+        if (portBindingsFromAnnotation != null && !Arrays.equals(portBindingsFromAnnotation, Cube.DEFAULT_PORT_BINDING)) {
+            final List<PortBinding> portBindings = Arrays.stream(portBindingsFromAnnotation)
+                    .map(PortBinding::valueOf)
+                    .collect(Collectors.toList());
+            cubeContainer.setPortBindings(portBindings);
+        }
+
+        // await using PollingStrategy with Cube::awaitPorts()
+        final int[] awaitPortsFromAnnotation = cubeAnnotation.awaitPorts();
+        if (awaitPortsFromAnnotation != null && !Arrays.equals(awaitPortsFromAnnotation, Cube.DEFAULT_AWAIT_PORT_BINDING)) {
+            final Await await = new Await();
+            await.setStrategy(PollingAwaitStrategy.TAG);
+            await.setPorts(Arrays.asList(ArrayUtils.toObject(awaitPortsFromAnnotation)));
+            cubeContainer.setAwait(await);
+        }
+
+        // environment variables from Environment annotations
+        final Environment[] environmentVariablesFromAnnotations = field.getAnnotationsByType(Environment.class);
+        if (environmentVariablesFromAnnotations != null && environmentVariablesFromAnnotations.length > 0) {
+            final List<String> environmentVariables = Arrays.stream(environmentVariablesFromAnnotations)
+                    .map(environment -> environment.key() + "=" + environment.value())
+                    .collect(Collectors.toList());
+            cubeContainer.setEnv(environmentVariables);
+        }
+
+        // volumes from Volume annotations
+        final Volume[] volumesFromAnnotations = field.getAnnotationsByType(Volume.class);
+        if (volumesFromAnnotations != null && volumesFromAnnotations.length > 0) {
+            final List<String> volumeBindings = Arrays.stream(volumesFromAnnotations)
+                    .map(volume -> volume.hostPath() + ":" + volume.containerPath() + ":rw")
+                    .collect(Collectors.toList());
+            cubeContainer.setBinds(volumeBindings);
+        }
+
+        // links from link annotations
+        final Link[] linksFromAnnotations = field.getAnnotationsByType(Link.class);
+        if (linksFromAnnotations != null && linksFromAnnotations.length > 0) {
+            final List<org.arquillian.cube.docker.impl.client.config.Link> links = Arrays.stream(linksFromAnnotations)
+                    .map(Link::value)
+                    .map(org.arquillian.cube.docker.impl.client.config.Link::valueOf)
+                    .collect(Collectors.toList());
+            cubeContainer.setLinks(links);
+        }
+
+        return cubeContainer;
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
@@ -174,6 +174,9 @@ public class DockerContainerObjectBuilder<T> {
      * @see CubeContainer
      */
     public DockerContainerObjectBuilder<T> withContainerObjectConfiguration(ContainerObjectConfiguration configuration) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("configuration cannot be null");
+        }
         if (configuration != null && !(configuration instanceof CubeContainerObjectConfiguration)) {
             throw new IllegalArgumentException(
                     String.format("container object configuration received of type %s, but only %s is supported", configuration.getClass().getSimpleName(), CubeContainerObjectConfiguration.class.getSimpleName()));
@@ -190,6 +193,9 @@ public class DockerContainerObjectBuilder<T> {
      * @return the current builder instance
      */
     public DockerContainerObjectBuilder<T> withEnrichers(Collection<TestEnricher> enrichers) {
+        if (enrichers == null) {
+            throw new IllegalArgumentException("enrichers cannot be null");
+        }
         this.enrichers = enrichers;
         return this;
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
@@ -1,0 +1,497 @@
+package org.arquillian.cube.docker.impl.client.containerobject;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.function.BiFunction;
+import java.util.function.Consumer;
+import java.util.logging.Logger;
+import java.util.stream.Collectors;
+
+import org.apache.commons.lang3.ArrayUtils;
+import org.arquillian.cube.ContainerObjectConfiguration;
+import org.arquillian.cube.CubeController;
+import org.arquillian.cube.CubeIp;
+import org.arquillian.cube.HostPort;
+import org.arquillian.cube.containerobject.Cube;
+import org.arquillian.cube.containerobject.CubeDockerFile;
+import org.arquillian.cube.containerobject.Environment;
+import org.arquillian.cube.containerobject.Image;
+import org.arquillian.cube.containerobject.Volume;
+import org.arquillian.cube.docker.impl.await.PollingAwaitStrategy;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.client.config.BuildImage;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.Link;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.docker.impl.util.ContainerObjectUtil;
+import org.arquillian.cube.docker.impl.util.DockerFileUtil;
+import org.arquillian.cube.impl.client.enricher.CubeIpTestEnricher;
+import org.arquillian.cube.impl.client.enricher.HostPortTestEnricher;
+import org.arquillian.cube.impl.util.ReflectionUtil;
+import org.arquillian.cube.spi.metadata.HasPortBindings;
+import org.arquillian.cube.spi.metadata.IsContainerObject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.exporter.ExplodedExporter;
+
+/**
+ * Instantiate container objects. This class is not thread safe.
+ *
+ * @see DockerContainerObjectFactory
+ *
+ * @author <a href="mailto:rivasdiaz@gmail.com">Ramon Rivas</a>
+ */
+public class DockerContainerObjectBuilder<T> {
+
+    private static final Logger logger = Logger.getLogger(DockerContainerObjectBuilder.class.getName());
+
+    public static final String TEMPORARY_FOLDER_PREFIX = "arquilliancube_";
+    public static final String TEMPORARY_FOLDER_SUFFIX = ".build";
+
+    // parameters received
+    private final DockerClientExecutor dockerClientExecutor;
+    private final CubeController cubeController;
+    private Class<T> containerObjectClass;
+    private Object containerObjectContainer;
+    private CubeContainer providedConfiguration;
+    private Collection<TestEnricher> enrichers = Collections.emptyList();
+    private Consumer<DockerCube> cubeCreatedCallback;
+
+    // temporary variables in the process of building the container and associated cube
+    private boolean classHasMethodWithCubeDockerFile;
+    private boolean classDefinesCubeDockerFile;
+    private boolean classDefinesImage;
+    private Method methodWithCubeDockerFile;
+    private CubeDockerFile cubeDockerFileAnnotation;
+    private Image cubeImageAnnotation;
+    private String containerName;
+    private File dockerfileLocation;
+    private CubeContainer generatedConfigutation, mergedConfiguration;
+
+    // results of the building
+    private T containerObjectInstance;
+    private DockerCube dockerCube;
+
+    public DockerContainerObjectBuilder(DockerClientExecutor dockerClientExecutor, CubeController cubeController) {
+        this.dockerClientExecutor = dockerClientExecutor;
+        this.cubeController = cubeController;
+    }
+
+    /**
+     * Specifies an optional object that has a strong reference to the object being created. If set, a reference to it
+     * is stored as part of the metadata of the container object. This object is expected to control the lifecycle of
+     * the container object
+     *
+     * @param containerObjectContainer the container object's container
+     * @return the current builder instance
+     *
+     * @see IsContainerObject
+     */
+    public DockerContainerObjectBuilder<T> withContainerObjectContainer(Object containerObjectContainer) {
+        this.containerObjectContainer = containerObjectContainer;
+        return this;
+    }
+
+    /**
+     * Specifies the container object class to be instantiated
+     *
+     * @param containerObjectClass container object class to be instantiated
+     * @return the current builder instance
+     */
+    public DockerContainerObjectBuilder<T> withContainerObjectClass(Class<T> containerObjectClass) {
+        if (containerObjectClass == null) {
+            throw new IllegalArgumentException("container object class cannot be null");
+        }
+        this.containerObjectClass = containerObjectClass;
+
+        //First we check if this ContainerObject is defining a @CubeDockerFile in static method
+        final List<Method> methodsWithCubeDockerFile = ReflectionUtil.getMethodsWithAnnotation(containerObjectClass, CubeDockerFile.class);
+
+        if (methodsWithCubeDockerFile.size() > 1) {
+            throw new IllegalArgumentException(
+                    String.format("More than one %s annotation found and only one was expected. Methods where annotation was found are: %s", CubeDockerFile.class.getSimpleName(), methodsWithCubeDockerFile));
+        }
+
+        classHasMethodWithCubeDockerFile = !methodsWithCubeDockerFile.isEmpty();
+        classDefinesCubeDockerFile = containerObjectClass.isAnnotationPresent(CubeDockerFile.class);
+        classDefinesImage = containerObjectClass.isAnnotationPresent(Image.class);
+
+        if (classHasMethodWithCubeDockerFile) {
+            methodWithCubeDockerFile = methodsWithCubeDockerFile.get(0);
+            boolean isMethodStatic = Modifier.isStatic(methodWithCubeDockerFile.getModifiers());
+            boolean methodHasNoArguments = methodWithCubeDockerFile.getParameterCount() == 0;
+            boolean methodReturnsAnArchive = Archive.class.isAssignableFrom(methodWithCubeDockerFile.getReturnType());
+            if (!isMethodStatic || !methodHasNoArguments || !methodReturnsAnArchive) {
+                throw new IllegalArgumentException(
+                        String.format("Method %s annotated with %s is expected to be static, no args and return %s.", methodWithCubeDockerFile,  CubeDockerFile.class.getSimpleName(), Archive.class.getSimpleName()));
+            }
+        }
+
+        // User has defined @CubeDockerfile on the class and a method
+        if (classHasMethodWithCubeDockerFile && classDefinesCubeDockerFile) {
+            throw new IllegalArgumentException(
+                    String.format("More than one %s annotation found and only one was expected. Both class and method %s has the annotation.", CubeDockerFile.class.getSimpleName(), methodWithCubeDockerFile));
+        }
+
+        // User has defined @CubeDockerfile and @Image
+        if ((classHasMethodWithCubeDockerFile || classDefinesCubeDockerFile) && classDefinesImage) {
+            throw new IllegalArgumentException(
+                    String.format("Container Object %s has defined %s annotation and %s annotation together.", containerObjectClass.getSimpleName(), Image.class.getSimpleName(), CubeDockerFile.class.getSimpleName()));
+        }
+
+        // User has not defined either @CubeDockerfile or @Image
+        if (!classDefinesCubeDockerFile && !classDefinesImage && !classHasMethodWithCubeDockerFile) {
+            throw new IllegalArgumentException(
+                    String.format("Container Object %s is not annotated with either %s or %s annotations.", containerObjectClass.getName(), CubeDockerFile.class.getSimpleName(), Image.class.getSimpleName()));
+        }
+
+        return this;
+    }
+
+    /**
+     * Specifies a configuration (can be partial) to be used to override the default configuration set using annotations
+     * on the container object. The received configuration will be merged with the configuration extracted from the
+     * container object, and the resulting configuration will be used to build the docker container.
+     *
+     * Currently only supports instances of {@link CubeContainerObjectConfiguration}
+     *
+     * @param configuration partial configuration to override default container object cube configuration
+     * @return the current builder instance
+     *
+     * @see CubeContainerObjectConfiguration
+     * @see CubeContainer
+     */
+    public DockerContainerObjectBuilder<T> withContainerObjectConfiguration(ContainerObjectConfiguration configuration) {
+        if (configuration != null && !(configuration instanceof CubeContainerObjectConfiguration)) {
+            throw new IllegalArgumentException(
+                    String.format("container object configuration received of type %s, but only %s is supported", configuration.getClass().getSimpleName(), CubeContainerObjectConfiguration.class.getSimpleName()));
+        }
+        this.providedConfiguration = configuration != null ? ((CubeContainerObjectConfiguration) configuration).getCubeContainerConfiguration() : null;
+
+        return this;
+    }
+
+    /**
+     * Specifies the list of enrichers that will be used to enrich the container object.
+     *
+     * @param enrichers list of enrichers that will be used to enrich the container object
+     * @return the current builder instance
+     */
+    public DockerContainerObjectBuilder<T> withEnrichers(Collection<TestEnricher> enrichers) {
+        this.enrichers = enrichers;
+        return this;
+    }
+
+    /**
+     * Specifies a consumer that will be executed after the cube object is created and after cube is created or started
+     * by the cube controller. Callers must use this callback to register anything necesary for the controller to work
+     * and also if they want to keep an instance of the created cube.
+     *
+     * @param cubeCreatedCallback consumer that will be called when the cube instance is created
+     * @return the current builder instance
+     */
+    public DockerContainerObjectBuilder<T> onCubeCreated(Consumer<DockerCube> cubeCreatedCallback) {
+        this.cubeCreatedCallback = cubeCreatedCallback;
+        return this;
+    }
+
+    /**
+     * Triggers the building process, builds, creates and starts the docker container associated with the requested
+     * container object, creates the container object and returns it
+     *
+     * @return the created container object
+     * @throws IllegalAccessException if there is an error accessing the container object fields
+     * @throws IOException if there is an I/O error while preparing the docker build
+     * @throws InvocationTargetException if there is an error while calling the DockerFile archive creation
+     */
+    public T build() throws IllegalAccessException, IOException, InvocationTargetException {
+        generatedConfigutation = new CubeContainer();
+
+        findContainerName();
+        // if needed, prepare prepare resources required to build a docker image
+        prepareImageBuild();
+        // instantiate container object
+        instantiateContainerObject();
+        // enrich container object (without cube instance)
+        enrichContainerObjectBeforeCube();
+        // extract configuration from container object class
+        extractConfigurationFromContainerObject();
+        // merge received configuration with extracted configuration
+        mergeContainerObjectConfiguration();
+        // create/start/register associated cube
+        initializeCube();
+        // enrich container object (with cube instance)
+        enrichContainerObjectWithCube();
+        // return created container object
+        return containerObjectInstance;
+    }
+
+    private void findContainerName() {
+        // container name
+        if (providedConfiguration != null) {
+            final String providedContainerName = providedConfiguration.getContainerName();
+            if (providedContainerName != null && !providedContainerName.isEmpty()) {
+                containerName = providedConfiguration.getContainerName();
+            }
+        }
+        if (containerName == null) {
+            final String cubeValue = ContainerObjectUtil.getTopCubeAttribute(containerObjectClass, "value", Cube.class, Cube.DEFAULT_VALUE);
+            if (cubeValue != null && !Cube.DEFAULT_VALUE.equals(cubeValue)) {
+                containerName = cubeValue;
+            }
+        }
+        if (containerName == null) {
+            containerName = containerObjectClass.getSimpleName();
+        }
+        generatedConfigutation.setContainerName(containerName);
+    }
+
+    private void prepareImageBuild() throws InvocationTargetException, IllegalAccessException, IOException {
+
+        // @CubeDockerfile is defined as static method
+        if (classHasMethodWithCubeDockerFile) {
+            cubeDockerFileAnnotation = methodWithCubeDockerFile.getAnnotation(CubeDockerFile.class);
+            final Archive<?> archive = (Archive<?>) methodWithCubeDockerFile.invoke(null, new Object[0]);
+            File output = createTemporalDirectoryForCopyingDockerfile(containerName);
+            logger.finer(String.format("Created %s directory for storing contents of %s cube.", output, containerName));
+
+            archive.as(ExplodedExporter.class).exportExplodedInto(output);
+            dockerfileLocation = output;
+        } else if (classDefinesCubeDockerFile) {
+            cubeDockerFileAnnotation = containerObjectClass.getAnnotation(CubeDockerFile.class);
+
+            //Copy Dockerfile and all contains of the same directory in a known directory.
+            File output = createTemporalDirectoryForCopyingDockerfile(containerName);
+            logger.finer(String.format("Created %s directory for storing contents of %s cube.", output, containerName));
+
+            DockerFileUtil.copyDockerfileDirectory(containerObjectClass, cubeDockerFileAnnotation, output);
+            dockerfileLocation = output;
+        } else if (classDefinesImage) {
+            cubeImageAnnotation = containerObjectClass.getAnnotation(Image.class);
+        }
+    }
+
+    private void instantiateContainerObject() {
+        containerObjectInstance = ReflectionUtil.newInstance(containerObjectClass.getName(), new Class[0], new Class[0], containerObjectClass);
+    }
+
+    private void enrichContainerObjectBeforeCube() {
+        for (TestEnricher enricher: enrichers) {
+            boolean requiresDockerInstanceCreated = enricher instanceof HostPortTestEnricher || enricher instanceof CubeIpTestEnricher;
+
+            if (!requiresDockerInstanceCreated) {
+                enricher.enrich(containerObjectInstance);
+            }
+        }
+    }
+
+    private void extractConfigurationFromContainerObject() {
+        // this method will focus on extracting the configuration from the container object class
+        // most probably, the caller will also try to pass some configuration from the current instantiation point
+        // (for example, annotations on a field)
+        // received configuration overrides container object configuration, so in some cases the extraction is skipped
+
+        // port bindings
+        if (providedConfiguration == null || providedConfiguration.getPortBindings() == null) {
+            final String[] portBindingsFromAnnotation = ContainerObjectUtil.getTopCubeAttribute(containerObjectClass, "portBinding", Cube.class, Cube.DEFAULT_PORT_BINDING);
+
+            if (portBindingsFromAnnotation != null && !Arrays.equals(portBindingsFromAnnotation, Cube.DEFAULT_PORT_BINDING)) {
+                List<PortBinding> portBindings = Arrays.stream(portBindingsFromAnnotation)
+                        .map(PortBinding::valueOf)
+                        .collect(Collectors.toList());
+                generatedConfigutation.setPortBindings(portBindings);
+            }
+
+        }
+        // await
+        if (providedConfiguration == null || providedConfiguration.getAwait() == null) {
+            final int[] awaitPortsFromAnnotation = ContainerObjectUtil.getTopCubeAttribute(containerObjectClass, "awaitPorts", Cube.class, Cube.DEFAULT_AWAIT_PORT_BINDING);
+
+            if (awaitPortsFromAnnotation != null && !Arrays.equals(awaitPortsFromAnnotation, Cube.DEFAULT_AWAIT_PORT_BINDING)) {
+                final Await await = new Await();
+                await.setStrategy(PollingAwaitStrategy.TAG);
+                await.setPorts(Arrays.asList(ArrayUtils.toObject(awaitPortsFromAnnotation)));
+                generatedConfigutation.setAwait(await);
+            }
+        }
+
+        // environment variables
+        // merged instead of overridden
+        if (true) {
+            List<String> environmentVariables = ContainerObjectUtil.getAllAnnotations(containerObjectClass, Environment.class)
+                    .stream()
+                    .map(environment -> environment.key() + "=" + environment.value())
+                    .collect(Collectors.toList());
+            generatedConfigutation.setEnv(environmentVariables);
+        }
+
+        // volumes
+        // merged instead of overridden
+        if (true) {
+            List<String> volumeBindings = ContainerObjectUtil.getAllAnnotations(containerObjectClass, Volume.class)
+                    .stream()
+                    .map(volume -> volume.hostPath() + ":" + volume.containerPath() + ":rw")
+                    .collect(Collectors.toList());
+            generatedConfigutation.setBinds(volumeBindings);
+        }
+
+        // links
+        if (providedConfiguration == null || providedConfiguration.getLinks() == null) {
+            List<Link> links = ReflectionUtil.getFieldsWithAnnotation(containerObjectClass, Cube.class)
+                   .stream()
+                   .map(DockerContainerObjectBuilder::linkFromCubeAnnotatedField)
+                   .collect(Collectors.toList());
+            generatedConfigutation.setLinks(links);
+        }
+
+        // image
+        if (classDefinesCubeDockerFile || classHasMethodWithCubeDockerFile) {
+            BuildImage dockerfileConfiguration = new BuildImage(
+                    dockerfileLocation.getAbsolutePath(),
+                    null,
+                    cubeDockerFileAnnotation.nocache(),
+                    cubeDockerFileAnnotation.remove());
+            generatedConfigutation.setBuildImage(dockerfileConfiguration);
+        } else {
+            generatedConfigutation.setImage(org.arquillian.cube.docker.impl.client.config.Image.valueOf(cubeImageAnnotation.value()));
+        }
+    }
+
+    private void mergeContainerObjectConfiguration() {
+        mergedConfiguration = new CubeContainer();
+        if (providedConfiguration != null) {
+            mergedConfiguration.merge(providedConfiguration);
+        }
+        mergedConfiguration.merge(generatedConfigutation);
+        // TODO if both provided and generated configurations have environment variables or volumes, they must be merged instead.
+        // TODO should this be handled in CubeContainer::merge() instead?
+        if (providedConfiguration != null) {
+            // environment variables
+            if (providedConfiguration.getEnv() != null && generatedConfigutation.getEnv() != null) {
+                Collection<String> env = new ArrayList<>();
+                env.addAll(mergedConfiguration.getEnv());
+                env.addAll(generatedConfigutation.getEnv());
+                mergedConfiguration.setEnv(env);
+            }
+            // volumes
+            if (providedConfiguration.getBinds() != null && generatedConfigutation.getBinds() != null) {
+                Collection<String> binds = new ArrayList<>();
+                binds.addAll(mergedConfiguration.getBinds());
+                binds.addAll(generatedConfigutation.getBinds());
+                mergedConfiguration.setBinds(binds);
+            }
+        }
+    }
+
+    private void initializeCube() {
+        dockerCube = new DockerCube(containerName, mergedConfiguration, dockerClientExecutor);
+        Class<?> containerObjectContainerClass = containerObjectContainer != null ? containerObjectContainer.getClass() : null;
+        dockerCube.addMetadata(IsContainerObject.class, new IsContainerObject(containerObjectContainerClass));
+        logger.finer(String.format("Created Cube with name %s and configuration %s", containerName, dockerCube.configuration()));
+        if (cubeCreatedCallback != null) {
+            cubeCreatedCallback.accept(dockerCube);
+        }
+        cubeController.create(containerName);
+        cubeController.start(containerName);
+    }
+
+    private void enrichContainerObjectWithCube() throws IllegalAccessException {
+        enrichAnnotatedPortBuildingFields(CubeIp.class, DockerContainerObjectBuilder::findEnrichedValueForFieldWithCubeIpAnnotation);
+        enrichAnnotatedPortBuildingFields(HostPort.class, DockerContainerObjectBuilder::findEnrichedValueForFieldWithHostPortAnnotation);
+    }
+
+    private <T extends Annotation> void enrichAnnotatedPortBuildingFields(Class<T> annotationType, BiFunction<T, HasPortBindings, ?> fieldEnricher) throws IllegalAccessException {
+        final List<Field> annotatedFields = ReflectionUtil.getFieldsWithAnnotation(containerObjectClass, annotationType);
+        if (annotatedFields.isEmpty()) return;
+
+        final HasPortBindings portBindings = dockerCube.getMetadata(HasPortBindings.class);
+        if (portBindings == null) {
+            throw new IllegalArgumentException(String.format("Container Object %s contains fields annotated with %s but no ports are exposed by the container", containerObjectClass.getSimpleName(), annotationType.getSimpleName()));
+        }
+
+        for (Field annotatedField: annotatedFields) {
+            final T annotation = annotatedField.getAnnotation(annotationType);
+            try {
+                annotatedField.set(containerObjectInstance, fieldEnricher.apply(annotation, portBindings));
+            } catch (IllegalArgumentException ex) {
+                throw new IllegalArgumentException(
+                        String.format("Container Object %s contains field %s annotated with %s, with error: %s", containerObjectClass.getSimpleName(), annotatedField.getName(), annotationType.getSimpleName(), ex.getLocalizedMessage()),
+                        ex);
+            }
+        }
+    }
+
+    private static String findEnrichedValueForFieldWithCubeIpAnnotation(CubeIp cubeIp, HasPortBindings portBindings) {
+        final boolean cubeIpInternal = cubeIp.internal();
+        final String cubeIpValue = (cubeIpInternal) ? portBindings.getInternalIP() : portBindings.getContainerIP();
+        return cubeIpValue;
+    }
+
+    private static int findEnrichedValueForFieldWithHostPortAnnotation(HostPort hostPort, HasPortBindings portBindings) {
+        int hostPortValue = hostPort.value();
+        if (hostPortValue == 0) {
+            throw new IllegalArgumentException(String.format("%s annotation does not specify any exposed port", HostPort.class.getSimpleName()));
+        }
+        final HasPortBindings.PortAddress bindingForExposedPort = portBindings.getMappedAddress(hostPortValue);
+        if (bindingForExposedPort == null) {
+            throw new IllegalArgumentException(String.format("exposed port %s is not exposed on container object.", hostPortValue));
+        }
+        return bindingForExposedPort.getPort();
+    }
+
+    private static File createTemporalDirectoryForCopyingDockerfile(String containerName) throws IOException {
+        File dir = File.createTempFile(TEMPORARY_FOLDER_PREFIX+containerName, TEMPORARY_FOLDER_SUFFIX);
+        dir.delete();
+        if (!dir.mkdirs()) {
+            throw new IllegalArgumentException("Temp Dir for storing Dockerfile contents could not be created.");
+        }
+        dir.deleteOnExit();
+        return dir;
+    }
+
+    private static Link linkFromCubeAnnotatedField(Field cubeField) {
+        final String linkName = linkNameFromCubeAnnotatedField(cubeField);
+        return Link.valueOf(linkName);
+    }
+
+    private static String linkNameFromCubeAnnotatedField(Field cubeField) {
+        if (cubeField.isAnnotationPresent(org.arquillian.cube.containerobject.Link.class)) {
+            return cubeField.getAnnotation(org.arquillian.cube.containerobject.Link.class).value();
+        }
+
+        final String cubeName = cubeNameFromCubeAnnotatedField(cubeField);
+        return cubeName + ":" + cubeName;
+    }
+
+    private static String cubeNameFromCubeAnnotatedField(Field cubeField) {
+        final org.arquillian.cube.containerobject.Cube cubeAnnotationOnField = cubeField.getAnnotation(org.arquillian.cube.containerobject.Cube.class);
+        final Class<?> containerObjectClassFromField = cubeField.getType();
+        String cubeName = null;
+        final String cubeAnnotationOnFieldValue = cubeAnnotationOnField.value();
+        if (cubeAnnotationOnFieldValue != null && !Cube.DEFAULT_VALUE.equals(cubeAnnotationOnFieldValue)) {
+            // We have found a valid cube name
+            return cubeAnnotationOnFieldValue;
+        }
+        // Needs to check if container object or one of his parents contains a Cube
+        final String cubeAnnotationOnClassValue = ContainerObjectUtil.getTopCubeAttribute(containerObjectClassFromField, "value", Cube.class, Cube.DEFAULT_VALUE);
+        if (cubeAnnotationOnClassValue != null && !Cube.DEFAULT_VALUE.equals(cubeAnnotationOnClassValue)) {
+            //We got the cubeName in containerobject
+            return cubeAnnotationOnClassValue;
+        }
+
+        //No override so we need to use the default logic
+        return containerObjectClassFromField.getSimpleName();
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectFactory.java
@@ -1,0 +1,59 @@
+package org.arquillian.cube.docker.impl.client.containerobject;
+
+import java.io.IOException;
+import java.lang.reflect.InvocationTargetException;
+import java.util.logging.Logger;
+
+import org.arquillian.cube.ContainerObjectConfiguration;
+import org.arquillian.cube.ContainerObjectFactory;
+import org.arquillian.cube.CubeController;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+/**
+ * An implementation of {@link ContainerObjectFactory} for Docker images.
+ *
+ * @see DockerContainerObjectBuilder
+ *
+ * @author <a href="mailto:rivasdiaz@gmail.com">Ramon Rivas</a>
+ */
+public class DockerContainerObjectFactory implements ContainerObjectFactory {
+
+    private static final Logger logger = Logger.getLogger(DockerContainerObjectFactory.class.getName());
+
+    @Inject Instance<ServiceLoader> serviceLoaderInstance;
+    @Inject Instance<DockerClientExecutor> dockerClientExecutorInstance;
+    @Inject Instance<CubeRegistry> cubeRegistryInstance;
+    @Inject Instance<CubeController> cubeControllerInstance;
+    @Inject Instance<Injector> injectorInstance;
+
+    @Override
+    public <T> T createContainerObject(Class<T> containerObjectClass, ContainerObjectConfiguration configuration) {
+        return createContainerObject(containerObjectClass, configuration,null);
+    }
+
+    public <T> T createContainerObject(Class<T> containerObjectClass, ContainerObjectConfiguration configuration, Object containerObjectContainer) {
+        try {
+            return new DockerContainerObjectBuilder<T>(dockerClientExecutorInstance.get(), cubeControllerInstance.get())
+                    .withEnrichers(serviceLoaderInstance.get().all(TestEnricher.class))
+                    .withContainerObjectClass(containerObjectClass)
+                    .withContainerObjectConfiguration(configuration)
+                    .withContainerObjectContainer(containerObjectContainer)
+                    .onCubeCreated(this::onCubeCreated)
+                    .build();
+        } catch (IllegalAccessException | IOException | InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private void onCubeCreated(DockerCube cube) {
+        injectorInstance.get().inject(cube);
+        cubeRegistryInstance.get().addCube(cube);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectFactory.java
@@ -34,11 +34,19 @@ public class DockerContainerObjectFactory implements ContainerObjectFactory {
     @Inject Instance<Injector> injectorInstance;
 
     @Override
+    public <T> T createContainerObject(Class<T> containerObjectClass) {
+        return createContainerObject(containerObjectClass, CubeContainerObjectConfiguration.empty(),null);
+    }
+
+    @Override
     public <T> T createContainerObject(Class<T> containerObjectClass, ContainerObjectConfiguration configuration) {
         return createContainerObject(containerObjectClass, configuration,null);
     }
 
     public <T> T createContainerObject(Class<T> containerObjectClass, ContainerObjectConfiguration configuration, Object containerObjectContainer) {
+        if (configuration == null) {
+            throw new IllegalArgumentException("configuration cannot be null");
+        }
         try {
             return new DockerContainerObjectBuilder<T>(dockerClientExecutorInstance.get(), cubeControllerInstance.get())
                     .withEnrichers(serviceLoaderInstance.get().all(TestEnricher.class))

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ContainerObjectUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ContainerObjectUtil.java
@@ -18,13 +18,13 @@ public class ContainerObjectUtil {
       super();
    }
 
-   public static List<? extends Annotation> getAllAnnotations(final Class<?> source, final Class<? extends Annotation> annotationClass) {
-      return AccessController.doPrivileged((PrivilegedAction<List<? extends Annotation>>) () -> {
-         List<Annotation> annotations = new ArrayList<>();
+   public static <T extends Annotation> List<T> getAllAnnotations(final Class<?> source, final Class<T> annotationClass) {
+      return AccessController.doPrivileged((PrivilegedAction<List<T>>) () -> {
+         List<T> annotations = new ArrayList<>();
 
          Class<?> nextSource = source;
          while (nextSource != Object.class) {
-            final Annotation[] annotationsByType = nextSource.getAnnotationsByType(annotationClass);
+            final T[] annotationsByType = nextSource.getAnnotationsByType(annotationClass);
             Collections.addAll(annotations, annotationsByType);
             //If not maybe we need to use the default value but maybe there is some parent class
             //That contains a different value rather than the default ones so we need to continue search.

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricherTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricherTest.java
@@ -1,6 +1,5 @@
 package org.arquillian.cube.docker.impl.client.containerobject;
 
-
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.notNullValue;
@@ -13,10 +12,14 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import java.io.File;
-import java.io.FilenameFilter;
-import java.util.ArrayList;
+import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 
+import com.google.common.base.StandardSystemProperty;
+
+import org.apache.commons.io.FileUtils;
 import org.arquillian.cube.CubeController;
 import org.arquillian.cube.containerobject.Cube;
 import org.arquillian.cube.containerobject.CubeDockerFile;
@@ -30,8 +33,8 @@ import org.arquillian.cube.impl.model.LocalCubeRegistry;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.arquillian.cube.spi.metadata.IsContainerObject;
 import org.jboss.arquillian.core.api.Injector;
-import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.spi.ServiceLoader;
+import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.GenericArchive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -44,11 +47,12 @@ import org.junit.Test;
 
 public class CubeContainerObjectTestEnricherTest {
 
-    private CubeRegistry cubeRegistry = new LocalCubeRegistry();
+    private CubeRegistry cubeRegistry;
     private CubeController cubeController;
     private DockerClientExecutor dockerClientExecutor;
     private Injector injector;
     private ServiceLoader serviceLoader;
+    private DockerContainerObjectFactory dockerContainerObjectFactory;
 
     @AfterClass
     public static void cleanEnvironment() {
@@ -57,11 +61,19 @@ public class CubeContainerObjectTestEnricherTest {
 
     @Before
     public void init() {
+        cubeRegistry = new LocalCubeRegistry();
+        dockerContainerObjectFactory = new DockerContainerObjectFactory();
         cubeController = mock(CubeController.class);
         dockerClientExecutor = mock(DockerClientExecutor.class);
         injector = mock(Injector.class);
         serviceLoader = mock(ServiceLoader.class);
-        when(serviceLoader.all(any(Class.class))).thenReturn(new ArrayList<Object>());
+        when(serviceLoader.all(any(Class.class))).thenReturn(Collections.emptyList());
+
+        dockerContainerObjectFactory.serviceLoaderInstance = () -> serviceLoader;
+        dockerContainerObjectFactory.dockerClientExecutorInstance = () -> dockerClientExecutor;
+        dockerContainerObjectFactory.cubeRegistryInstance = () -> cubeRegistry;
+        dockerContainerObjectFactory.cubeControllerInstance = () -> cubeController;
+        dockerContainerObjectFactory.injectorInstance = () -> injector;
 
         //We asure that there is no previous executions there.
         deleteTestDirectory();
@@ -70,36 +82,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldStartAContainerObject() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         InjectableTest injectableTest = new InjectableTest();
         cubeContainerObjectTestEnricher.enrich(injectableTest);
@@ -117,36 +101,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldShouldStartAContainerObjectDefinedUsingDescriptor() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         SecondInjectableTest secondInjectableTest = new SecondInjectableTest();
         cubeContainerObjectTestEnricher.enrich(secondInjectableTest);
@@ -165,36 +121,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldLinkInnerContainers() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         ThirdInjetableTest thirdInjetableTest = new ThirdInjetableTest();
         cubeContainerObjectTestEnricher.enrich(thirdInjetableTest);
@@ -220,36 +148,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldLinkInnerContainersWithoutLink() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         FifthInjetableTest fifthInjetableTest = new FifthInjetableTest();
         cubeContainerObjectTestEnricher.enrich(fifthInjetableTest);
@@ -275,36 +175,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldStartAContainerObjectDefinedAsImage() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         FourthInjectableTest injectableTest = new FourthInjectableTest();
         cubeContainerObjectTestEnricher.enrich(injectableTest);
@@ -325,36 +197,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldStartAContainerObjectDefinedAsImageAndEnvironmentVariables() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         FifthInjectableTest injectableTest = new FifthInjectableTest();
         cubeContainerObjectTestEnricher.enrich(injectableTest);
@@ -376,36 +220,8 @@ public class CubeContainerObjectTestEnricherTest {
     @Test
     public void shouldStartAContainerObjectDefinedAsImageAndVolumesVariables() {
         CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher = new CubeContainerObjectTestEnricher();
-        cubeContainerObjectTestEnricher.injectorInstance = new Instance<Injector>() {
-            @Override
-            public Injector get() {
-                return injector;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeRegistryInstance = new Instance<CubeRegistry>() {
-            @Override
-            public CubeRegistry get() {
-                return cubeRegistry;
-            }
-        };
-        cubeContainerObjectTestEnricher.serviceLoader = new Instance<ServiceLoader>() {
-            @Override
-            public ServiceLoader get() {
-                return serviceLoader;
-            }
-        };
-        cubeContainerObjectTestEnricher.cubeControllerInstance = new Instance<CubeController>() {
-            @Override
-            public CubeController get() {
-                return cubeController;
-            }
-        };
-        cubeContainerObjectTestEnricher.dockerClientExecutorInstance = new Instance<DockerClientExecutor>() {
-            @Override
-            public DockerClientExecutor get() {
-                return dockerClientExecutor;
-            }
-        };
+        cubeContainerObjectTestEnricher.containerObjectFactoryInstance = () -> dockerContainerObjectFactory;
+        when(serviceLoader.all(TestEnricher.class)).thenReturn(Arrays.asList(cubeContainerObjectTestEnricher));
 
         SixthInjectableTest injectableTest = new SixthInjectableTest();
         cubeContainerObjectTestEnricher.enrich(injectableTest);
@@ -527,31 +343,30 @@ public class CubeContainerObjectTestEnricherTest {
     }
 
     private static void deleteTestDirectory() {
-        File tempDirectory = new File(System.getProperty("java.io.tmpdir"));
-        final File[] tests = tempDirectory.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name.startsWith("Test");
+        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        final File[] testsDirectories = tempDirectory.listFiles(CubeContainerObjectTestEnricherTest::testDirectoryFilter);
+        for (File testDirectory: testsDirectories) {
+            try {
+                FileUtils.deleteDirectory(testDirectory);
+            } catch (IOException e) {
+                // ignore
             }
-        });
-        for (File testDirectory : tests) {
-            testDirectory.delete();
         }
     }
 
-    private File findGeneratedDirectory() {
-
-        File tempDirectory = new File(System.getProperty("java.io.tmpdir"));
-        final File[] tests = tempDirectory.listFiles(new FilenameFilter() {
-            @Override
-            public boolean accept(File dir, String name) {
-                return name.startsWith("Test");
-            }
-        });
-        if (tests.length > 0) {
-            return tests[0];
+    private static File findGeneratedDirectory() {
+        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        final File[] testsDirectories = tempDirectory.listFiles(CubeContainerObjectTestEnricherTest::testDirectoryFilter);
+        if (testsDirectories.length > 0) {
+            return testsDirectories[0];
         } else {
             return null;
         }
+    }
+
+    private static boolean testDirectoryFilter(File dir, String name) {
+        return dir.isDirectory()
+                && name.startsWith(DockerContainerObjectBuilder.TEMPORARY_FOLDER_PREFIX)
+                && name.endsWith(DockerContainerObjectBuilder.TEMPORARY_FOLDER_SUFFIX);
     }
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricherTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/CubeContainerObjectTestEnricherTest.java
@@ -17,8 +17,6 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 
-import com.google.common.base.StandardSystemProperty;
-
 import org.apache.commons.io.FileUtils;
 import org.arquillian.cube.CubeController;
 import org.arquillian.cube.containerobject.Cube;
@@ -343,7 +341,7 @@ public class CubeContainerObjectTestEnricherTest {
     }
 
     private static void deleteTestDirectory() {
-        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        File tempDirectory = new File(System.getProperty("java.io.tmpdir"));
         final File[] testsDirectories = tempDirectory.listFiles(CubeContainerObjectTestEnricherTest::testDirectoryFilter);
         for (File testDirectory: testsDirectories) {
             try {
@@ -355,7 +353,7 @@ public class CubeContainerObjectTestEnricherTest {
     }
 
     private static File findGeneratedDirectory() {
-        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        File tempDirectory = new File(System.getProperty("java.io.tmpdir"));
         final File[] testsDirectories = tempDirectory.listFiles(CubeContainerObjectTestEnricherTest::testDirectoryFilter);
         if (testsDirectories.length > 0) {
             return testsDirectories[0];

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
@@ -1,10 +1,17 @@
 package org.arquillian.cube.docker.impl.client.containerobject;
 
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.*;
+import static org.junit.Assert.fail;
+import static org.junit.Assert.assertThat;
 import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
 
 import java.io.File;
 import java.io.IOException;

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
@@ -1,0 +1,499 @@
+package org.arquillian.cube.docker.impl.client.containerobject;
+
+import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.*;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.*;
+
+import java.io.File;
+import java.io.IOException;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.security.AccessController;
+import java.security.PrivilegedExceptionAction;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+
+import com.google.common.base.StandardSystemProperty;
+
+import org.apache.commons.io.FileUtils;
+import org.arquillian.cube.CubeController;
+import org.arquillian.cube.CubeIp;
+import org.arquillian.cube.HostPort;
+import org.arquillian.cube.containerobject.Cube;
+import org.arquillian.cube.containerobject.CubeDockerFile;
+import org.arquillian.cube.containerobject.Environment;
+import org.arquillian.cube.containerobject.Image;
+import org.arquillian.cube.containerobject.Link;
+import org.arquillian.cube.containerobject.Volume;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.impl.util.ReflectionUtil;
+import org.arquillian.cube.spi.metadata.HasPortBindings;
+import org.arquillian.cube.spi.metadata.IsContainerObject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+import org.jboss.shrinkwrap.api.Archive;
+import org.jboss.shrinkwrap.api.GenericArchive;
+import org.jboss.shrinkwrap.api.ShrinkWrap;
+import org.jboss.shrinkwrap.api.asset.StringAsset;
+import org.jboss.shrinkwrap.descriptor.api.Descriptors;
+import org.jboss.shrinkwrap.descriptor.api.docker.DockerDescriptor;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+public class DockerContainerObjectBuilderTest {
+
+    public static final String BASE_IMAGE = "tomee:8-jre-1.7.2-webprofile";
+
+    private CubeController cubeController;
+    private DockerClientExecutor dockerClientExecutor;
+    private CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher;
+    private Collection<TestEnricher> enrichers;
+
+    @Before
+    public void initMocks() {
+        cubeController = mock(CubeController.class);
+        dockerClientExecutor = mock(DockerClientExecutor.class);
+        cubeContainerObjectTestEnricher = mock(CubeContainerObjectTestEnricher.class);
+        doAnswer(DockerContainerObjectBuilderTest::objectContainerEnricherMockEnrich)
+                .when(cubeContainerObjectTestEnricher).enrich(any());
+        enrichers = Collections.singleton(cubeContainerObjectTestEnricher);
+    }
+
+    @Before
+    public void cleanupTestDirsBeforeEachTest() {
+        deleteTestDirectory();
+    }
+
+    @AfterClass
+    public static void cleanupTestDirsWhenDone() {
+        deleteTestDirectory();
+    }
+
+    @Test
+    public void shouldStartAContainerObjectDefinedUsingDockerfile() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            TestContainerObjectDefinedUsingDockerfile containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingDockerfile>(dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectDefinedUsingDockerfile.class)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+
+        verify(cubeController, times(1)).create("containerDefinedUsingDockerfile");
+        verify(cubeController, times(1)).start("containerDefinedUsingDockerfile");
+    }
+
+    @Test
+    public void shouldStartAContainerObjectDefinedUsingDescriptor() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            TestContainerObjectDefinedUsingDescriptor containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingDescriptor>(
+                        dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectDefinedUsingDescriptor.class)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+
+        verify(cubeController, times(1)).create("containerDefinedUsingDescriptor");
+        verify(cubeController, times(1)).start("containerDefinedUsingDescriptor");
+
+        final File generatedDirectory = findGeneratedDirectory();
+        assertThat(generatedDirectory, is(notNullValue()));
+        assertThat(new File(generatedDirectory, "Dockerfile").exists(), is(true));
+    }
+
+    @Test
+    public void shouldLinkInnerContainersWithLink() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            TestContainerObjectWithAnnotatedLink containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithAnnotatedLink>(
+                        dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectWithAnnotatedLink.class)
+                    .withEnrichers(enrichers)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+            assertThat(containerObject.linkedContainerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        Collection<org.arquillian.cube.docker.impl.client.config.Link> links = cube.configuration().getLinks();
+        assertThat(links, is(notNullValue()));
+        assertThat(links.size(), is(1));
+        assertThat(links, hasItem(org.arquillian.cube.docker.impl.client.config.Link.valueOf("db:db")));
+
+        verify(cubeController, times(1)).create("containerWithAnnotatedLink");
+        verify(cubeController, times(1)).start("containerWithAnnotatedLink");
+
+        verify(cubeContainerObjectTestEnricher, times(1)).enrich(any(TestContainerObjectWithAnnotatedLink.class));
+    }
+
+    @Test
+    public void shouldLinkInnerContainersWithoutLink() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            TestContainerObjectWithNonAnnotatedLink containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithNonAnnotatedLink>(dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectWithNonAnnotatedLink.class)
+                    .withEnrichers(enrichers)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+            assertThat(containerObject.linkedContainerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        Collection<org.arquillian.cube.docker.impl.client.config.Link> links = cube.configuration().getLinks();
+        assertThat(links, is(notNullValue()));
+        assertThat(links.size(), is(1));
+        assertThat(links, hasItem(org.arquillian.cube.docker.impl.client.config.Link.valueOf("inner:inner")));
+
+        verify(cubeController, times(1)).create("containerWithNonAnnotatedLink");
+        verify(cubeController, times(1)).start("containerWithNonAnnotatedLink");
+
+        verify(cubeContainerObjectTestEnricher, times(1)).enrich(any(TestContainerObjectWithAnnotatedLink.class));
+    }
+
+    @Test
+    public void shouldStartAContainerObjectDefinedUsingImage() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            TestContainerObjectDefinedUsingImage containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImage>(dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectDefinedUsingImage.class)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        assertThat(cube.configuration().getImage().toImageRef(), is(BASE_IMAGE));
+
+        verify(cubeController, times(1)).create("containerDefinedUsingImage");
+        verify(cubeController, times(1)).start("containerDefinedUsingImage");
+    }
+
+    @Test
+    public void shouldStartAContainerObjectDefinedUsingImageAndEnvironmentVariables() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            CubeContainer ccconfig = new CubeContainer();
+            ccconfig.setEnv(Collections.singleton("e=f"));
+            CubeContainerObjectConfiguration ccoconfig = new CubeContainerObjectConfiguration(ccconfig);
+            TestContainerObjectDefinedUsingImageAndEnvironmentVariables containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImageAndEnvironmentVariables>(dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectDefinedUsingImageAndEnvironmentVariables.class)
+                    .withContainerObjectConfiguration(ccoconfig)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        assertThat(cube.configuration().getImage().toImageRef(), is(BASE_IMAGE));
+        assertThat(cube.configuration().getEnv(), hasItems("a=b", "c=d", "e=f"));
+
+        verify(cubeController, times(1)).create("containerWithEnvironmentVariables");
+        verify(cubeController, times(1)).start("containerWithEnvironmentVariables");
+    }
+
+    @Test
+    public void shouldStartAContainerObjectDefinedUsingImageAndVolumes() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        try {
+            CubeContainer ccconfig = new CubeContainer();
+            ccconfig.setBinds(Collections.singleton("/mypath3:/containerPath3:rw"));
+            CubeContainerObjectConfiguration ccoconfig = new CubeContainerObjectConfiguration(ccconfig);
+            TestContainerObjectDefinedUsingImageAndVolumes containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImageAndVolumes>(dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectDefinedUsingImageAndVolumes.class)
+                    .withContainerObjectConfiguration(ccoconfig)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        assertThat(cube.configuration().getImage().toImageRef(), is(BASE_IMAGE));
+        assertThat(cube.configuration().getBinds(), hasItems("/mypath:/containerPath:rw", "/mypath2:/containerPath2:rw", "/mypath3:/containerPath3:rw"));
+
+        verify(cubeController, times(1)).create("containerWithVolumes");
+        verify(cubeController, times(1)).start("containerWithVolumes");
+    }
+
+    @Test
+    public void shouldEnrichAContainerWithCubeIp() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            // when started, initialize cube port bindings
+            initDockerCubeInternalIP(cubeRef.get(), "172.17.0.2");
+            return null;
+        }).when(cubeController).start("containerWithCubeIp");
+        try {
+            TestContainerObjectWithCubeIp containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithCubeIp>(
+                        dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectWithCubeIp.class)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+            assertThat(containerObject.cubeIp, is("172.17.0.2"));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        assertThat(cube.hasMetadata(HasPortBindings.class), is(true));
+
+        verify(cubeController, times(1)).create("containerWithCubeIp");
+        verify(cubeController, times(1)).start("containerWithCubeIp");
+    }
+
+    @Test
+    public void shouldEnrichAContainerWithHostPort() {
+        final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
+        doAnswer(invocation -> {
+            // when started, initialize cube port bindings
+            initDockerCubeMappedPort(cubeRef.get(), "127.0.0.1", 8080, 8080);
+            return null;
+        }).when(cubeController).start("containerWithHostPort");
+        try {
+            TestContainerObjectWithHostPort containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithHostPort>(
+                    dockerClientExecutor, cubeController)
+                    .withContainerObjectClass(TestContainerObjectWithHostPort.class)
+                    .onCubeCreated(cubeRef::set)
+                    .build();
+            assertThat(containerObject, is(notNullValue()));
+            assertThat(containerObject.port, is(8080));
+        } catch (IllegalAccessException|InvocationTargetException|IOException e) {
+            fail();
+        }
+
+        DockerCube cube = cubeRef.get();
+        assertThat(cube, is(notNullValue()));
+        assertThat(cube.hasMetadata(IsContainerObject.class), is(true));
+        assertThat(cube.getMetadata(IsContainerObject.class).getTestClass(), is(nullValue()));
+        assertThat(cube.hasMetadata(HasPortBindings.class), is(true));
+
+        verify(cubeController, times(1)).create("containerWithHostPort");
+        verify(cubeController, times(1)).start("containerWithHostPort");
+    }
+
+    //<editor-fold desc="container object classes used by test methods">
+
+    @Cube("containerDefinedUsingDockerfile")
+    @CubeDockerFile
+    public static class TestContainerObjectDefinedUsingDockerfile {
+    }
+
+    @Cube("containerDefinedUsingDescriptor")
+    public static class TestContainerObjectDefinedUsingDescriptor {
+
+        @CubeDockerFile
+        public static Archive<?> createDockerfile() {
+            String dockerDescriptor = Descriptors.create(DockerDescriptor.class)
+                    .from(BASE_IMAGE)
+                    .exportAsString();
+            return ShrinkWrap.create(GenericArchive.class)
+                    .add(new StringAsset(dockerDescriptor), "Dockerfile");
+        }
+    }
+
+    @Cube("containerWithAnnotatedLink")
+    public static class TestContainerObjectWithAnnotatedLink {
+
+        @CubeDockerFile
+        public static Archive<?> createDockerfile() {
+            String dockerDescriptor = Descriptors.create(DockerDescriptor.class)
+                    .from(BASE_IMAGE)
+                    .exportAsString();
+            return ShrinkWrap.create(GenericArchive.class)
+                    .add(new StringAsset(dockerDescriptor), "Dockerfile");
+        }
+
+        @Cube("inner")
+        @Link("db:db")
+        TestContainerObjectDefinedUsingDescriptor linkedContainerObject;
+    }
+
+    @Cube("containerWithNonAnnotatedLink")
+    public static class TestContainerObjectWithNonAnnotatedLink {
+
+        @CubeDockerFile
+        public static Archive<?> createDockerfile() {
+            String dockerDescriptor = Descriptors.create(DockerDescriptor.class)
+                    .from(BASE_IMAGE)
+                    .exportAsString();
+            return ShrinkWrap.create(GenericArchive.class)
+                    .add(new StringAsset(dockerDescriptor), "Dockerfile");
+        }
+
+        @Cube("inner")
+        TestContainerObjectDefinedUsingDescriptor linkedContainerObject;
+    }
+
+    @Cube("containerDefinedUsingImage")
+    @Image(BASE_IMAGE)
+    public static class TestContainerObjectDefinedUsingImage {
+    }
+
+    @Cube("containerWithEnvironmentVariables")
+    @Image(BASE_IMAGE)
+    @Environment(key = "a", value = "b")
+    @Environment(key = "c",  value = "d")
+    public static class TestContainerObjectDefinedUsingImageAndEnvironmentVariables {
+    }
+
+    @Cube("containerWithVolumes")
+    @Image(BASE_IMAGE)
+    @Volume(hostPath = "/mypath", containerPath = "/containerPath")
+    @Volume(hostPath = "/mypath2", containerPath = "/containerPath2")
+    public static class TestContainerObjectDefinedUsingImageAndVolumes {
+    }
+
+    @Cube("containerWithCubeIp")
+    @Image(BASE_IMAGE)
+    public static class TestContainerObjectWithCubeIp {
+
+        @CubeIp
+        String cubeIp;
+    }
+
+    @Cube(value = "containerWithHostPort", portBinding = "8080->8080/tcp")
+    @Image(BASE_IMAGE)
+    public static class TestContainerObjectWithHostPort {
+
+        @HostPort(8080)
+        int port;
+    }
+
+    //</editor-fold>
+    //<editor-fold desc="utility methods used by test methods">
+
+    private static void deleteTestDirectory() {
+        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        final File[] testsDirectories = tempDirectory.listFiles(DockerContainerObjectBuilderTest::testDirectoryFilter);
+        for (File testDirectory: testsDirectories) {
+            try {
+                FileUtils.deleteDirectory(testDirectory);
+            } catch (IOException e) {
+                // ignore
+            }
+        }
+    }
+
+    private static File findGeneratedDirectory() {
+        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        final File[] testsDirectories = tempDirectory.listFiles(DockerContainerObjectBuilderTest::testDirectoryFilter);
+        if (testsDirectories.length > 0) {
+            return testsDirectories[0];
+        } else {
+            return null;
+        }
+    }
+
+    private static boolean testDirectoryFilter(File dir, String name) {
+        return dir.isDirectory()
+                && name.startsWith(DockerContainerObjectBuilder.TEMPORARY_FOLDER_PREFIX)
+                && name.endsWith(DockerContainerObjectBuilder.TEMPORARY_FOLDER_SUFFIX);
+    }
+
+    private static Void objectContainerEnricherMockEnrich(InvocationOnMock invocation) throws Throwable {
+        // simulate ContainerObjectTestEnricher by setting every field annotated with @Cube with a new instance
+        Object containerObject = invocation.getArguments()[0];
+        ReflectionUtil.getFieldsWithAnnotation(containerObject.getClass(), Cube.class)
+                .stream().forEach(field -> {
+            try {
+                field.set(containerObject, field.getType().newInstance());
+            } catch (IllegalAccessException | InstantiationException e) {
+                throw new RuntimeException(e);
+            }
+        });
+        return null;
+    }
+
+    private static void initDockerCubeInternalIP(DockerCube dockerCube, String internalIP) {
+        PrivilegedExceptionAction<Void> action = () -> {
+            Field dockerCubePortBindingsField = DockerCube.class.getDeclaredField("portBindings");
+            dockerCubePortBindingsField.setAccessible(true);
+            Class<?> dockerCubePortBindingsClass = dockerCubePortBindingsField.getType();
+            Field dockerCubePortBindingsInternalIpField = dockerCubePortBindingsClass.getDeclaredField("internalIP");
+            dockerCubePortBindingsInternalIpField.setAccessible(true);
+            Object dockerCubePortBindings = dockerCubePortBindingsField.get(dockerCube);
+            dockerCubePortBindingsInternalIpField.set(dockerCubePortBindings, internalIP);
+            return null;
+        };
+        try {
+            AccessController.doPrivileged(action);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    private static void initDockerCubeMappedPort(DockerCube dockerCube, String containerIP, int exposedPort, int boundPort) {
+        PrivilegedExceptionAction<Void> action = () -> {
+            Field dockerCubePortBindingsField = DockerCube.class.getDeclaredField("portBindings");
+            dockerCubePortBindingsField.setAccessible(true);
+            Class<?> dockerCubePortBindingsClass = dockerCubePortBindingsField.getType();
+            Field dockerCubePortBindingsMappedPortsField = dockerCubePortBindingsClass.getDeclaredField("mappedPorts");
+            dockerCubePortBindingsMappedPortsField.setAccessible(true);
+            Object dockerCubePortBindings = dockerCubePortBindingsField.get(dockerCube);
+            Map<Integer, HasPortBindings.PortAddress> mappedPorts = (Map<Integer, HasPortBindings.PortAddress>) dockerCubePortBindingsMappedPortsField.get(dockerCubePortBindings);
+            mappedPorts.put(exposedPort, new HasPortBindings.PortAddressImpl(containerIP, boundPort));
+            return null;
+        };
+        try {
+            AccessController.doPrivileged(action);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    //</editor-fold>
+}

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
@@ -17,8 +17,6 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 
-import com.google.common.base.StandardSystemProperty;
-
 import org.apache.commons.io.FileUtils;
 import org.arquillian.cube.CubeController;
 import org.arquillian.cube.CubeIp;
@@ -417,7 +415,7 @@ public class DockerContainerObjectBuilderTest {
     //<editor-fold desc="utility methods used by test methods">
 
     private static void deleteTestDirectory() {
-        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        File tempDirectory = new File(System.getProperty("java.io.tmpdir"));
         final File[] testsDirectories = tempDirectory.listFiles(DockerContainerObjectBuilderTest::testDirectoryFilter);
         for (File testDirectory: testsDirectories) {
             try {
@@ -429,7 +427,7 @@ public class DockerContainerObjectBuilderTest {
     }
 
     private static File findGeneratedDirectory() {
-        File tempDirectory = new File(StandardSystemProperty.JAVA_IO_TMPDIR.value());
+        File tempDirectory = new File(System.getProperty("java.io.tmpdir"));
         final File[] testsDirectories = tempDirectory.listFiles(DockerContainerObjectBuilderTest::testDirectoryFilter);
         if (testsDirectories.length > 0) {
             return testsDirectories[0];

--- a/docker/docker/src/test/resources/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest/TestContainerObjectDefinedUsingDockerfile/Dockerfile
+++ b/docker/docker/src/test/resources/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest/TestContainerObjectDefinedUsingDockerfile/Dockerfile
@@ -1,0 +1,1 @@
+FROM tomee:8-jre-1.7.2-webprofile

--- a/docs/cop.adoc
+++ b/docs/cop.adoc
@@ -251,7 +251,7 @@ public class PingPongTest {
     @Test
     public void shouldReturnOkAsPong() throws IOException {
         PingPongContainer pingPongContainer =
-            factory.createContainer(PingPongContainer.class, null); // <2>
+            factory.createContainer(PingPongContainer.class); // <2>
         try {
             String pong = ping();
             assertThat(pong, containsString("OK"));

--- a/docs/cop.adoc
+++ b/docs/cop.adoc
@@ -1,43 +1,46 @@
 == Container Object pattern
 
-If you search for a description of what *Page Object* is, you’ll find that The Page Object Pattern gives us a common sense way to model content in a reusable and maintainable way.
+If you search for a description of what *Page Object* is, you'll find that it describes a pattern that allows you to model content in a reusable and maintainable way.
+The description also points that within your web app's UI, there are areas that your tests interact with, and a Page Object simply models those areas as objects within the test code.
+Using the Page Object pattern reduces the amount of duplicated code. If the UI changes, only the Page Object will need to be updated for the test cases to run.
 
-And also points that: Within your web app’s UI there are areas that your tests interact with. A Page Object simply models these as objects within the test code. This reduces the amount of duplicated code and means that if the UI changes, the fix need only be applied in one place.
+As you can see, the Page Object pattern applies to UI elements. We (the Arquillian community) have coined a new pattern following Page Object that we call the *Container Object* pattern.
+You can think of a Container Object as a mechanism to encapsulate areas (data and actions) related to a container (for now only Docker containers) that your test might interact with.
+For example:
 
-As you can see, Page Object applies to UI elements. We (the Arquillian community) has coined a new pattern following Page Object pattern called *Container Object* pattern. You can think about Container Object as areas of a container (for now Docker container) that your test might interact with. For example some of these areas could be:
-
-* to get the host IP where container is running
+* the host IP where the container is running
 * the bounded port for a given exposed port
-* any parameter configured inside the configuration file (Dockerfile) like a user or password to access to the service which the container exposes.
+* any parameter configured inside the configuration file (Dockerfile), like a user or password to access the service running in the container.
 
-In case of running a MySQL database in the container, it could be the user and password to access to database. Notice that nothing prevents you to generate the correct URL for accessing to the service from the test, or execute commands against container like retrieving an internal file.
+For example, if running a MySQL database in a container, it could be the user and password to access the database.
+Notice that nothing prevents you from generating the correct URL to access the service directly from your test, or executing commands against the container, for example retrieving an internal file.
 
-And of course as Page Object does, Container Object gives you a way to build a model content that can be reused for several projects.
+As is the case with Page Objects, the Container Object pattern gives you a mechanism to build a model that can be reused on several projects.
 
-Before looking at how this pattern is implemented in Cube, let’s go thorough an example:
+Before looking at how this pattern is implemented in Cube, let's go through an example:
 
-Suppose all of your applications need to send a file to an FTP server.
-To write an integration/component test you might need a FTP server to send the file and check that the file was correctly sent.
-One way to do this is using Docker to start a FTP server just before executing the test, then execute the test using this docker container for FTP server, before stopping the container check that the file is there, and finally stop the container.
+Suppose all your applications need to send a file to an FTP server.
+To write an integration/component test for your apps, you might need an FTP server to send the file to, and then check that the file was correctly sent.
+One way to implement such test is (i) by using Docker to start an FTP server just before executing the test, then (ii) execute the test using this docker container as the receiving FTP server, (iii) before stopping the container check that the file is present, and finally (iv) stop and destroy the container.
 
-So all these operations that involves the FTP server and container could be joined inside a Container Object.
-This container object might contain information of:
+All these operations that involve the FTP server and container could be encapsulated inside a Container Object.
+This container object might contain the following information:
 
 * which image is used
-* IP and bounded port of host where this FTP server is running
-* user and password to access to the FTP server
-* methods for asserting the existence of a file
+* IP and port bound to the host where the FTP server is running
+* user and password required to access the FTP server
+* methods for asserting the existence of a file inside the container
 
-Then from the point of view of test, it only communicate with this object instead of directly hard coding all information inside the test.
-Again as in Page Object, any change on the container only affects the Container Object and not the test itself.
+Test code will only interact with this object instead of directly hard coding all required information inside the test.
+Again, as in the Page Object pattern, any change on the container only affects the Container Object and not the test itself.
 
-Now let’s see how _Arquillian Cube_ implements Container Object pattern.
+Now let's see how _Arquillian Cube_ implements the Container Object pattern.
 
 === Arquillian Cube and Container Object
 
-Let’s see a simple example on how you can implement a Container Object in _Cube_.
+Let's see a simple example of how you can implement a Container Object in _Cube_.
 Suppose you want to create a container object that encapsulates a ping pong server running inside Docker.
-The Container Object will be like a simple POJO with special annotations:
+The Container Object will be a simple POJO with special annotations:
 
 [source, java]
 .PingPongContainer.java
@@ -56,34 +59,35 @@ public class PingPongContainer {
 
   public URL getConnectionUrl() { // <3>
     try {
-      return new URL(“http://” + dockerHost + “:” + port);
+      return new URL("http://" + dockerHost + ":" + port);
 	  } catch (MalformedURLException e) {
 		  throw new IllegalArgumentException(e);
 	  }
   }
 }
 ----
-<1> `@Cube` annotation configures Container Object
+<1> The `@Cube` annotation configures the Container Object
 <2> A Container Object can be enriched with Arquillian enrichers
-<3> Container Object hides how to connect to PingPong server.
+<3> The Container Object hides how to connect to the PingPong server
 
-`@Cube` annotation is used to configure this Container Object.
-Initially you set that the started container will be named `pingpong` and the port binding information for the container instance, in this case `5000->8080/tcp`.
-Notice that this can be an array to set more than one port binding definition.
+The `@Cube` annotation is used to configure a Container Object.
+Its `value` property is used to specify how the started container will be named (in this example `pingpong`) while the `portBinding` property can be used to specify the port binding information for the container instance (in this case `5000->8080/tcp`).
+Notice that `portBinding` can also accept an array, in which case more than one port binding definitions can be specified.
 
-Next annotation is `@CubeDockerFile` which configure how Container is created.
-In this case using a Dockerfile located at default class path location.
-The default location is the _package+classname_, so for example in previous case, `Dockerfile` should be placed at `org/superbiz/containerobject/PingPongContainer`.
-Of course you can set any other class path location by passing as value of the annotation.
+The next annotation is `@CubeDockerFile`, which configures how the container is created.
+This example will use a Dockerfile located at the default class path location.
+As the default location is the _package+classname_, in our example the `Dockerfile` should be placed at `org/superbiz/containerobject/PingPongContainer`.
+It is possible to set any other class path location by passing it as the `value` property of the `@CubeDockerFile` annotation.
 
-IMPORTANT: `CubeDockerFile` annotation sets the location where the `Dockerfile` is found and not the file itself. Also this location should be reachable from ClassLoader, so it means it should be loaded in class path in order to find it.
+IMPORTANT: The `@CubeDockerFile` annotation defines the _location_ where the `Dockerfile` is found, not the file itself.
+This location must be reachable from the ClassLoader creating the container object, which means it should be on the class path for the class loader to be able to find it.
 
-Any Cube can be enriched with any client side enricher, in this case with `@HostIp` enricher, but it could be enriched with `DockerClient` using `@ArquillianResource` as well.
+Any Cube can be enriched with any client side enricher. In the previous example a `@HostIp` enricher is used, but it could be enriched similarly with `@CubeIp` (which works similar to `@HostPort`), or a `DockerClient` instance if the field is annotated with `@ArquillianResource`.
 
-Finally the `@HostPort` is used to translate the exposed port to bound port.
-So in this example port value will be 5000. You are going to lean briefly why this annotation is important.
+Finally the `@HostPort` is used to translate the exposed port to the bound port.
+In this example the port value will be 5000. Later you will learn briefly why this annotation is important.
 
-And then you can start using this container object in your test:
+After creating the container object, you can start using it in your test:
 
 [source, java]
 .PingPongTest.java
@@ -103,13 +107,13 @@ public class PingPongTest {
 }
 ----
 
-The most important thing here is that you need to set Container Object as a field of the class and annotate with `@Cube`.
-It is very important to annotate the field with `Cube`, so before Arquillian runs the test, it can detect that it needs to  start a new Cube (Docker container), create the Container Object and inject it in the test.
-Notice that this annotation is exactly the same as used when you defined the Container Object.
-And it is in this way because you can override any property of the Container Object from the test side.
-This is why `@HostPort` annotation is important, since port can be changed from the test definition, you need to find a way to inject the correct port inside the container object.
+The most important step in that test example is setting the Container Object as a field of the test class, and annotating it with `@Cube`.
+Before running a test, Arquillian will detect that it needs to (i) start a new Cube (Docker container), (ii) create the Container Object and (iii) inject it in the test.
+Notice that this `@Cube` annotation is exactly the same as the one used when you defined the Container Object.
+Placing a `@Cube` annotation on the field will allow you to override any property of the Container Object from the test side.
+Due to the override mechanism, it is important to use the `@HostPort` annotation when the bound port is needed, since it can be changed from the test definition.
 
-IMPORTANT: Container Object pattern only works in Client mode or Arquillian standalone.
+IMPORTANT: The Container Object pattern only works in Client mode or Arquillian Standalone.
 
 ==== ShrinkWrap Dockerfile Descriptor
 
@@ -152,15 +156,14 @@ public class PingPongContainer {
 <2> Method must be `public` and `static`.
 <3> Returns a `GenericArchive` with all elements required for building the Docker container instance.
 
-
-In Arquillian Cube we are providing a `org.arquillian.cube.impl.shrinkwrap.asset.CacheUrlAsset` asset.
-This asset is like `org.jboss.shrinkwrap.api.asset.UrlAsset` but it caches to disk for an amount of time the content that has been downloaded from the URL.
-By default this expiration time is 1 hour but it is configurable by using proper constructor.
+As part of Arquillian Cube, we are providing a `org.arquillian.cube.impl.shrinkwrap.asset.CacheUrlAsset` asset.
+This asset is similar to `org.jboss.shrinkwrap.api.asset.UrlAsset`, but the former caches to disk for an amount of time the content that has been downloaded from the URL.
+By default this expiration time is 1 hour, and it is configurable by using the proper constructor.
 
 ==== Links
 
-A Container Object can contain more Container Objects inside.
-So effectively a Container Object can be an aggregation of other Container Objects:
+A Container Object can reference more Container Objects from inside of it.
+Effectively, a Container Object can be an aggregation of other Container Objects:
 
 [source, java]
 .FirstContainerObject.java
@@ -177,7 +180,7 @@ public class FirstContainerObject {
 
 In this case Arquillian Cube will create a link from `FirstContainerObject` to `LinkContainerObject` with link value `inner:inner`.
 
-But of course you can override the link value using `@Link` annotation.
+Of course you can override the link value using `@Link` annotation.
 
 [source, java]
 ----
@@ -188,18 +191,18 @@ TestLinkContainerObject linkContainerObject;
 
 ==== Image
 
-So far, you’ve seen that the Container Object creates a Container object from a `Dockerfile` using `@CubeDockerFile` annotation, but you can also creates a Container Object from an image by using `@Image` annotation:
+So far, you've seen that a Container Object creates an instance from a `Dockerfile` using `@CubeDockerFile` annotation. You can also create a Container Object from an image by using `@Image` annotation:
 
 [source, java]
 .ImageContainerObject.java
 ----
-@Cube(“tomme”)
+@Cube("tomme")
 @Image("tomee:8-jre-1.7.2-webprofile")
 public static class ImageContainerObject {
 }
 ----
 
-So in this case Arquillian Cube starts and stops the image defined in the annotation.
+In this case Arquillian Cube will create containers based on the image defined in the annotation.
 
 ==== Environment
 
@@ -227,14 +230,55 @@ public class ImageContainer {
 }
 ----
 
+==== Creating container objects dynamically
+
+Up to this point you have seen how to automatically inject Container Objects in tests.
+Arquillian Cube also allows creating container objects from code.
+In the next example, the original `PingPongTest` has been rewritten to create the Container Object inside the test method.
+
+[source, java]
+.PingPongTest.java
+----
+@RunWith(Arquillian.class)
+public class PingPongTest {
+
+    @ArquillianResource
+    ContainerObjectFactory factory; // <1>
+
+    @ArquillianResource
+    CubeController cubeController;
+
+    @Test
+    public void shouldReturnOkAsPong() throws IOException {
+        PingPongContainer pingPongContainer =
+            factory.createContainer(PingPongContainer.class, null); // <2>
+        try {
+            String pong = ping();
+            assertThat(pong, containsString("OK"));
+            assertThat(pingPongContainer.getConnectionPort(), is(5000));
+        } finally {
+            cubeController.stop("pingpong"); // <3>
+            cubeController.destroy("pingpong");
+        }
+    }
+}
+----
+<1> A `ContainerObjectFactory` instance is injected into the test.
+<2> The injectect factory instance is used to instantiate a container object.
+<3> A `CubeController` could be used to stop the associated docker container.
+
+Although declaring container objects as fields of a test class is preffered, as it offers better control of the lifecycle of the container, creating container objects dynamically allows controlling exactly in which moment in time and in which order the containers are created.
+
 == Arquillian Standalone and Cube
 
 You can use Arquillian Standalone with Arquillian Cube too.
 Arquillian Standalone is a mode of Arquillian which allows you to use Arquillian but without deploying any application.
-Basically it means no `@Deployment` static method and tests runs as client implicitly.
+Basically it means no `@Deployment` static method, and tests runs as client implicitly.
 
 Running Arquillian Cube in Standalone mode means that Arquillian Cube starts all defined containers in the correct order.
-Internally Arquillian Cube registers a `autostartContainers`property (in case you have not registered any) with `regexp:.*` expression.
+Internally Arquillian Cube implicitly defines the `autostartContainers` property (unless you define it), with `regexp:.*` expression, which means all containers will be created/started.
+If you want to avoid this behavior, you can set this property to `[none]`.
+As a result, Arquilian Cube will not auto-start any container and you will be responsible of starting manually each instance (using for example, the CubeController class) by your own.
 
 Dependencies you need to set for Standalone mode are:
 
@@ -255,6 +299,3 @@ Dependencies you need to set for Standalone mode are:
 </dependencies>
 ----
 <1> You need to change `arquillian-junit-container` to `standalone`.
-
-Notice that in case of Standalone mode, Arquillian Cube registers automatically `autostartContainers` property to `regexp:.*`.
-If you want to avoid this, you can set yourself this property to `[none]`. Then Arquilian Cube will not touch anything and you will be the responsible of starting manually each instance using for example CubeController class by your own.


### PR DESCRIPTION
#### Short description of what this resolves:

Allows creating cubes from container objects programmatically

#### Changes proposed in this pull request:

- A new interface injectable inside Arquillian test classes: ```ContainerObjectFactory```
- support for programmatically creating container objects with ```factory.createContainerObject(...)```. Created container objects will work exactly as if they were created by injecting them as fields. Associated Cube instances can also be stopped/destroyed using an injected ```CubeController```

**Fixes**: #564 
