### PR TITLE
Polish pom for assertj

### DIFF
--- a/docker/ftest-docker-compose-v2-git-context/pom.xml
+++ b/docker/ftest-docker-compose-v2-git-context/pom.xml
@@ -30,7 +30,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/docker/ftest-drone-custom/pom.xml
+++ b/docker/ftest-drone-custom/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>

--- a/docker/ftest-drone-reporter/pom.xml
+++ b/docker/ftest-drone-reporter/pom.xml
@@ -65,7 +65,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>

--- a/docker/ftest-drone/pom.xml
+++ b/docker/ftest-drone/pom.xml
@@ -54,7 +54,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>

--- a/docker/ftest-graphene/pom.xml
+++ b/docker/ftest-graphene/pom.xml
@@ -67,7 +67,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
         </dependency>
         <dependency>
             <groupId>org.jboss.arquillian.extension</groupId>

--- a/docker/ftest-restassured/pom.xml
+++ b/docker/ftest-restassured/pom.xml
@@ -52,7 +52,6 @@
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>3.5.2</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:

Existing modules inherit assertj's version 3.6.1 but some modules
override this version. This commit polish pom files which override
version declared in dependencyManagement section.

#### Changes proposed in this pull request:

- Remove tag `version` where `assertj.version` is overriden


**Fixes**: #
