### PR TITLE
Deprecate and stop using redundant method.

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/NamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/NamespaceService.java
@@ -39,6 +39,7 @@ public interface NamespaceService {
     /**
      * Clears all resources from the specified {@link Namespace}/
      */
+    @Deprecated // The method is redundant (since its called always before destroy).
     void clean(String namespace);
 
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionCreatedListener.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionCreatedListener.java
@@ -171,7 +171,6 @@ public class SessionCreatedListener {
         String namespace = session.getNamespace();
 
         if (configuration.isNamespaceCleanupEnabled()) {
-            namespaceService.clean(namespace);
             namespaceService.destroy(namespace);
         } else {
             namespaceService.annotate(session.getNamespace(), annotationProvider.create(session.getId(), status));

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
@@ -66,6 +66,7 @@ public class DefaultNamespaceService implements NamespaceService {
     }
 
     @Override
+    @Deprecated // The method is redundant (since its called always before destroy).
     public void clean(String namespace) {
         KubernetesClient client = this.client.get();
         client.extensions().deployments().inNamespace(namespace).delete();

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/namespace/OpenshiftNamespaceService.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/namespace/OpenshiftNamespaceService.java
@@ -67,6 +67,7 @@ public class OpenshiftNamespaceService extends DefaultNamespaceService {
     }
 
     @Override
+    @Deprecated // The method is redundant (since its called always before destroy).
     public void clean(String namespace) {
         KubernetesClient client = this.client.get();
         if (client.isAdaptable(OpenShiftClient.class)) {


### PR DESCRIPTION
We only use NamespaceService.clean() method only before we destroy a namespace, which is so redundant.
Let's stop using it and deprecate it, before we completely wipe it.