### PR TITLE
Ns cleanup destroy

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -54,14 +54,17 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 | namespace.use.existing              | String         | Any | Don't generate a namespace use the specified one instead                         |
 | namespace.prefix                    | String (itest) | Any | If you don't specify a namespace, a random one will be created, with this prefix |
 | namespace.lazy.enabled              | Bool (true)    | Any | Should the specified namespace be created if not exists, or throw exception?     |
-| namespace.cleanup.enabled           | Bool (true)    | Any | Flag to destroy the namespace after the end of the test suite                    |
-| namespace.cleanup.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to delete the namespace                             |
+| namespace.destroy.enabled           | Bool (true)    | Any | Flag to destroy the namespace after the end of the test suite                    |
+| namespace.destroy.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to delete the namespace                             |
+| namespace.destroy.timeout           | Long           | Any | Time to wait before destroying the namespace                                     |
+| namespace.cleanup.enabled           | Bool (true)    | Any | Flag to clean (delete resources) the namespace after the end of the test suite   |
+| namespace.cleanup.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to clean the namespace                              |
 | namespace.cleanup.timeout           | Long           | Any | Time to wait when cleaning up the namespace                                      |
 | env.init.enabled                    | Bool (true)    | Any | Flag to initialize the environment (apply kubernetes resources)                  |
 | env.config.url                      | URL            | Any | URL to the Kubernetes JSON (defaults to classpath resource kubernetes.json)      |
 | env.config.resource.name            | String         | Any | Option to select a different classpath resource (other than kubernetes.json)     |
 | env.dependencies                    | List           | Any | Whitespace separated list of URLs to more dependency kubernetes.json             |
-| wait.timeout                        | Long (5mins)   | Any | The total amount of time to wait until the env is ready                         |
+| wait.timeout                        | Long (5mins)   | Any | The total amount of time to wait until the env is ready                          |
 | wait.poll.interval                  | Long (5secs)   | Any | The poll interval to use for checking if the environment is ready                |
 | wait.for.service.list               | Long (5secs)   | Any | Explicitly specify a list of service to wait upon                                |
 | wait.for.service.connection.enabled | Bool (false)   | Any | Flag to specify if we should wait for an actual connection to the service        |

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -28,6 +28,9 @@ public interface Configuration {
     String NAMESPACE_CLEANUP_TIMEOUT = "namespace.cleanup.timeout";
     String NAMESPACE_CLEANUP_CONFIRM_ENABLED = "namespace.cleanup.confirm.enabled";
     String NAMESPACE_CLEANUP_ENABLED = "namespace.cleanup.enabled";
+    String NAMESPACE_DESTROY_ENABLED = "namespace.destroy.enabled";
+    String NAMESPACE_DESTROY_CONFIRM_ENABLED = "namespace.destroy.confirm.enabled";
+    String NAMESPACE_DESTROY_TIMEOUT = "namespace.destroy.timeout";
     String NAMESPACE_TO_USE = "namespace.use.existing";
     String NAMESPACE_PREFIX = "namespace.prefix";
 
@@ -57,6 +60,7 @@ public interface Configuration {
 
     String DEFAULT_CONFIG_FILE_NAME = "kubernetes.json";
     Long DEFAULT_NAMESPACE_CLEANUP_TIMEOUT = 0L;
+    Long DEFAULT_NAMESPACE_DESTROY_TIMEOUT = 0L;
     Boolean DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED = true;
 
     Config FALLBACK_CLIENT_CONFIG = new ConfigBuilder().build();
@@ -81,6 +85,12 @@ public interface Configuration {
     long getNamespaceCleanupTimeout();
 
     boolean isNamespaceCleanupConfirmationEnabled();
+
+    boolean isNamespaceDestroyEnabled();
+
+    boolean isNamespaceDestroyConfirmationEnabled();
+
+    long getNamespaceDestroyTimeout();
 
     long getWaitTimeout();
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/ResourceInstaller.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/ResourceInstaller.java
@@ -6,7 +6,7 @@ import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
-public interface ResourceInstaller {
+public interface ResourceInstaller extends WithToImmutable<ResourceInstaller> {
 
     /**
      * Installs the resources found in the specified URL.

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/ResourceInstaller.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/ResourceInstaller.java
@@ -2,10 +2,31 @@ package org.arquillian.cube.kubernetes.api;
 
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.HasMetadata;
 
 public interface ResourceInstaller {
 
+    /**
+     * Installs the resources found in the specified URL.
+     * @param url   The URL to read resources from.
+     * @return      The list with the created resources.
+     */
     List<HasMetadata> install(URL url);
+
+    /**
+     * Uninstalls the resources found in the specified URL.
+     * @param url   The URL to read resources from.
+     * @return      A map of the resources to their delete status.
+     */
+    Map<HasMetadata, Boolean> uninstall(URL url);
+
+
+    /**
+     * Uninstalls the resources found in the specified list.
+     * @param list      The list with the resources.
+     * @return          A map of the resources to their delete status.
+     */
+    Map<HasMetadata, Boolean> uninstall(List<HasMetadata> list);
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -36,6 +36,10 @@ public class DefaultConfiguration implements Configuration {
     private final long namespaceCleanupTimeout;
     private final boolean namespaceCleanupConfirmationEnabled;
 
+    private final boolean namespaceDestroyEnabled;
+    private final boolean namespaceDestroyConfirmationEnabled;
+    private final long namespaceDestroyTimeout;
+
     private final long waitTimeout;
     private final long waitPollInterval;
     private final boolean waitForServiceConnectionEnabled;
@@ -66,6 +70,11 @@ public class DefaultConfiguration implements Configuration {
                     .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, namespace.contains(sessionId)))
                     .withNamespaceCleanupConfirmationEnabled(getBooleanProperty(NAMESPACE_CLEANUP_CONFIRM_ENABLED, map, false))
                     .withNamespaceCleanupTimeout(getLongProperty(NAMESPACE_CLEANUP_TIMEOUT, map, DEFAULT_NAMESPACE_CLEANUP_TIMEOUT))
+
+                    .withNamespaceDestroyEnabled(getBooleanProperty(NAMESPACE_DESTROY_ENABLED, map, namespace.contains(sessionId)))
+                    .withNamespaceDestroyConfirmationEnabled(getBooleanProperty(NAMESPACE_DESTROY_CONFIRM_ENABLED, map, false))
+                    .withNamespaceDestroyTimeout(getLongProperty(NAMESPACE_DESTROY_TIMEOUT, map, DEFAULT_NAMESPACE_DESTROY_TIMEOUT))
+
                     .withWaitTimeout(getLongProperty(WAIT_TIMEOUT, map, DEFAULT_WAIT_TIMEOUT))
                     .withWaitPollInterval(getLongProperty(WAIT_POLL_INTERVAL, map, DEFAULT_WAIT_POLL_INTERVAL))
                     .withWaitForServiceList(Strings.splitAndTrimAsList(getStringProperty(WAIT_FOR_SERVICE_LIST, map, ""), " "))
@@ -85,7 +94,7 @@ public class DefaultConfiguration implements Configuration {
     }
 
 
-    public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout, boolean namespaceCleanupConfirmationEnabled, long waitTimeout, long waitPollInterval, boolean waitForServiceConnectionEnabled, List<String> waitForServiceList, long waitForServiceConnectionTimeout, boolean ansiLoggerEnabled, boolean environmentInitEnabled, String kubernetesDomain, String dockerRegistry) {
+    public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout, boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled, boolean namespaceDestroyConfirmationEnabled, long namespaceDestroyTimeout, long waitTimeout, long waitPollInterval, boolean waitForServiceConnectionEnabled, List<String> waitForServiceList, long waitForServiceConnectionTimeout, boolean ansiLoggerEnabled, boolean environmentInitEnabled, String kubernetesDomain, String dockerRegistry) {
         this.masterUrl = masterUrl;
         this.environmentDependencies = environmentDependencies;
         this.environmentConfigUrl = environmentConfigUrl;
@@ -95,6 +104,9 @@ public class DefaultConfiguration implements Configuration {
         this.namespaceCleanupEnabled = namespaceCleanupEnabled;
         this.namespaceCleanupTimeout = namespaceCleanupTimeout;
         this.namespaceCleanupConfirmationEnabled = namespaceCleanupConfirmationEnabled;
+        this.namespaceDestroyEnabled = namespaceDestroyEnabled;
+        this.namespaceDestroyConfirmationEnabled = namespaceDestroyConfirmationEnabled;
+        this.namespaceDestroyTimeout = namespaceDestroyTimeout;
         this.waitTimeout = waitTimeout;
         this.waitPollInterval = waitPollInterval;
         this.waitForServiceConnectionEnabled = waitForServiceConnectionEnabled;
@@ -155,6 +167,21 @@ public class DefaultConfiguration implements Configuration {
     @Override
     public boolean isNamespaceCleanupConfirmationEnabled() {
         return namespaceCleanupConfirmationEnabled;
+    }
+
+    @Override
+    public boolean isNamespaceDestroyEnabled() {
+        return namespaceDestroyEnabled;
+    }
+
+    @Override
+    public boolean isNamespaceDestroyConfirmationEnabled() {
+        return namespaceDestroyConfirmationEnabled;
+    }
+
+    @Override
+    public long getNamespaceDestroyTimeout() {
+        return namespaceDestroyTimeout;
     }
 
     @Override

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManagerLifecycle.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManagerLifecycle.java
@@ -58,7 +58,7 @@ public class SessionManagerLifecycle {
                 annotationProvider.get(),
                 namespaceService.get().toImmutable(),
                 kubernetesResourceLocator.get().toImmutable(),
-                dependencyResolver.get().toImmutable(), resourceInstaller.get());
+                dependencyResolver.get().toImmutable(), resourceInstaller.get().toImmutable());
 
         sessionManagerRef.set(sessionManager);
         sessionManager.start();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/install/DefaultResourceInstaller.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/install/DefaultResourceInstaller.java
@@ -3,18 +3,19 @@ package org.arquillian.cube.kubernetes.impl.install;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.Logger;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
+import org.arquillian.cube.kubernetes.api.WithToImmutable;
 import org.arquillian.cube.kubernetes.impl.visitor.CompositeVisitor;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 
-import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Scanner;
 
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -35,84 +36,119 @@ public class DefaultResourceInstaller implements ResourceInstaller {
     @Inject
     protected Instance<ServiceLoader> serviceLoader;
 
+    protected ResourceInstaller delegate;
+
+
+    @Override
+    public ResourceInstaller toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                delegate = new DefaultResourceInstaller.ImmutableResourceInstaller(client.get(), configuration.get(),
+                        logger.get().toImmutable(),
+                        new ArrayList<>(serviceLoader.get().all(Visitor.class)));
+            }
+        }
+        return delegate;
+    }
+
     @Override
     public List<HasMetadata> install(URL url) {
-        ServiceLoader serviceLoader = this.serviceLoader.get();
-        KubernetesClient client = this.client.get();
-        List<Visitor> visitors = new ArrayList<>(serviceLoader.all(Visitor.class));
-        CompositeVisitor compositeVisitor = new CompositeVisitor(visitors);
-        try (InputStream is = url.openStream()) {
-            return client.load(is).accept(compositeVisitor).createOrReplace();
-        } catch (Throwable t) {
-            throw KubernetesClientException.launderThrowable(t);
-        }
+        return toImmutable().install(url);
     }
 
     @Override
     public Map<HasMetadata, Boolean> uninstall(URL url) {
-        ServiceLoader serviceLoader = this.serviceLoader.get();
-        KubernetesClient client = this.client.get();
-
-        Map<HasMetadata, Boolean> result = new HashMap<>();
-        List<Visitor> visitors = new ArrayList<>(serviceLoader.all(Visitor.class));
-        CompositeVisitor compositeVisitor = new CompositeVisitor(visitors);
-
-        try (InputStream is = url.openStream()) {
-            return uninstall(client.load(is).accept(compositeVisitor).get());
-        } catch (Throwable t) {
-            throw KubernetesClientException.launderThrowable(t);
-        }
+        return toImmutable().uninstall(url);
     }
 
     @Override
     public Map<HasMetadata, Boolean> uninstall(List<HasMetadata> list) {
-        KubernetesClient client = this.client.get();
-        Map<HasMetadata, Boolean> result = new HashMap<>();
-        preUninstallCheck();
-        for (HasMetadata h : list) {
-            try {
-                Boolean deleted = client.resource(h).delete();
-                result.put(h, deleted);
-            } catch (Throwable t) {
-                result.put(h, false);
-            }
-        }
-        return result;
+        return toImmutable().uninstall(list);
     }
 
-    public void preUninstallCheck() {
-        Logger logger = this.logger.get();
-        Configuration configuration = this.configuration.get();
-        if (configuration.isNamespaceCleanupEnabled()) {
-            logger.info("");
-            logger.info("Waiting to cleanup the namespace.");
-            logger.info("Please type: [Q] to cleanup the namespace.");
+    public static class ImmutableResourceInstaller implements ResourceInstaller, WithToImmutable<ResourceInstaller> {
 
-            while (true) {
+
+        private final KubernetesClient client;
+        private final Configuration configuration;
+        private final Logger logger;
+        private final List<Visitor> visitors;
+
+
+        public ImmutableResourceInstaller(KubernetesClient client, Configuration configuration, Logger logger,  List<Visitor> visitors) {
+            this.client = client;
+            this.configuration = configuration;
+            this.logger = logger;
+            this.visitors = visitors;
+        }
+
+        @Override
+        public List<HasMetadata> install(URL url) {
+            CompositeVisitor compositeVisitor = new CompositeVisitor(visitors);
+            try (InputStream is = url.openStream()) {
+                return client.load(is).accept(compositeVisitor).createOrReplace();
+            } catch (Throwable t) {
+                throw KubernetesClientException.launderThrowable(t);
+            }
+        }
+
+        @Override
+        public Map<HasMetadata, Boolean> uninstall(URL url) {
+            Map<HasMetadata, Boolean> result = new HashMap<>();
+            CompositeVisitor compositeVisitor = new CompositeVisitor(visitors);
+
+            try (InputStream is = url.openStream()) {
+                return uninstall(client.load(is).accept(compositeVisitor).get());
+            } catch (Throwable t) {
+                throw KubernetesClientException.launderThrowable(t);
+            }
+        }
+
+        @Override
+        public Map<HasMetadata, Boolean> uninstall(List<HasMetadata> list) {
+            Map<HasMetadata, Boolean> result = new HashMap<>();
+            preUninstallCheck();
+            for (HasMetadata h : list) {
                 try {
-                    int ch = System.in.read();
-                    if (ch < 0 || ch == 'Q') {
-                        logger.info("Cleaning up...");
-                        break;
-                    } else {
-                        logger.info("Found character: " + Character.toString((char) ch));
-                    }
-                } catch (IOException e) {
-                    logger.warn("Failed to read from input. " + e);
-                    break;
+                    Boolean deleted = client.resource(h).delete();
+                    result.put(h, deleted);
+                } catch (Throwable t) {
+                    result.put(h, false);
                 }
             }
-        } else {
-            long timeout = configuration.getNamespaceCleanupTimeout();
-            if (timeout > 0L) {
+            return result;
+        }
+
+        public void preUninstallCheck() {
+            if (configuration.isNamespaceCleanupConfirmationEnabled()) {
                 logger.info("");
-                logger.info("Waiting for " + timeout + " seconds before cleaning the namespace");
-                try {
-                    Thread.sleep(timeout * 1000);
-                } catch (InterruptedException e) {
-                    logger.info("Interrupted waiting to cleanup the namespace: " + e);
+                logger.info("Waiting to cleanup the namespace.");
+                logger.info("Please press <enter> to cleanup the namespace.");
+
+                Scanner scanner = new Scanner(System.in);
+                scanner.nextLine();
+                logger.info("Cleaning up...");
+                return;
+            } else {
+                long timeout = configuration.getNamespaceCleanupTimeout();
+                if (timeout > 0L) {
+                    logger.info("");
+                    logger.info("Waiting for " + timeout + " seconds before cleaning the namespace");
+                    try {
+                        Thread.sleep(timeout * 1000);
+                    } catch (InterruptedException e) {
+                        logger.info("Interrupted waiting to cleanup the namespace: " + e);
+                    }
                 }
             }
+        }
+
+        @Override
+        public ResourceInstaller toImmutable() {
+            return this;
         }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/install/DefaultResourceInstaller.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/install/DefaultResourceInstaller.java
@@ -1,15 +1,20 @@
 package org.arquillian.cube.kubernetes.impl.install;
 
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.Logger;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.visitor.CompositeVisitor;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.spi.ServiceLoader;
 
+import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.api.model.HasMetadata;
@@ -20,6 +25,12 @@ public class DefaultResourceInstaller implements ResourceInstaller {
 
     @Inject
     protected Instance<KubernetesClient> client;
+
+    @Inject
+    protected Instance<Configuration> configuration;
+
+    @Inject
+    protected Instance<Logger> logger;
 
     @Inject
     protected Instance<ServiceLoader> serviceLoader;
@@ -34,6 +45,74 @@ public class DefaultResourceInstaller implements ResourceInstaller {
             return client.load(is).accept(compositeVisitor).createOrReplace();
         } catch (Throwable t) {
             throw KubernetesClientException.launderThrowable(t);
+        }
+    }
+
+    @Override
+    public Map<HasMetadata, Boolean> uninstall(URL url) {
+        ServiceLoader serviceLoader = this.serviceLoader.get();
+        KubernetesClient client = this.client.get();
+
+        Map<HasMetadata, Boolean> result = new HashMap<>();
+        List<Visitor> visitors = new ArrayList<>(serviceLoader.all(Visitor.class));
+        CompositeVisitor compositeVisitor = new CompositeVisitor(visitors);
+
+        try (InputStream is = url.openStream()) {
+            return uninstall(client.load(is).accept(compositeVisitor).get());
+        } catch (Throwable t) {
+            throw KubernetesClientException.launderThrowable(t);
+        }
+    }
+
+    @Override
+    public Map<HasMetadata, Boolean> uninstall(List<HasMetadata> list) {
+        KubernetesClient client = this.client.get();
+        Map<HasMetadata, Boolean> result = new HashMap<>();
+        preUninstallCheck();
+        for (HasMetadata h : list) {
+            try {
+                Boolean deleted = client.resource(h).delete();
+                result.put(h, deleted);
+            } catch (Throwable t) {
+                result.put(h, false);
+            }
+        }
+        return result;
+    }
+
+    public void preUninstallCheck() {
+        Logger logger = this.logger.get();
+        Configuration configuration = this.configuration.get();
+        if (configuration.isNamespaceCleanupEnabled()) {
+            logger.info("");
+            logger.info("Waiting to cleanup the namespace.");
+            logger.info("Please type: [Q] to cleanup the namespace.");
+
+            while (true) {
+                try {
+                    int ch = System.in.read();
+                    if (ch < 0 || ch == 'Q') {
+                        logger.info("Cleaning up...");
+                        break;
+                    } else {
+                        logger.info("Found character: " + Character.toString((char) ch));
+                    }
+                } catch (IOException e) {
+                    logger.warn("Failed to read from input. " + e);
+                    break;
+                }
+            }
+        } else {
+            long timeout = configuration.getNamespaceCleanupTimeout();
+            if (timeout > 0L) {
+                logger.info("");
+                logger.info("Waiting for " + timeout + " seconds before cleaning the namespace");
+                try {
+                    Thread.sleep(timeout * 1000);
+                } catch (InterruptedException e) {
+                    logger.info("Interrupted waiting to cleanup the namespace: " + e);
+                }
+            }
         }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
@@ -15,6 +15,7 @@ import org.jboss.arquillian.core.spi.Validate;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Map;
+import java.util.Scanner;
 
 public class DefaultNamespaceService implements NamespaceService {
 
@@ -162,36 +163,26 @@ public class DefaultNamespaceService implements NamespaceService {
             Logger logger = this.logger;
             Configuration configuration = this.configuration;
             try {
-                if (configuration.isNamespaceCleanupConfirmationEnabled()) {
+                if (configuration.isNamespaceDestroyConfirmationEnabled()) {
                     showErrors();
                     logger.info("");
                     logger.info("Waiting to destroy the namespace.");
-                    logger.info("Please type: [Q] to terminate the namespace.");
+                    logger.info("Please press <enter> to cleanup the namespace.");
 
-                    while (true) {
-                        try {
-                            int ch = System.in.read();
-                            if (ch < 0 || ch == 'Q') {
-                                logger.info("Stopping...");
-                                break;
-                            } else {
-                                logger.info("Found character: " + Character.toString((char) ch));
-                            }
-                        } catch (IOException e) {
-                            logger.warn("Failed to read from input. " + e);
-                            break;
-                        }
-                    }
+                    Scanner scanner = new Scanner(System.in);
+                    scanner.nextLine();
+                    logger.info("Cleaning up...");
+                    return;
                 } else {
-                    long timeout = configuration.getNamespaceCleanupTimeout();
+                    long timeout = configuration.getNamespaceDestroyTimeout();
                     if (timeout > 0L) {
                         showErrors();
                         logger.info("");
-                        logger.info("Sleeping for " + timeout + " seconds until destroying the namespace");
+                        logger.info("Waiting for " + timeout + " seconds before destroying the namespace");
                         try {
                             Thread.sleep(timeout * 1000);
                         } catch (InterruptedException e) {
-                            logger.info("Interupted sleeping to GC the namespace: " + e);
+                            logger.info("Interrupted waiting to GC the namespace: " + e);
                         }
                     }
                 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -44,8 +44,8 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private final Set<String> proxiedContainerPorts;
     private final String portForwardBindAddress;
 
-    public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout, boolean namespaceCleanupConfirmationEnabled, long waitTimeout, long waitPollInterval, boolean waitForServiceConnectionEnabled, List<String> waitForServiceList, long waitForServiceConnectionTimeout, boolean ansiLoggerEnabled, boolean environmentInitEnabled, String kubernetesDomain, String dockerRegistry, boolean keepAliveGitServer, String definitions, String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts, String portForwardBindAddress) {
-        super(sessionId, masterUrl, namespace, environmentConfigUrl, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled, namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, waitTimeout, waitPollInterval, waitForServiceConnectionEnabled, waitForServiceList, waitForServiceConnectionTimeout, ansiLoggerEnabled, environmentInitEnabled, kubernetesDomain, dockerRegistry);
+    public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout, boolean namespaceCleanupConfirmationEnabled,boolean namespaceDestroyEnabled, long namespaceDestroyTimeout, boolean namespaceDestroyConfirmationEnabled, long waitTimeout, long waitPollInterval, boolean waitForServiceConnectionEnabled, List<String> waitForServiceList, long waitForServiceConnectionTimeout, boolean ansiLoggerEnabled, boolean environmentInitEnabled, String kubernetesDomain, String dockerRegistry, boolean keepAliveGitServer, String definitions, String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts, String portForwardBindAddress) {
+        super(sessionId, masterUrl, namespace, environmentConfigUrl, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled, namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled, namespaceDestroyConfirmationEnabled, namespaceDestroyTimeout, waitTimeout, waitPollInterval, waitForServiceConnectionEnabled, waitForServiceList, waitForServiceConnectionTimeout, ansiLoggerEnabled, environmentInitEnabled, kubernetesDomain, dockerRegistry);
         this.keepAliveGitServer = keepAliveGitServer;
         this.definitions = definitions;
         this.definitionsFile = definitionsFile;
@@ -114,6 +114,11 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                     .withNamespaceCleanupEnabled(c.isNamespaceCleanupEnabled())
                     .withNamespaceCleanupConfirmationEnabled(c.isNamespaceCleanupConfirmationEnabled())
                     .withNamespaceCleanupTimeout(c.getNamespaceCleanupTimeout())
+
+                    .withNamespaceDestroyEnabled(c.isNamespaceDestroyEnabled())
+                    .withNamespaceDestroyConfirmationEnabled(c.isNamespaceDestroyConfirmationEnabled())
+                    .withNamespaceDestroyTimeout(c.getNamespaceDestroyTimeout())
+
                     .withWaitTimeout(c.getWaitTimeout())
                     .withWaitPollInterval(c.getWaitPollInterval())
                     .withWaitForServiceList(c.getWaitForServiceList())

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
         <version.junit>4.11</version.junit>
         <version.hamcrest>1.3</version.hamcrest>
         <version.docker-java>3.0.6</version.docker-java>
-        <version.kubernetes_client>2.2.0</version.kubernetes_client>
+        <version.kubernetes_client>2.2.1</version.kubernetes_client>
         <version.snakeyaml>1.15</version.snakeyaml>
         <version.shrinkwrap_resolver>2.2.2</version.shrinkwrap_resolver>
         <version.mockito>1.10.19</version.mockito>


### PR DESCRIPTION
Originally, there was the concept of `namespace cleanup` and `namespace destroy`. During the move to `arquillian-cube` both concepts collapsed into `namespace destroy`.

However, there is a valid use case "Use a single namespace/project, don't delete but clean it up". In fact in restricted environment this is likely to be the most common use case, so we need to be able to handle it.

This pull request, fixes cleanup vs destroy so that we can selectively do both.