### PR TITLE
Openshift configuration now extends the kubernetes configuration. Ope…

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -20,7 +20,6 @@ public class CubeOpenshiftExtension implements LoadableExtension {
                .observer(CubeOpenShiftConfigurator.class)
                .observer(CubeOpenShiftRegistrar.class)
                .observer(OpenShiftSuiteLifecycleController.class)
-
                 .service(ResourceProvider.class, DeploymentConfigResourceProvider.class)
                 .service(ResourceProvider.class, DeploymentConfigListResourceProvider.class)
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurator.java
@@ -2,6 +2,8 @@ package org.arquillian.cube.openshift.impl.client;
 
 import java.util.Map;
 
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
 import org.arquillian.cube.spi.CubeConfiguration;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.core.api.InstanceProducer;
@@ -17,9 +19,13 @@ public class CubeOpenShiftConfigurator {
     @ApplicationScoped
     private InstanceProducer<CubeOpenShiftConfiguration> configurationProducer;
 
-    public void configure(@Observes CubeConfiguration event, ArquillianDescriptor arquillianDescriptor) {
-        Map<String, String> config = arquillianDescriptor.extension(EXTENSION_NAME).getExtensionProperties();
-        CubeOpenShiftConfiguration cubeConfiguration = CubeOpenShiftConfiguration.fromMap(config);
+    public void configure(@Observes Configuration configuration, ArquillianDescriptor arquillianDescriptor) {
+        if (configuration instanceof CubeOpenShiftConfiguration) {
+            //It has been already configured, no need to do it again.
+            return;
+        }
+        Map<String, String> properties = arquillianDescriptor.extension(EXTENSION_NAME).getExtensionProperties();
+        CubeOpenShiftConfiguration cubeConfiguration = CubeOpenShiftConfiguration.fromMap(configuration, properties);
         configurationProducer.set(cubeConfiguration);
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftRegistrar.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftRegistrar.java
@@ -3,6 +3,8 @@ package org.arquillian.cube.openshift.impl.client;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.Service;
+
+import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.openshift.impl.model.BuildablePodCube;
 import org.arquillian.cube.openshift.impl.model.ServiceCube;
 import org.arquillian.cube.spi.CubeRegistry;

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClientCreator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClientCreator.java
@@ -3,9 +3,8 @@ package org.arquillian.cube.openshift.impl.client;
 import io.fabric8.kubernetes.api.builder.TypedVisitor;
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.ConfigBuilder;
-import io.fabric8.kubernetes.client.KubernetesClient;
-import io.fabric8.openshift.client.OpenShiftConfig;
 
+import org.arquillian.cube.kubernetes.impl.event.AfterStart;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -18,13 +17,11 @@ public class OpenShiftClientCreator {
     @ApplicationScoped
     private InstanceProducer<OpenShiftClient> openShiftClientProducer;
 
-    public void createClient(@Observes CubeOpenShiftConfiguration cubeConfiguration) {
-        // System.setProperty(Configs.OPENSHIFT_CONFIG_FILE_PROPERTY,
-        // "./src/test/resources/config.yaml");
+    public void createClient(@Observes AfterStart afterStart, CubeOpenShiftConfiguration cubeConfiguration) {
         System.setProperty("KUBERNETES_TRUST_CERT", "true");
         // override defaults for master and namespace
         final Config config = new ConfigBuilder()
-                .withMasterUrl(cubeConfiguration.getOriginServer().toString())
+                .withMasterUrl(cubeConfiguration.getMasterUrl().toString())
                 .withNamespace(cubeConfiguration.getNamespace())
                 .withTrustCerts(true)
                 .accept(new TypedVisitor<ConfigBuilder>() {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftSuiteLifecycleController.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftSuiteLifecycleController.java
@@ -17,14 +17,14 @@ public class OpenShiftSuiteLifecycleController {
     @Inject
     private Event<CubeControlEvent> controlEvent;
 
-    public void startAutoContainers(@Observes(precedence = 100) BeforeSuite event, CubeConfiguration cubeConfiguration, CubeOpenShiftConfiguration openshiftConfiguration) {
+    public void startAutoContainers(@Observes(precedence = 99) BeforeSuite event, CubeConfiguration cubeConfiguration, CubeOpenShiftConfiguration openshiftConfiguration) {
         for(String cubeId : openshiftConfiguration.getAutoStartContainers()) {
             controlEvent.fire(new CreateCube(cubeId));
             controlEvent.fire(new StartCube(cubeId));
         }
     }
 
-    public void stopAutoContainers(@Observes(precedence = -100) AfterSuite event, CubeOpenShiftConfiguration openshiftConfiguration) {
+    public void stopAutoContainers(@Observes(precedence = -99) AfterSuite event, CubeOpenShiftConfiguration openshiftConfiguration) {
         String[] autostart = openshiftConfiguration.getAutoStartContainers();
         for(int i = autostart.length-1; i > -1; i--) {
             String cubeId = autostart[i];


### PR DESCRIPTION
Noways, the Openshift extension works on top of the Kubernetes extension.

However, their lifecycles are not aligned, so there is no synergy between them and also can be a source of issues.

This pull request further aligns the two extesions:

- Aligns configuration and clients
- Creates and starts `auto containers` within the environment created by the kubernetes extension.

So with this pull request both extension share the same mechanism of workspace management for both `containerless` and `in container` tests. 


