### PR TITLE
[ISSUE #392] Fixed: Using star operator with @HostPort and @DockerUrl

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/model/CubeId.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/CubeId.java
@@ -1,0 +1,9 @@
+package org.arquillian.cube.impl.model;
+
+public interface CubeId {
+
+    String getId();
+
+    boolean isMatching(CubeId other);
+
+}

--- a/core/src/main/java/org/arquillian/cube/impl/model/CubeIdFactory.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/CubeIdFactory.java
@@ -1,0 +1,26 @@
+package org.arquillian.cube.impl.model;
+
+import java.util.Objects;
+
+public class CubeIdFactory {
+    private static final CubeIdFactory INSTANCE = new CubeIdFactory();
+
+    public static CubeIdFactory get() {
+        return INSTANCE;
+    }
+
+    public CubeId create(String id) {
+        Objects.requireNonNull(id, "Id must not be null.");
+        final CubeId cubeId;
+
+        if (id.matches(StarredCubeId.PATTERN)) {
+            cubeId = new StarredCubeId(id);
+        } else if (id.matches(ParallelizedCubeId.PATTERN)) {
+            cubeId = new ParallelizedCubeId(id);
+        } else {
+            cubeId = new DefaultCubeId(id);
+        }
+
+        return cubeId;
+    }
+}

--- a/core/src/main/java/org/arquillian/cube/impl/model/DefaultCubeId.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/DefaultCubeId.java
@@ -1,0 +1,44 @@
+package org.arquillian.cube.impl.model;
+
+public class DefaultCubeId implements CubeId {
+
+    private final String id;
+
+    public DefaultCubeId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isMatching(CubeId other) {
+        return equals(other);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        DefaultCubeId that = (DefaultCubeId) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "DefaultCubeId{id='" + id + "'}";
+    }
+}

--- a/core/src/main/java/org/arquillian/cube/impl/model/ParallelizedCubeId.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/ParallelizedCubeId.java
@@ -1,0 +1,56 @@
+package org.arquillian.cube.impl.model;
+
+public class ParallelizedCubeId implements CubeId {
+    static final String PATTERN = "^(.*?)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$";
+
+    private final String id;
+
+    public ParallelizedCubeId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isMatching(CubeId other) {
+        if (other instanceof ParallelizedCubeId) {
+            return equals(other);
+        }
+
+        if (other instanceof StarredCubeId) {
+            String otherId = other.getId();
+            String otherStarlessId = otherId.substring(0, otherId.length() - 1);
+            String uuidLessId = id.substring(0, id.lastIndexOf('_'));
+            return uuidLessId.equals(otherStarlessId);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ParallelizedCubeId that = (ParallelizedCubeId) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "ParallelizedCubeId{id='" + id + "'}";
+    }
+}

--- a/core/src/main/java/org/arquillian/cube/impl/model/StarredCubeId.java
+++ b/core/src/main/java/org/arquillian/cube/impl/model/StarredCubeId.java
@@ -1,0 +1,55 @@
+package org.arquillian.cube.impl.model;
+
+public class StarredCubeId implements CubeId {
+    static final String PATTERN = "^(.*?)\\*$";
+
+    private final String id;
+
+    public StarredCubeId(String id) {
+        this.id = id;
+    }
+
+    @Override
+    public String getId() {
+        return id;
+    }
+
+    @Override
+    public boolean isMatching(CubeId other) {
+        if (other instanceof StarredCubeId) {
+            return equals(other);
+        }
+
+        if (other instanceof ParallelizedCubeId) {
+            String otherId = other.getId();
+            String starlessId = id.substring(0, id.length() - 1);
+            return otherId.startsWith(starlessId);
+        }
+
+        return false;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        StarredCubeId that = (StarredCubeId) o;
+
+        return id.equals(that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return id.hashCode();
+    }
+
+    @Override
+    public String toString() {
+        return "StarredCubeId{id='" + id + "'}";
+    }
+}

--- a/core/src/test/java/org/arquillian/cube/impl/model/CubeIdFactoryTest.java
+++ b/core/src/test/java/org/arquillian/cube/impl/model/CubeIdFactoryTest.java
@@ -1,0 +1,33 @@
+package org.arquillian.cube.impl.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class CubeIdFactoryTest {
+
+    @Test(expected = NullPointerException.class)
+    public void shouldThrowNPEOnNull() throws Exception {
+        CubeIdFactory.get().create(null);
+    }
+
+    @Test
+    public void shouldCreateStarredCubeId() throws Exception {
+        CubeId cubeId = CubeIdFactory.get().create("tomcat*");
+
+        Assert.assertTrue(cubeId instanceof StarredCubeId);
+    }
+
+    @Test
+    public void shouldCreateParallelizedCubeId() throws Exception {
+        CubeId cubeId = CubeIdFactory.get().create("tomcat_46fd2cc1-0084-42a8-9ffd-35f305a08dcc");
+
+        Assert.assertTrue(cubeId instanceof ParallelizedCubeId);
+    }
+
+    @Test
+    public void shouldCreateDefaultCubeId() throws Exception {
+        CubeId cubeId = CubeIdFactory.get().create("tomcat");
+
+        Assert.assertTrue(cubeId instanceof DefaultCubeId);
+    }
+}

--- a/core/src/test/java/org/arquillian/cube/impl/model/LocalCubeRegistryTest.java
+++ b/core/src/test/java/org/arquillian/cube/impl/model/LocalCubeRegistryTest.java
@@ -1,0 +1,100 @@
+package org.arquillian.cube.impl.model;
+
+import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class LocalCubeRegistryTest {
+
+    private CubeRegistry cubeRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        cubeRegistry = new LocalCubeRegistry();
+    }
+
+    @Test
+    public void shouldAddAndRemoveCube() throws Exception {
+        // given:
+        String cubeId = "tomcat";
+        Cube cube = createCubeMock(cubeId);
+
+        // when:
+        cubeRegistry.addCube(cube);
+
+        // then:
+        Cube<?> resolvedCube = cubeRegistry.getCube(cubeId);
+        Assert.assertSame(cube, resolvedCube);
+
+        // when:
+        cubeRegistry.removeCube(cubeId);
+
+        // then:
+        Cube<?> resolvedCubeAfterRemove = cubeRegistry.getCube(cubeId);
+        Assert.assertNull(resolvedCubeAfterRemove);
+    }
+
+    private Cube createCubeMock(String cubeId) {
+        Cube cube = Mockito.mock(Cube.class);
+        Mockito.doReturn(cubeId).when(cube).getId();
+
+        return cube;
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotBeAbleToAddCubeByStarredCubeId() throws Exception {
+        // given:
+        String cubeId = "tomcat*";
+        Cube cube = createCubeMock(cubeId);
+
+        // when:
+        cubeRegistry.addCube(cube);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void shouldNotBeAbleToRemoveCubeByStarredCubeId() throws Exception {
+        // given:
+        String cubeId = "tomcat*";
+
+        // when:
+        cubeRegistry.removeCube(cubeId);
+    }
+
+    @Test
+    public void shouldGetAllCubes() throws Exception {
+        // given:
+        List<String> cubeIds = Arrays.asList("tomcat1", "tomcat2", "tomcat_46fd2cc1-0084-42a8-9ffd-35f305a08dcc");
+
+        for (String cubeId : cubeIds) {
+            Cube cube = createCubeMock(cubeId);
+            cubeRegistry.addCube(cube);
+        }
+
+        // when:
+        List<Cube<?>> cubes = cubeRegistry.getCubes();
+
+        // then:
+        Assert.assertEquals(cubeIds.size(), cubes.size());
+    }
+
+    @Test
+    public void shouldGetCubeByStarredCubeId() throws Exception {
+        // given:
+        String cubeId = "tomcat_46fd2cc1-0084-42a8-9ffd-35f305a08dcc";
+        Cube cube = createCubeMock(cubeId);
+        cubeRegistry.addCube(cube);
+
+        // when:
+        Cube<?> resolvedCube = cubeRegistry.getCube("tomcat*");
+
+        // then:
+        Assert.assertSame(cube, resolvedCube);
+    }
+
+}

--- a/docker/ftest-standalone-star-operator/pom.xml
+++ b/docker/ftest-standalone-star-operator/pom.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>arquillian-cube-docker-parent</artifactId>
+        <groupId>org.arquillian.cube</groupId>
+        <version>1.0.0.Final-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <name>Arquillian Cube Docker Functional Test Standalone With Star Operator</name>
+    <artifactId>arquillian-cube-docker-ftest-standalone-star-operator</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jboss.arquillian.junit</groupId>
+            <artifactId>arquillian-junit-standalone</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.arquillian.cube</groupId>
+            <artifactId>arquillian-cube-docker</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-deploy-plugin</artifactId>
+                <configuration>
+                    <skip>true</skip>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/docker/ftest-standalone-star-operator/src/test/java/org/arquillian/cube/StandaloneStarOperatorTestCase.java
+++ b/docker/ftest-standalone-star-operator/src/test/java/org/arquillian/cube/StandaloneStarOperatorTestCase.java
@@ -1,0 +1,73 @@
+package org.arquillian.cube;
+
+import org.hamcrest.Matcher;
+import org.jboss.arquillian.junit.Arquillian;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.junit.Assert.assertThat;
+
+@RunWith(Arquillian.class)
+public class StandaloneStarOperatorTestCase {
+
+    @HostIp
+    String ip;
+
+    @HostPort(containerName = "pingpong*", value = 8080)
+    int port;
+
+    @DockerUrl(containerName = "pingpong*", exposedPort = 8080)
+    @ArquillianResource
+    private URL url;
+
+    @Test
+    public void shouldHaveRandomizedPort() {
+        Assert.assertNotEquals(8080, port);
+    }
+
+    @Test
+    public void shouldHaveRandomizedUrlPort() {
+        assertThat(url, is(notNullValue()));
+        assertThat(url.getProtocol(), is("http"));
+        assertThat(url.getHost(), is(ip));
+        assertThat(url.getPort(), is(not(8080)));
+        assertThat(url.getPort(), is(port));
+    }
+
+    @Test
+    public void shouldBeAvailable() throws IOException {
+        String pong = ping();
+        assertThat(pong, containsString("OK"));
+    }
+
+    private String ping() throws IOException {
+        HttpURLConnection con = (HttpURLConnection) url.openConnection();
+        con.setRequestMethod("GET");
+
+        BufferedReader in = new BufferedReader(
+                new InputStreamReader(con.getInputStream()));
+        String inputLine;
+        StringBuilder response = new StringBuilder();
+
+        while ((inputLine = in.readLine()) != null) {
+            response.append(inputLine);
+        }
+        in.close();
+
+        return response.toString();
+    }
+
+
+}

--- a/docker/ftest-standalone-star-operator/src/test/resources/arquillian.xml
+++ b/docker/ftest-standalone-star-operator/src/test/resources/arquillian.xml
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xmlns="http://jboss.org/schema/arquillian"
+    xsi:schemaLocation="http://jboss.org/schema/arquillian
+    http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+    <extension qualifier="docker">
+        <property name="definitionFormat">CUBE</property>
+        <property name="dockerContainers">
+            pingpong*:
+              image: jonmorehouse/ping-pong
+              exposedPorts: [8080/tcp]
+              portBindings: [8080/tcp]
+        </property>
+    </extension>
+
+</arquillian>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -53,6 +53,7 @@
         <module>ftest-docker-machine-network</module>
         <module>ftest-docker-containerobject</module>
         <module>ftest-standalone-autostart</module>
+        <module>ftest-standalone-star-operator</module>
         <module>ftest-docker-compose-v2-git-context</module>
     </modules>
 

--- a/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
+++ b/docker/recorder/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
@@ -23,7 +23,6 @@ import org.arquillian.recorder.reporter.model.entry.table.TableRowEntry;
 import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.test.spi.event.suite.After;
 import org.junit.Before;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
@@ -93,8 +92,8 @@ public class TakeDockerEnvironmentTest {
 
     private void configureCube() throws IOException {
         cubeRegistry = new LocalCubeRegistry();
-        cubeRegistry.addCube(cube);
         when(cube.getId()).thenReturn(CUBE_ID);
+        cubeRegistry.addCube(cube);
         when(statistics.getNetworks()).thenReturn(getNetworks());
         when(statistics.getMemoryStats()).thenReturn(getMemory());
         when(statistics.getBlkioStats()).thenReturn(getIOStats());

--- a/docs/parallel.adoc
+++ b/docs/parallel.adoc
@@ -1,6 +1,6 @@
 == Parallel Execution
 
-Soemtimes using any Mave/Gradle/Jenkins plugin you end up by executing tests in parallel.
+Sometimes using any Mave/Gradle/Jenkins plugin you end up by executing tests in parallel.
 This means that same `docker-compose` file is executed for all tests.
 The problem is that probably _docker host_ is the same.
 So when you start the second test (in parallel) you will get a failure regarding that a container with same name is already started in that docker host.
@@ -64,3 +64,7 @@ So for example the result file could look like:
 Since now the ports are unique and names are unique, you can run tests using same orchestration in parallel against same docker host.
 
 NOTE: You can use the same approach for _docker-compose_ files not only with _cube_ format. But then your _docker-compose_ will be tight to Arquillian Cube. The best approach if you want to use docker-compose format is using `extends`.
+
+NOTE: Star operator must also used on enrichers for example:
+`@HostPort(containerName = "tomcat*", value = 8080)` or
+`@DockerUrl(containerName = "tomcat*", exposedPort = 8080)`


### PR DESCRIPTION
#### Short description of what this resolves:
As reported in [ISSUE 392](https://github.com/arquillian/arquillian-cube/issues/392), it is not possible to use `@HostPort` and `@DockerUrl` when using the star operator.

**Fixes**: #392 
