### PR TITLE
Remove travis's before_install step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,6 @@ language: java
 services:
   - docker
 
-before_install:
-  - mvn -N io.takari:maven:wrapper -Dmaven=3.3.9
-
 script:
   - ./mvnw -fae clean install
 


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:
Maven wrapper is part of the source code so no installation is required.

#### Changes proposed in this pull request:

- Remove before_install step in .travis.yml


**Fixes**: #
