### PR TITLE
Changed tomcat 7 image to use jre8.

### DIFF
--- a/docker/ftest-boot2docker/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest-boot2docker/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:7-jre8
+FROM tomcat:7.0.75-jre8
 
 ENV JAVA_OPTS -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
 ADD tomcat-users.xml conf/

--- a/docker/ftest-boot2docker/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest-boot2docker/src/test/resources/tomcat/Dockerfile
@@ -1,7 +1,6 @@
-FROM tutum/tomcat:7.0
-
+FROM tomcat:7-jre8
 
 ENV JAVA_OPTS -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
-ADD tomcat-users.xml /tomcat/conf/
+ADD tomcat-users.xml conf/
 EXPOSE 8089
-CMD ["/tomcat/bin/catalina.sh","run"]
+CMD ["catalina.sh","run"]

--- a/docker/ftest-docker-compose-v2-git-context/docker-compose.yml
+++ b/docker/ftest-docker-compose-v2-git-context/docker-compose.yml
@@ -1,5 +1,5 @@
 version: '2'
-services:
+services: |
   pingpong:
     build:
       context: https://github.com/lordofthejars/pingpongdockerfile.git

--- a/docker/ftest-docker-compose-v2/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest-docker-compose-v2/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:jre8
+FROM tomcat:7-jre8
 
 ADD tomcat-users.xml conf/
 

--- a/docker/ftest-docker-compose-v2/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest-docker-compose-v2/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:7-jre8
+FROM tomcat:7.0.75-jre8
 
 ADD tomcat-users.xml conf/
 

--- a/docker/ftest-docker-compose/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest-docker-compose/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:jre8
+FROM tomcat:7-jre8
 
 ADD tomcat-users.xml conf/
 

--- a/docker/ftest-docker-compose/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest-docker-compose/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:7-jre8
+FROM tomcat:7.0.75-jre8
 
 ADD tomcat-users.xml conf/
 

--- a/docker/ftest/pom.xml
+++ b/docker/ftest/pom.xml
@@ -99,43 +99,10 @@
 
     <profiles>
         <profile>
-            <id>tomcat-7</id>
+            <id>tomcat-7-jre8-dockerfile</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
             </activation>
-            <properties>
-                <arquillian.launch>tomcat</arquillian.launch>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-remote-7</artifactId>
-                    <version>${version.tomcat}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>tomcat-7-default-ports</id>
-            <activation>
-                <activeByDefault>true</activeByDefault>
-            </activation>
-            <properties>
-                <arquillian.launch>tomcat_default</arquillian.launch>
-            </properties>
-            <dependencies>
-                <dependency>
-                    <groupId>org.jboss.arquillian.container</groupId>
-                    <artifactId>arquillian-tomcat-remote-7</artifactId>
-                    <version>${version.tomcat}</version>
-                    <scope>test</scope>
-                </dependency>
-            </dependencies>
-        </profile>
-
-        <profile>
-            <id>tomcat-7-dockerfile</id>
             <properties>
                 <arquillian.launch>tomcat_dockerfile</arquillian.launch>
             </properties>

--- a/docker/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
+++ b/docker/ftest/src/test/java/org/arquillian/cube/servlet/CubeControllerTest.java
@@ -19,7 +19,6 @@ import org.junit.runner.RunWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.IOException;
 import java.util.List;
 
 import static org.hamcrest.CoreMatchers.is;

--- a/docker/ftest/src/test/resources/arquillian.xml
+++ b/docker/ftest/src/test/resources/arquillian.xml
@@ -11,18 +11,6 @@
         <property name="autoStartContainers">${arquillian.cube.autostart}</property>
         <property name="definitionFormat">CUBE</property>
         <property name="dockerContainers">
-            tomcat_default:
-              image: tutum/tomcat:7.0
-              exposedPorts: [8089/tcp]
-              env: [TOMCAT_PASS=mypass, "CATALINA_OPTS=-Djava.security.egd=file:/dev/./urandom", JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host} -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
-              portBindings: [8089/tcp, "8088", 8081->8080/tcp]
-            tomcat:
-              image: tutum/tomcat:7.0
-              exposedPorts: [8089/tcp]
-              await:
-                strategy: polling
-              env: [TOMCAT_PASS=mypass, "CATALINA_OPTS=-Djava.security.egd=file:/dev/./urandom", JAVA_OPTS=-Djava.rmi.server.hostname=${docker.tomcat.host} -Dcom.sun.management.jmxremote.rmi.port=8088 -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false]
-              portBindings: [8089/tcp, 8088/tcp, 8081->8080/tcp]
             tomcat_dockerfile:
               buildImage:
                 dockerfileLocation: src/test/resources/tomcat
@@ -61,18 +49,6 @@
     </extension>
 
     <container qualifier="tomcat_dockerfile">
-        <configuration>
-            <property name="user">admin</property>
-            <property name="pass">mypass</property>
-        </configuration>
-    </container>
-    <container qualifier="tomcat_default">
-        <configuration>
-            <property name="user">admin</property>
-            <property name="pass">mypass</property>
-        </configuration>
-    </container>
-    <container qualifier="tomcat">
         <configuration>
             <property name="user">admin</property>
             <property name="pass">mypass</property>

--- a/docker/ftest/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:7-jre8
+FROM tomcat:7.0.75-jre8
 
 ENV JAVA_OPTS -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
 ADD tomcat-users.xml conf/

--- a/docker/ftest/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest/src/test/resources/tomcat/Dockerfile
@@ -1,4 +1,4 @@
-FROM tomcat:jre8
+FROM tomcat:7-jre8
 
 ENV JAVA_OPTS -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
 ADD tomcat-users.xml conf/

--- a/docker/ftest/src/test/resources/tomcat/Dockerfile
+++ b/docker/ftest/src/test/resources/tomcat/Dockerfile
@@ -1,7 +1,6 @@
-FROM tutum/tomcat:7.0
-
+FROM tomcat:jre8
 
 ENV JAVA_OPTS -Dcom.sun.management.jmxremote.port=8089 -Dcom.sun.management.jmxremote.ssl=false -Dcom.sun.management.jmxremote.authenticate=false
-ADD tomcat-users.xml /tomcat/conf/
+ADD tomcat-users.xml conf/
 EXPOSE 8089
-CMD ["/tomcat/bin/catalina.sh","run"]
+CMD ["catalina.sh","run"]


### PR DESCRIPTION

#### Short description of what this resolves:
Functional tests are failing when we try to run it  tutum/tomcat:7.0 from docker/ftest.
It is skipping on travis as it needs docker-machine to run. So we couldn't analyse this before.

#### Changes proposed in this pull request:

- Removed all unnecessary tomcat configuration.
- Adds tomcat:jre8 image

@lordofthejars Can you please check docker-machine ftests to execute on your machine?
