### PR TITLE
Fixes String format syntax

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
@@ -132,7 +132,7 @@ public class DockerCompositions {
                 }
 
             } else {
-                logger.warning(String.format("Overriding Container %s are not defined in main definition of containers."));
+                logger.warning(String.format("Overriding Container %s are not defined in main definition of containers.", containerId));
             }
         }
     }

--- a/docker/ftest-standalone-star-operator-docker-compose/src/test/resources/arquillian.xml
+++ b/docker/ftest-standalone-star-operator-docker-compose/src/test/resources/arquillian.xml
@@ -6,6 +6,11 @@
 
     <extension qualifier="docker">
         <property name="machineName">dev</property>
+        <property name="cubeSpecificProperties">
+          pingpong*:
+            await:
+              strategy: polling
+        </property>
     </extension>
 
 </arquillian>


### PR DESCRIPTION
#### Short description of what this resolves:

If user uses `customSettings` in `docker-compose` format and the cube id is not found then an exception is thrown because `String.format` contains an invalid syntax.


#### Changes proposed in this pull request:

-
-
-


**Fixes**: #620 
