### PR TITLE
Allow creating immutable variations of the core kubernetes services, …

### DIFF
--- a/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/annotation/Fabric8AnnotationProvider.java
+++ b/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/annotation/Fabric8AnnotationProvider.java
@@ -4,10 +4,12 @@ import org.arquillian.cube.impl.util.IOUtil;
 import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.impl.util.SystemEnvironmentVariables;
 import org.arquillian.cube.kubernetes.api.AnnotationProvider;
+import org.arquillian.cube.kubernetes.api.LabelProvider;
 import org.arquillian.cube.kubernetes.api.Logger;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.Validate;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -30,119 +32,153 @@ public class Fabric8AnnotationProvider implements AnnotationProvider {
     @ApplicationScoped
     Instance<Logger> logger;
 
+    private AnnotationProvider delegate;
+
+    @Override
+    public AnnotationProvider toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                delegate = new ImmutableFabric8AnnotationProvider(logger.get());
+            }
+        }
+        return delegate;
+    }
+
     @Override
     public Map<String, String> create(String sessionId, String status) {
-        Map<String, String> annotations = new HashMap<>();
-        annotations.put(SESSION_ID, sessionId);
-        annotations.put(TEST_SESSION_STATUS, status);
-
-        File baseDir = getProjectBaseDir();
-        String gitUrl = getGitUrl(baseDir);
-        if (Strings.isNotNullOrEmpty(gitUrl)) {
-            annotations.put(GIT_URL, gitUrl);
-        }
-        annotations.putAll(getPomProperties(baseDir));
-        return annotations;
+        return toImmutable().create(sessionId, status);
     }
 
-    private Map<String, String> getPomProperties(File baseDir) {
-        Map<String, String> annotations = new HashMap<>();
-        // lets see if there's a maven generated set of pom properties
-        File pomProperties = new File(baseDir, "target/maven-archiver/pom.properties");
-        if (pomProperties.isFile()) {
-            try {
-                Properties properties = new Properties();
-                properties.load(new FileInputStream(pomProperties));
-                for (Object o : properties.keySet()) {
-                    String key = String.valueOf(o);
-                    String value = String.valueOf(properties.get(o));
-                    if (Strings.isNotNullOrEmpty(key) && Strings.isNotNullOrEmpty(value)) {
-                        annotations.put(PROJECT_PREFIX + key, value);
-                    }
-                }
-            } catch (IOException e) {
-                logger.get().warn("Failed to load:[ " + pomProperties + "] file to annotate the namespace. Due to: " + e);
+    private static class ImmutableFabric8AnnotationProvider implements AnnotationProvider {
+
+        private final Logger logger;
+
+        private ImmutableFabric8AnnotationProvider(Logger logger) {
+            Validate.notNull(logger, "A Logger instance is required.");
+            this.logger = logger;
+        }
+
+        @Override
+        public Map<String, String> create(String sessionId, String status) {
+            Map<String, String> annotations = new HashMap<>();
+            annotations.put(SESSION_ID, sessionId);
+            annotations.put(TEST_SESSION_STATUS, status);
+
+            File baseDir = getProjectBaseDir();
+            String gitUrl = getGitUrl(baseDir);
+            if (Strings.isNotNullOrEmpty(gitUrl)) {
+                annotations.put(GIT_URL, gitUrl);
             }
-        }
+            annotations.putAll(getPomProperties(baseDir));
             return annotations;
-    }
+        }
 
-    private String getGitUrl(File basedir)  {
-        if (basedir.exists() && basedir.isDirectory()) {
-            File gitConfig = new File(basedir, ".git/config");
-
-            if (gitConfig.isFile() && gitConfig.exists()) {
-
-                try (InputStream is = new FileInputStream(gitConfig)) {
-                    String text = IOUtil.asString(is);
-                    if (text != null) {
-                        return getGitUrl(text);
+        private Map<String, String> getPomProperties(File baseDir) {
+            Map<String, String> annotations = new HashMap<>();
+            // lets see if there's a maven generated set of pom properties
+            File pomProperties = new File(baseDir, "target/maven-archiver/pom.properties");
+            if (pomProperties.isFile()) {
+                try {
+                    Properties properties = new Properties();
+                    properties.load(new FileInputStream(pomProperties));
+                    for (Object o : properties.keySet()) {
+                        String key = String.valueOf(o);
+                        String value = String.valueOf(properties.get(o));
+                        if (Strings.isNotNullOrEmpty(key) && Strings.isNotNullOrEmpty(value)) {
+                            annotations.put(PROJECT_PREFIX + key, value);
+                        }
                     }
                 } catch (IOException e) {
-                    logger.get().warn("Failed to read:[ " + gitConfig + "] file to annotate the namespace. Due to: " + e);
+                    logger.warn("Failed to load:[ " + pomProperties + "] file to annotate the namespace. Due to: " + e);
                 }
             }
+            return annotations;
         }
-        File parentFile = basedir.getParentFile();
-        if (parentFile != null) {
-            return getGitUrl(parentFile);
-        }
-        return null;
-    }
 
-    private static File getProjectBaseDir() {
-        String basedir = SystemEnvironmentVariables.getPropertyVariable("basedir", ".");
-        return new File(basedir);
-    }
+        private String getGitUrl(File basedir)  {
+            if (basedir.exists() && basedir.isDirectory()) {
+                File gitConfig = new File(basedir, ".git/config");
 
-    private static String getGitUrl(String configText) {
-        String remote = null;
-        String lastUrl = null;
-        String firstUrl = null;
-        BufferedReader reader = new BufferedReader(new StringReader(configText));
-        Map<String, String> remoteUrls = new HashMap<>();
-        while (true) {
-            String line = null;
-            try {
-                line = reader.readLine();
-            } catch (IOException e) {
-                // ignore should never happen!
-            }
-            if (line == null) {
-                break;
-            }
-            if (line.startsWith("[remote ")) {
-                String[] parts = line.split("\"");
-                if (parts.length > 1) {
-                    remote = parts[1];
-                }
-            } else if (line.startsWith("[")) {
-                remote = null;
-            } else if (remote != null && line.length() > 0 && Character.isWhitespace(line.charAt(0))) {
-                String trimmed = line.trim();
-                if (trimmed.startsWith("url ")) {
-                    String[] parts = trimmed.split("=", 2);
-                    if (parts.length > 1) {
-                        lastUrl = parts[1].trim();
-                        if (firstUrl == null) {
-                            firstUrl = lastUrl;
+                if (gitConfig.isFile() && gitConfig.exists()) {
+
+                    try (InputStream is = new FileInputStream(gitConfig)) {
+                        String text = IOUtil.asString(is);
+                        if (text != null) {
+                            return getGitUrl(text);
                         }
-                        remoteUrls.put(remote, lastUrl);
+                    } catch (IOException e) {
+                        logger.warn("Failed to read:[ " + gitConfig + "] file to annotate the namespace. Due to: " + e);
                     }
                 }
+            }
+            File parentFile = basedir.getParentFile();
+            if (parentFile != null) {
+                return getGitUrl(parentFile);
+            }
+            return null;
+        }
 
-            }
+        private static File getProjectBaseDir() {
+            String basedir = SystemEnvironmentVariables.getPropertyVariable("basedir", ".");
+            return new File(basedir);
         }
-        String answer = null;
-        if (remoteUrls.size() == 1) {
-            return lastUrl;
-        } else if (remoteUrls.size() > 1) {
-            answer = remoteUrls.get("origin");
-            if (answer == null) {
-                answer = firstUrl;
+
+        private static String getGitUrl(String configText) {
+            String remote = null;
+            String lastUrl = null;
+            String firstUrl = null;
+            BufferedReader reader = new BufferedReader(new StringReader(configText));
+            Map<String, String> remoteUrls = new HashMap<>();
+            while (true) {
+                String line = null;
+                try {
+                    line = reader.readLine();
+                } catch (IOException e) {
+                    // ignore should never happen!
+                }
+                if (line == null) {
+                    break;
+                }
+                if (line.startsWith("[remote ")) {
+                    String[] parts = line.split("\"");
+                    if (parts.length > 1) {
+                        remote = parts[1];
+                    }
+                } else if (line.startsWith("[")) {
+                    remote = null;
+                } else if (remote != null && line.length() > 0 && Character.isWhitespace(line.charAt(0))) {
+                    String trimmed = line.trim();
+                    if (trimmed.startsWith("url ")) {
+                        String[] parts = trimmed.split("=", 2);
+                        if (parts.length > 1) {
+                            lastUrl = parts[1].trim();
+                            if (firstUrl == null) {
+                                firstUrl = lastUrl;
+                            }
+                            remoteUrls.put(remote, lastUrl);
+                        }
+                    }
+
+                }
             }
+            String answer = null;
+            if (remoteUrls.size() == 1) {
+                return lastUrl;
+            } else if (remoteUrls.size() > 1) {
+                answer = remoteUrls.get("origin");
+                if (answer == null) {
+                    answer = firstUrl;
+                }
+            }
+            return answer;
         }
-        return answer;
+
+        @Override
+        public AnnotationProvider toImmutable() {
+            return this;
+        }
     }
-
 }

--- a/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/label/Fabric8LabelProvider.java
+++ b/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/label/Fabric8LabelProvider.java
@@ -1,17 +1,12 @@
 package org.arquillian.cube.kubernetes.fabric8.impl.label;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
-import org.arquillian.cube.impl.util.IOUtil;
+
 import org.arquillian.cube.kubernetes.api.LabelProvider;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.Validate;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.FileInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.io.StringReader;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -20,13 +15,48 @@ public class Fabric8LabelProvider implements LabelProvider {
     @Inject
     Instance<KubernetesClient> client;
 
+    LabelProvider delegate;
+
     @Override
     public Map<String, String> getLabels() {
-        Map<String, String> labels = new HashMap<String, String>();
-        labels.put("project", client.get().getNamespace());
-        labels.put("framework", "arquillian");
-        labels.put("provider", "fabric8");
-        labels.put("component", "integrationTest");
-        return labels;
+       return toImmutable().getLabels();
+    }
+
+    @Override
+    public LabelProvider toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized(this) {
+            if (delegate == null) {
+                delegate = new ImmutableFabric8LabelProvider(client.get());
+            }
+        }
+        return delegate;
+    }
+
+    private static class ImmutableFabric8LabelProvider implements LabelProvider {
+
+        private final KubernetesClient client;
+
+        private ImmutableFabric8LabelProvider(KubernetesClient client) {
+            Validate.notNull(client, "A KubernetesClient instance is required.");
+            this.client = client;
+        }
+
+        @Override
+        public Map<String, String> getLabels() {
+            Map<String, String> labels = new HashMap<String, String>();
+            labels.put("project", client.getNamespace());
+            labels.put("framework", "arquillian");
+            labels.put("provider", "fabric8");
+            labels.put("component", "integrationTest");
+            return labels;
+        }
+
+        @Override
+        public LabelProvider toImmutable() {
+            return this;
+        }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/AnnotationProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/AnnotationProvider.java
@@ -2,7 +2,7 @@ package org.arquillian.cube.kubernetes.api;
 
 import java.util.Map;
 
-public interface AnnotationProvider {
+public interface AnnotationProvider extends WithToImmutable<AnnotationProvider> {
     String SESSION_ID = "arquillian.org/test-session-id";
     String TEST_SESSION_STATUS = "arquillian.org/test-session-status";
     String TEST_CASE_STATUS_FORMAT = "fabric8.io/test-status-%s";

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/DependencyResolver.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/DependencyResolver.java
@@ -4,7 +4,7 @@ import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 
-public interface DependencyResolver {
+public interface DependencyResolver extends WithToImmutable<DependencyResolver> {
 
     /**
      * Resolves dependencies to additional kubernetes resources.

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/KubernetesResourceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/KubernetesResourceLocator.java
@@ -2,7 +2,7 @@ package org.arquillian.cube.kubernetes.api;
 
 import java.net.URL;
 
-public interface KubernetesResourceLocator {
+public interface KubernetesResourceLocator extends WithToImmutable<KubernetesResourceLocator> {
 
     /**
      * Locates the kubernetes resource.

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/LabelProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/LabelProvider.java
@@ -2,7 +2,7 @@ package org.arquillian.cube.kubernetes.api;
 
 import java.util.Map;
 
-public interface LabelProvider {
+public interface LabelProvider extends WithToImmutable<LabelProvider> {
 
     Map<String, String> getLabels();
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Logger.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Logger.java
@@ -1,6 +1,6 @@
 package org.arquillian.cube.kubernetes.api;
 
-public interface Logger {
+public interface Logger extends WithToImmutable<Logger> {
 
     void info(String msg);
     void warn(String msg);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/NamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/NamespaceService.java
@@ -4,7 +4,7 @@ import io.fabric8.kubernetes.api.model.Namespace;
 
 import java.util.Map;
 
-public interface NamespaceService {
+public interface NamespaceService extends WithToImmutable<NamespaceService> {
 
     /**
      * Creates a {@link Namespace} with the specified name.

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/SessionCreatedListener.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/SessionCreatedListener.java
@@ -1,0 +1,9 @@
+package org.arquillian.cube.kubernetes.api;
+
+public interface SessionCreatedListener {
+
+    void start();
+    void stop();
+    void clean(String status);
+    void display();
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/WithToImmutable.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/WithToImmutable.java
@@ -1,0 +1,6 @@
+package org.arquillian.cube.kubernetes.api;
+
+public interface WithToImmutable<T> {
+
+    T toImmutable();
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesExtension.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesExtension.java
@@ -68,7 +68,7 @@ public class KubernetesExtension implements LoadableExtension {
                 .observer(getClientCreator())
                 .observer(SuiteListener.class)
                 .observer(TestListener.class)
-                .observer(SessionCreatedListener.class);
+                .observer(SessionManagerLifecycle.class);
 
         builder.service(NamespaceService.class, DefaultNamespaceService.class)
                 .service(LabelProvider.class, DefaultLabelProvider.class)

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManagerLifecycle.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManagerLifecycle.java
@@ -1,0 +1,74 @@
+package org.arquillian.cube.kubernetes.impl;
+
+import org.arquillian.cube.kubernetes.api.AnnotationProvider;
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.DependencyResolver;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
+import org.arquillian.cube.kubernetes.api.NamespaceService;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.impl.event.AfterStart;
+import org.arquillian.cube.kubernetes.impl.event.Start;
+import org.arquillian.cube.kubernetes.impl.event.Stop;
+import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+
+import io.fabric8.kubernetes.api.builder.Visitor;
+import io.fabric8.kubernetes.client.KubernetesClient;
+
+public class SessionManagerLifecycle {
+
+    @Inject
+    Instance<KubernetesClient> kubernetesClient;
+
+    @Inject
+    Instance<Configuration> configuration;
+
+    @Inject
+    Instance<AnnotationProvider> annotationProvider;
+
+    @Inject
+    Instance<NamespaceService> namespaceService;
+
+    @Inject
+    Instance<KubernetesResourceLocator> kubernetesResourceLocator;
+
+    @Inject
+    Instance<DependencyResolver> dependencyResolver;
+
+    @Inject
+    Instance<ServiceLoader> serviceLoader;
+
+    @Inject
+    Event<AfterStart> afterStartEvent;
+
+    AtomicReference<SessionManager> sessionManagerRef = new AtomicReference<>();
+
+    public void start(final @Observes Start event) throws Exception {
+        List<Visitor> visitors = new ArrayList<>(serviceLoader.get().all(Visitor.class));
+
+        Session session = event.getSession();
+        SessionManager sessionManager = new SessionManager(session, kubernetesClient.get(), configuration.get(),
+                annotationProvider.get(),
+                namespaceService.get().toImmutable(),
+                kubernetesResourceLocator.get().toImmutable(),
+                dependencyResolver.get().toImmutable(), visitors);
+
+        sessionManagerRef.set(sessionManager);
+        sessionManager.start();
+        afterStartEvent.fire(new AfterStart(session));
+    }
+
+    public void stop(@Observes Stop event, Configuration configuration) throws Exception {
+        SessionManager sessionManager = sessionManagerRef.get();
+        if (sessionManager != null) {
+            sessionManager.stop();
+        }
+    }
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/annotation/DefaultAnnotationProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/annotation/DefaultAnnotationProvider.java
@@ -10,12 +10,16 @@ public class DefaultAnnotationProvider implements AnnotationProvider {
     public static final String SESSION_ID = "arquillian.org/test-session-id";
     public static final String TEST_SESSION_STATUS = "arquillian.org/test-session-status";
 
-
     @Override
     public Map<String, String> create(String sessionId, String status) {
         Map<String, String> annotations = new HashMap<>();
         annotations.put(SESSION_ID, sessionId);
         annotations.put(TEST_SESSION_STATUS, status);
         return annotations;
+    }
+
+    @Override
+    public AnnotationProvider toImmutable() {
+        return this;
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/label/DefaultLabelProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/label/DefaultLabelProvider.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.api.LabelProvider;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.Validate;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -13,12 +14,46 @@ public class DefaultLabelProvider implements LabelProvider {
     @Inject
     Instance<KubernetesClient> client;
 
+    private LabelProvider delegate;
+
     @Override
     public Map<String, String> getLabels() {
-        Map<String, String> labels = new HashMap<String, String>();
-        labels.put("project", client.get().getNamespace());
-        labels.put("framework", "arquillian");
-        labels.put("component", "integrationTest");
-        return labels;
+        return delegate.getLabels();
+    }
+
+    @Override
+    public LabelProvider toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                delegate = new ImmutableLabelProvider(client.get());
+            }
+        }
+        return delegate;
+    }
+
+    private static class ImmutableLabelProvider implements LabelProvider {
+
+        private final KubernetesClient client;
+
+        private ImmutableLabelProvider(KubernetesClient client) {
+            Validate.notNull(client, "A KubernetesClient instance is required.");
+            this.client = client;
+        }
+        @Override
+        public Map<String, String> getLabels() {
+            Map<String, String> labels = new HashMap<String, String>();
+            labels.put("project", client.getNamespace());
+            labels.put("framework", "arquillian");
+            labels.put("component", "integrationTest");
+            return labels;
+        }
+
+        @Override
+        public LabelProvider toImmutable() {
+            return this;
+        }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResouceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResouceLocator.java
@@ -26,4 +26,9 @@ public class DefaultKubernetesResouceLocator implements KubernetesResourceLocato
     URL getResource(String resource) {
         return KubernetesResourceLocator.class.getResource(resource.startsWith(ROOT) ? resource : ROOT + resource);
     }
+
+    @Override
+    public KubernetesResourceLocator toImmutable() {
+        return this;
+    }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/log/AnsiLogger.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/log/AnsiLogger.java
@@ -29,4 +29,8 @@ public class AnsiLogger implements Logger {
         System.out.println(ansi().fg(GREEN).a(msg).reset());
     }
 
+    @Override
+    public Logger toImmutable() {
+        return this;
+    }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/log/SimpleLogger.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/log/SimpleLogger.java
@@ -23,4 +23,8 @@ public class SimpleLogger implements Logger {
         System.out.println(msg);
     }
 
+    @Override
+    public Logger toImmutable() {
+        return this;
+    }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
@@ -2,26 +2,27 @@ package org.arquillian.cube.kubernetes.impl.namespace;
 
 import io.fabric8.kubernetes.api.model.Namespace;
 import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClientException;
+
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.LabelProvider;
 import org.arquillian.cube.kubernetes.api.Logger;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
+import org.arquillian.cube.kubernetes.api.WithToImmutable;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.spi.Validate;
 
 import java.io.IOException;
 import java.util.Map;
 
 public class DefaultNamespaceService implements NamespaceService {
 
-    private static final String PROJECT_LABEL = "project";
-    private static final String FRAMEWORK_LABEL = "framework";
-    private static final String COMPONENT_LABEL = "component";
+    protected static final String PROJECT_LABEL = "project";
+    protected static final String FRAMEWORK_LABEL = "framework";
+    protected static final String COMPONENT_LABEL = "component";
 
-    private static final String ARQUILLIAN_FRAMEWORK = "arquillian";
-    private static final String ITEST_COMPONENT = "integrationTest";
-
+    protected static final String ARQUILLIAN_FRAMEWORK = "arquillian";
+    protected static final String ITEST_COMPONENT = "integrationTest";
 
     @Inject
     protected Instance<KubernetesClient> client;
@@ -35,94 +36,166 @@ public class DefaultNamespaceService implements NamespaceService {
     @Inject
     protected Instance<Configuration> configuration;
 
+    protected NamespaceService delegate;
+
+    @Override
+    public NamespaceService toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                delegate = new ImmutableNamespaceService(client.get(), configuration.get(),
+                        labelProvider.get().toImmutable(),
+                        logger.get().toImmutable());
+            }
+        }
+        return delegate;
+    }
+
     @Override
     public Namespace create(String namespace) {
-        return client.get().namespaces().createNew().withNewMetadata()
-                .withName(namespace)
-                .addToLabels(labelProvider.get().getLabels())
-                .addToLabels(PROJECT_LABEL, client.get().getNamespace())
-                .addToLabels(FRAMEWORK_LABEL, ARQUILLIAN_FRAMEWORK)
-                .addToLabels(COMPONENT_LABEL, ITEST_COMPONENT)
-                .endMetadata()
-                .done();
+        return toImmutable().create(namespace);
     }
 
     @Override
     public Namespace annotate(String namespace, Map<String, String> annotations) {
-        return client.get().namespaces().withName(namespace).edit()
-                .editMetadata()
-                .addToAnnotations(annotations)
-                .endMetadata().done();
+        return toImmutable().annotate(namespace, annotations);
     }
 
     @Override
     public Boolean delete(String namespace) {
-        return client.get().namespaces().withName(namespace).delete();
+        return toImmutable().delete(namespace);
     }
 
     @Override
     public Boolean exists(String namespace) {
-        return client.get().namespaces().withName(namespace).get() != null;
+        return toImmutable().exists(namespace);
     }
 
     @Override
     @Deprecated // The method is redundant (since its called always before destroy).
     public void clean(String namespace) {
-        KubernetesClient client = this.client.get();
-        client.extensions().deployments().inNamespace(namespace).delete();
-        client.extensions().replicaSets().inNamespace(namespace).delete();
-        client.replicationControllers().inNamespace(namespace).delete();
-        client.pods().inNamespace(namespace).delete();
-        client.extensions().ingresses().inNamespace(namespace).delete();
-        client.services().inNamespace(namespace).delete();
-        client.securityContextConstraints().withName(namespace).delete();
+        toImmutable().clean(namespace);
     }
 
 
     public void destroy(String namespace) {
-        Logger logger = this.logger.get();
-        Configuration configuration = this.configuration.get();
-        try {
-            if (configuration.isNamespaceCleanupConfirmationEnabled()) {
-                showErrors();
-                logger.info("");
-                logger.info("Waiting to destroy the namespace.");
-                logger.info("Please type: [Q] to terminate the namespace.");
+        toImmutable().destroy(namespace);
+    }
 
-                while (true) {
-                    try {
-                        int ch = System.in.read();
-                        if (ch < 0 || ch == 'Q') {
-                            logger.info("Stopping...");
-                            break;
-                        } else {
-                            logger.info("Found character: " + Character.toString((char) ch));
-                        }
-                    } catch (IOException e) {
-                        logger.warn("Failed to read from input. " + e);
-                        break;
-                    }
-                }
-            } else {
-                long timeout = configuration.getNamespaceCleanupTimeout();
-                if (timeout > 0L) {
+    public static class ImmutableNamespaceService implements NamespaceService, WithToImmutable<NamespaceService> {
+
+        protected final KubernetesClient client;
+        protected final LabelProvider labelProvider;
+        protected final Logger logger;
+        protected final Configuration configuration;
+
+        public ImmutableNamespaceService(KubernetesClient client, Configuration configuration, LabelProvider labelProvider, Logger logger) {
+            Validate.notNull(client, "A KubernetesClient instance is required.");
+            Validate.notNull(labelProvider, "A LabelProvider  instance is required.");
+            Validate.notNull(logger, "A Logger instance is required.");
+            Validate.notNull(configuration, "Configuration is required.");
+            this.client = client;
+            this.configuration = configuration;
+            this.labelProvider = labelProvider;
+            this.logger = logger;
+        }
+
+        @Override
+        public Namespace create(String namespace) {
+            return client.namespaces().createNew().withNewMetadata()
+                    .withName(namespace)
+                    .addToLabels(labelProvider.getLabels())
+                    .addToLabels(PROJECT_LABEL, client.getNamespace())
+                    .addToLabels(FRAMEWORK_LABEL, ARQUILLIAN_FRAMEWORK)
+                    .addToLabels(COMPONENT_LABEL, ITEST_COMPONENT)
+                    .endMetadata()
+                    .done();
+        }
+
+        @Override
+        public Namespace annotate(String namespace, Map<String, String> annotations) {
+            return client.namespaces().withName(namespace).edit()
+                    .editMetadata()
+                    .addToAnnotations(annotations)
+                    .endMetadata().done();
+        }
+
+        @Override
+        public Boolean delete(String namespace) {
+            return client.namespaces().withName(namespace).delete();
+        }
+
+        @Override
+        public Boolean exists(String namespace) {
+            return client.namespaces().withName(namespace).get() != null;
+        }
+
+        @Override
+        @Deprecated // The method is redundant (since its called always before destroy).
+        public void clean(String namespace) {
+            KubernetesClient client = this.client;
+            client.extensions().deployments().inNamespace(namespace).delete();
+            client.extensions().replicaSets().inNamespace(namespace).delete();
+            client.replicationControllers().inNamespace(namespace).delete();
+            client.pods().inNamespace(namespace).delete();
+            client.extensions().ingresses().inNamespace(namespace).delete();
+            client.services().inNamespace(namespace).delete();
+            client.securityContextConstraints().withName(namespace).delete();
+        }
+
+
+        public void destroy(String namespace) {
+            Logger logger = this.logger;
+            Configuration configuration = this.configuration;
+            try {
+                if (configuration.isNamespaceCleanupConfirmationEnabled()) {
                     showErrors();
                     logger.info("");
-                    logger.info("Sleeping for " + timeout + " seconds until destroying the namespace");
-                    try {
-                        Thread.sleep(timeout * 1000);
-                    } catch (InterruptedException e) {
-                        logger.info("Interupted sleeping to GC the namespace: " + e);
+                    logger.info("Waiting to destroy the namespace.");
+                    logger.info("Please type: [Q] to terminate the namespace.");
+
+                    while (true) {
+                        try {
+                            int ch = System.in.read();
+                            if (ch < 0 || ch == 'Q') {
+                                logger.info("Stopping...");
+                                break;
+                            } else {
+                                logger.info("Found character: " + Character.toString((char) ch));
+                            }
+                        } catch (IOException e) {
+                            logger.warn("Failed to read from input. " + e);
+                            break;
+                        }
+                    }
+                } else {
+                    long timeout = configuration.getNamespaceCleanupTimeout();
+                    if (timeout > 0L) {
+                        showErrors();
+                        logger.info("");
+                        logger.info("Sleeping for " + timeout + " seconds until destroying the namespace");
+                        try {
+                            Thread.sleep(timeout * 1000);
+                        } catch (InterruptedException e) {
+                            logger.info("Interupted sleeping to GC the namespace: " + e);
+                        }
                     }
                 }
+            } finally {
+                delete(namespace);
             }
-        } finally {
-            delete(namespace);
+        }
+
+
+        private void showErrors() {
+        }
+
+
+        @Override
+        public NamespaceService toImmutable() {
+            return this;
         }
     }
-
-
-    private void showErrors() {
-    }
-
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/resolve/ShrinkwrapResolver.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/resolve/ShrinkwrapResolver.java
@@ -81,4 +81,9 @@ public class ShrinkwrapResolver implements DependencyResolver {
         }
         return false;
     }
+
+    @Override
+    public DependencyResolver toImmutable() {
+        return this;
+    }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -1,6 +1,8 @@
 package org.arquillian.cube.openshift.impl;
 
+import org.arquillian.cube.impl.client.enricher.StandaloneCubeUrlResourceProvider;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
+import org.arquillian.cube.kubernetes.impl.enricher.UrlResourceProvider;
 import org.arquillian.cube.kubernetes.impl.namespace.DefaultNamespaceService;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfigurator;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftRegistrar;
@@ -24,7 +26,8 @@ public class CubeOpenshiftExtension implements LoadableExtension {
                 .service(ResourceProvider.class, DeploymentConfigResourceProvider.class)
                 .service(ResourceProvider.class, DeploymentConfigListResourceProvider.class)
 
-               .override(NamespaceService.class, DefaultNamespaceService.class, OpenshiftNamespaceService.class);
+                .override(ResourceProvider.class, StandaloneCubeUrlResourceProvider.class, UrlResourceProvider.class)
+                .override(NamespaceService.class, DefaultNamespaceService.class, OpenshiftNamespaceService.class);
     }
 
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/namespace/OpenshiftNamespaceService.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/namespace/OpenshiftNamespaceService.java
@@ -1,5 +1,9 @@
 package org.arquillian.cube.openshift.impl.namespace;
 
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.LabelProvider;
+import org.arquillian.cube.kubernetes.api.Logger;
+import org.arquillian.cube.kubernetes.api.NamespaceService;
 import org.arquillian.cube.kubernetes.impl.namespace.DefaultNamespaceService;
 
 import io.fabric8.kubernetes.api.model.Namespace;
@@ -11,70 +15,85 @@ import io.fabric8.openshift.client.OpenShiftClient;
 
 public class OpenshiftNamespaceService extends DefaultNamespaceService {
 
-    private static final String PROJECT_LABEL = "project";
-    private static final String FRAMEWORK_LABEL = "framework";
-    private static final String COMPONENT_LABEL = "component";
-
-    private static final String ARQUILLIAN_FRAMEWORK = "arquillian";
-    private static final String ITEST_COMPONENT = "integrationTest";
-
     @Override
-    public Namespace create(String namespace) {
-        KubernetesClient client = this.client.get();
-        if (client.isAdaptable(OpenShiftClient.class)) {
-            OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
-            ProjectRequest projectRequest = new ProjectRequestBuilder()
-                    .withNewMetadata()
-                    .withName(namespace)
-                    .addToLabels(labelProvider.get().getLabels())
-                    .addToLabels(PROJECT_LABEL, client.getNamespace())
-                    .addToLabels(FRAMEWORK_LABEL, ARQUILLIAN_FRAMEWORK)
-                    .addToLabels(COMPONENT_LABEL, ITEST_COMPONENT)
-                    .endMetadata()
-                    .build();
-
-            ProjectRequest request = openShiftClient.projectrequests().create(projectRequest);
-            return openShiftClient.namespaces().withName(request.getMetadata().getName()).get();
-        } else {
-            return super.create(namespace);
+    public NamespaceService toImmutable() {
+        if (delegate != null) {
+            return delegate;
         }
-    }
-
-    @Override
-    public Boolean delete(String namespace) {
-        KubernetesClient client = this.client.get();
-        if (client.isAdaptable(OpenShiftClient.class)) {
-            OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
-            return openShiftClient.projects().withName(namespace).delete();
-        } else {
-            return super.delete(namespace);
-        }
-    }
-
-    @Override
-    public Boolean exists(String namespace) {
-        KubernetesClient client = this.client.get();
-        if (client.isAdaptable(OpenShiftClient.class)) {
-            OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
-            try {
-                return openShiftClient.projects().withName(namespace).get() != null;
-            } catch (KubernetesClientException e) {
-                return false;
+        synchronized(this) {
+            if (delegate == null) {
+                delegate = new ImmutableOpenshiftNamespaceService(client.get(),
+                        configuration.get(),
+                        labelProvider.get().toImmutable(),
+                        logger.get().toImmutable()
+                );
             }
-        } else {
-            return super.exists(namespace);
         }
+        return delegate;
     }
 
-    @Override
-    @Deprecated // The method is redundant (since its called always before destroy).
-    public void clean(String namespace) {
-        KubernetesClient client = this.client.get();
-        if (client.isAdaptable(OpenShiftClient.class)) {
-            OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
-            openShiftClient.deploymentConfigs().inNamespace(namespace).delete();
+    public static class ImmutableOpenshiftNamespaceService extends DefaultNamespaceService.ImmutableNamespaceService {
+
+
+        public ImmutableOpenshiftNamespaceService(KubernetesClient client, Configuration configuration, LabelProvider labelProvider, Logger logger) {
+            super(client, configuration, labelProvider, logger);
         }
 
-        super.clean(namespace);
+
+        @Override
+        public Namespace create(String namespace) {
+            if (client.isAdaptable(OpenShiftClient.class)) {
+                OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
+                ProjectRequest projectRequest = new ProjectRequestBuilder()
+                        .withNewMetadata()
+                        .withName(namespace)
+                        .addToLabels(labelProvider.getLabels())
+                        .addToLabels(PROJECT_LABEL, client.getNamespace())
+                        .addToLabels(FRAMEWORK_LABEL, ARQUILLIAN_FRAMEWORK)
+                        .addToLabels(COMPONENT_LABEL, ITEST_COMPONENT)
+                        .endMetadata()
+                        .build();
+
+                ProjectRequest request = openShiftClient.projectrequests().create(projectRequest);
+                return openShiftClient.namespaces().withName(request.getMetadata().getName()).get();
+            } else {
+                return super.create(namespace);
+            }
+        }
+
+        @Override
+        public Boolean delete(String namespace) {
+            if (client.isAdaptable(OpenShiftClient.class)) {
+                OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
+                return openShiftClient.projects().withName(namespace).delete();
+            } else {
+                return super.delete(namespace);
+            }
+        }
+
+        @Override
+        public Boolean exists(String namespace) {
+            if (client.isAdaptable(OpenShiftClient.class)) {
+                OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
+                try {
+                    return openShiftClient.projects().withName(namespace).get() != null;
+                } catch (KubernetesClientException e) {
+                    return false;
+                }
+            } else {
+                return super.exists(namespace);
+            }
+        }
+
+        @Override
+        @Deprecated // The method is redundant (since its called always before destroy).
+        public void clean(String namespace) {
+            if (client.isAdaptable(OpenShiftClient.class)) {
+                OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
+                openShiftClient.deploymentConfigs().inNamespace(namespace).delete();
+            }
+
+            super.clean(namespace);
+        }
     }
 }


### PR DESCRIPTION
The kubernetes extension, is creating a shutdown hook, that it performs cleanup if the test is aborted.

This does not play nicely, mostly because all `Instance.get()` return null, during the shutdown hook _(like the DI framework is unavailable)_.

The only possible solution is to create and use immutable variations of the services that are DI free.

This pull request does exactly this.