### PR TITLE
Checks if container object is already up before initializing it

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectFactory.java
@@ -48,7 +48,7 @@ public class DockerContainerObjectFactory implements ContainerObjectFactory {
             throw new IllegalArgumentException("configuration cannot be null");
         }
         try {
-            return new DockerContainerObjectBuilder<T>(dockerClientExecutorInstance.get(), cubeControllerInstance.get())
+            return new DockerContainerObjectBuilder<T>(dockerClientExecutorInstance.get(), cubeControllerInstance.get(), cubeRegistryInstance.get())
                     .withEnrichers(serviceLoaderInstance.get().all(TestEnricher.class))
                     .withContainerObjectClass(containerObjectClass)
                     .withContainerObjectConfiguration(configuration)

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
@@ -38,6 +38,7 @@ import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.model.DockerCube;
 import org.arquillian.cube.impl.util.ReflectionUtil;
+import org.arquillian.cube.spi.CubeRegistry;
 import org.arquillian.cube.spi.metadata.HasPortBindings;
 import org.arquillian.cube.spi.metadata.IsContainerObject;
 import org.jboss.arquillian.test.spi.TestEnricher;
@@ -60,11 +61,13 @@ public class DockerContainerObjectBuilderTest {
     private DockerClientExecutor dockerClientExecutor;
     private CubeContainerObjectTestEnricher cubeContainerObjectTestEnricher;
     private Collection<TestEnricher> enrichers;
+    private CubeRegistry cubeRegistry;
 
     @Before
     public void initMocks() {
         cubeController = mock(CubeController.class);
         dockerClientExecutor = mock(DockerClientExecutor.class);
+        cubeRegistry = mock(CubeRegistry.class);
         cubeContainerObjectTestEnricher = mock(CubeContainerObjectTestEnricher.class);
         doAnswer(DockerContainerObjectBuilderTest::objectContainerEnricherMockEnrich)
                 .when(cubeContainerObjectTestEnricher).enrich(any());
@@ -85,7 +88,7 @@ public class DockerContainerObjectBuilderTest {
     public void shouldStartAContainerObjectDefinedUsingDockerfile() {
         final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
         try {
-            TestContainerObjectDefinedUsingDockerfile containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingDockerfile>(dockerClientExecutor, cubeController)
+            TestContainerObjectDefinedUsingDockerfile containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingDockerfile>(dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectDefinedUsingDockerfile.class)
                     .onCubeCreated(cubeRef::set)
                     .build();
@@ -108,7 +111,7 @@ public class DockerContainerObjectBuilderTest {
         final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
         try {
             TestContainerObjectDefinedUsingDescriptor containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingDescriptor>(
-                        dockerClientExecutor, cubeController)
+                        dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectDefinedUsingDescriptor.class)
                     .onCubeCreated(cubeRef::set)
                     .build();
@@ -135,7 +138,7 @@ public class DockerContainerObjectBuilderTest {
         final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
         try {
             TestContainerObjectWithAnnotatedLink containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithAnnotatedLink>(
-                        dockerClientExecutor, cubeController)
+                        dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectWithAnnotatedLink.class)
                     .withEnrichers(enrichers)
                     .onCubeCreated(cubeRef::set)
@@ -165,7 +168,7 @@ public class DockerContainerObjectBuilderTest {
     public void shouldLinkInnerContainersWithoutLink() {
         final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
         try {
-            TestContainerObjectWithNonAnnotatedLink containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithNonAnnotatedLink>(dockerClientExecutor, cubeController)
+            TestContainerObjectWithNonAnnotatedLink containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithNonAnnotatedLink>(dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectWithNonAnnotatedLink.class)
                     .withEnrichers(enrichers)
                     .onCubeCreated(cubeRef::set)
@@ -195,7 +198,7 @@ public class DockerContainerObjectBuilderTest {
     public void shouldStartAContainerObjectDefinedUsingImage() {
         final AtomicReference<DockerCube> cubeRef = new AtomicReference<>();
         try {
-            TestContainerObjectDefinedUsingImage containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImage>(dockerClientExecutor, cubeController)
+            TestContainerObjectDefinedUsingImage containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImage>(dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectDefinedUsingImage.class)
                     .onCubeCreated(cubeRef::set)
                     .build();
@@ -221,7 +224,7 @@ public class DockerContainerObjectBuilderTest {
             CubeContainer ccconfig = new CubeContainer();
             ccconfig.setEnv(Collections.singleton("e=f"));
             CubeContainerObjectConfiguration ccoconfig = new CubeContainerObjectConfiguration(ccconfig);
-            TestContainerObjectDefinedUsingImageAndEnvironmentVariables containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImageAndEnvironmentVariables>(dockerClientExecutor, cubeController)
+            TestContainerObjectDefinedUsingImageAndEnvironmentVariables containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImageAndEnvironmentVariables>(dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectDefinedUsingImageAndEnvironmentVariables.class)
                     .withContainerObjectConfiguration(ccoconfig)
                     .onCubeCreated(cubeRef::set)
@@ -249,7 +252,7 @@ public class DockerContainerObjectBuilderTest {
             CubeContainer ccconfig = new CubeContainer();
             ccconfig.setBinds(Collections.singleton("/mypath3:/containerPath3:rw"));
             CubeContainerObjectConfiguration ccoconfig = new CubeContainerObjectConfiguration(ccconfig);
-            TestContainerObjectDefinedUsingImageAndVolumes containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImageAndVolumes>(dockerClientExecutor, cubeController)
+            TestContainerObjectDefinedUsingImageAndVolumes containerObject = new DockerContainerObjectBuilder<TestContainerObjectDefinedUsingImageAndVolumes>(dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectDefinedUsingImageAndVolumes.class)
                     .withContainerObjectConfiguration(ccoconfig)
                     .onCubeCreated(cubeRef::set)
@@ -280,7 +283,7 @@ public class DockerContainerObjectBuilderTest {
         }).when(cubeController).start("containerWithCubeIp");
         try {
             TestContainerObjectWithCubeIp containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithCubeIp>(
-                        dockerClientExecutor, cubeController)
+                        dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectWithCubeIp.class)
                     .onCubeCreated(cubeRef::set)
                     .build();
@@ -310,7 +313,7 @@ public class DockerContainerObjectBuilderTest {
         }).when(cubeController).start("containerWithHostPort");
         try {
             TestContainerObjectWithHostPort containerObject = new DockerContainerObjectBuilder<TestContainerObjectWithHostPort>(
-                    dockerClientExecutor, cubeController)
+                    dockerClientExecutor, cubeController, cubeRegistry)
                     .withContainerObjectClass(TestContainerObjectWithHostPort.class)
                     .onCubeCreated(cubeRef::set)
                     .build();

--- a/docker/ftest-docker-containerobject/src/test/java/org/arquillian/cube/containerobject/PingPongTest.java
+++ b/docker/ftest-docker-containerobject/src/test/java/org/arquillian/cube/containerobject/PingPongTest.java
@@ -1,6 +1,5 @@
 package org.arquillian.cube.containerobject;
 
-import org.arquillian.cube.CubeIp;
 import org.arquillian.cube.docker.impl.requirement.RequiresDockerMachine;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.junit.Test;
@@ -14,7 +13,6 @@ import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ArquillianConditionalRunner.class)
@@ -24,19 +22,11 @@ public class PingPongTest {
     @Cube
     PingPongContainer pingPongContainer;
 
-    @CubeIp(containerName = "pingpong")
-    private String pingpongAddr;
-
     @Test
     public void shouldReturnOkAsPong() throws IOException {
         String pong = ping();
         assertThat(pong, containsString("OK"));
         assertThat(pingPongContainer.getConnectionPort(), is(5000));
-    }
-
-    @Test
-    public void shouldInjectCubeIp() {
-        assertThat(pingpongAddr, notNullValue());
     }
 
     public String ping() throws IOException {

--- a/docker/ftest-docker-containerobject/src/test/java/org/arquillian/cube/containerobject/PingPongTest.java
+++ b/docker/ftest-docker-containerobject/src/test/java/org/arquillian/cube/containerobject/PingPongTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.containerobject;
 
+import org.arquillian.cube.CubeIp;
 import org.arquillian.cube.docker.impl.requirement.RequiresDockerMachine;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.junit.Test;
@@ -13,6 +14,7 @@ import java.net.URL;
 
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ArquillianConditionalRunner.class)
@@ -22,6 +24,9 @@ public class PingPongTest {
     @Cube
     PingPongContainer pingPongContainer;
 
+    @CubeIp(containerName = "pingpong")
+    private String pingpongAddr;
+
     @Test
     public void shouldReturnOkAsPong() throws IOException {
         String pong = ping();
@@ -29,6 +34,10 @@ public class PingPongTest {
         assertThat(pingPongContainer.getConnectionPort(), is(5000));
     }
 
+    @Test
+    public void shouldInjectCubeIp() {
+        assertThat(pingpongAddr, notNullValue());
+    }
 
     public String ping() throws IOException {
         URL url = new URL("http://" + pingPongContainer.getDockerHost() + ":" + pingPongContainer.getConnectionPort());


### PR DESCRIPTION

#### Short description of what this resolves:

Checks if container object is already up before initializing it. If more than one test uses the same container object, the test fails because the container is already initialized.

#### Changes proposed in this pull request:

-
-
-


**Fixes**: #610 
