### PR TITLE
Changed definitionsFile to env.config.url

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -79,7 +79,7 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 |===============================================================================================================================================
 | Option                              | Type           | Env | Description                                                                      |
 | autoStartContainers                 | List           | Any | Comma Separated List of Pods which you want to auto start                       |
-| definitionsFile                     | String         | Any | Definitions file path                                                            |
+| env.config.url                      | String         | Any | Config file path                                                            |
 | proxiedContainerPorts               | List           | Any | Comma Separated List following Pod:containerPort OR Pod:MappedPort:ContainerPort |                                        |
 |===============================================================================================================================================
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -109,6 +109,8 @@ public class SessionManager implements SessionCreatedListener {
                         try (InputStream is = definitionsFileURL.openStream()) {
                             resources.addAll(resourceInstaller.install(definitionsFileURL));
                         }
+                    } else {
+                        throw new IllegalStateException("Did not find any k8s or openshift resources configuration file.");
                     }
                 }
 

--- a/openshift/ftest-containerless/src/test/resources/arquillian.xml
+++ b/openshift/ftest-containerless/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
 	<extension qualifier="openshift">
-		<property name="definitionsFile">src/test/resources/hello_pod.json</property>
+		<property name="env.config.url">src/test/resources/hello_pod.json</property>
 	</extension>
 
 	<container qualifier="test-container" default="true">

--- a/openshift/ftest-standalone/src/test/resources/arquillian.xml
+++ b/openshift/ftest-standalone/src/test/resources/arquillian.xml
@@ -5,7 +5,7 @@
 
 
     <extension qualifier="openshift">
-        <property name="definitionsFile">src/test/resources/hello-openshift.json</property>
+        <property name="env.config.url">src/test/resources/hello-openshift.json</property>
     </extension>
 
 </arquillian>

--- a/openshift/ftest/src/test/resources/arquillian.xml
+++ b/openshift/ftest/src/test/resources/arquillian.xml
@@ -4,7 +4,7 @@
     xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
 	<extension qualifier="openshift">
-		<property name="definitionsFile">src/test/resources/hello_pod.json</property>
+		<property name="env.config.url">src/test/resources/hello_pod.json</property>
 		<property name="proxiedContainerPorts">hello-openshift:9990</property>
 	</extension>
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -30,7 +30,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     // }
 
     private static final String KEEP_ALIVE_GIT_SERVER = "keepAliveGitServer";
-    private static final String DEFINITIONS_FILE = "definitionsFile";
+    private static final String ENV_CONFIG_URL = "env.config.url";
     private static final String DEFINITIONS = "definitions";
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String PROXIED_CONTAINER_PORTS = "proxiedContainerPorts";
@@ -130,7 +130,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                     //Local properties
                     .withKeepAliveGitServer(getBooleanProperty(KEEP_ALIVE_GIT_SERVER, map, false))
                     .withDefinitions(getStringProperty(DEFINITIONS, map, null))
-                    .withDefinitionsFile(getStringProperty(DEFINITIONS_FILE, map, null))
+                    .withDefinitionsFile(getStringProperty(ENV_CONFIG_URL, map, null))
                     .withAutoStartContainers(split(getStringProperty(AUTO_START_CONTAINERS, map, ""), ","))
                     .withProxiedContainerPorts(split(getStringProperty(PROXIED_CONTAINER_PORTS, map, ""), ","))
                     .withPortForwardBindAddress(getStringProperty(PORT_FORWARDER_BIND_ADDRESS, map, "127.0.0.1"))
@@ -145,19 +145,22 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     }
 
     private static void setDefinitionsFile(Configuration c, Map<String, String> map) throws MalformedURLException {
-        final String stringProperty = getStringProperty(DEFINITIONS_FILE, map, null);
-        URL configResource = findConfigResource(stringProperty);
+        final String stringProperty = getStringProperty(ENV_CONFIG_URL, map, null);
 
-        if (configResource == null) {
-            final File file = new File(stringProperty);
-            if (file.exists()) {
-                configResource = file.toURI().toURL();
+        if (stringProperty != null) {
+            URL configResource = findConfigResource(stringProperty);
+
+            if (configResource == null) {
+                final File file = new File(stringProperty);
+                if (file.exists()) {
+                    configResource = file.toURI().toURL();
+                }
             }
-        }
 
-        if (c instanceof DefaultConfiguration && configResource != null) {
-            DefaultConfiguration defaultConfiguration = (DefaultConfiguration) c;
-            defaultConfiguration.setDefinitionsFileURL(configResource);
+            if (c instanceof DefaultConfiguration && configResource != null) {
+                DefaultConfiguration defaultConfiguration = (DefaultConfiguration) c;
+                defaultConfiguration.setDefinitionsFileURL(configResource);
+            }
         }
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Change property `definitionsFile` to `env.config.url` in openshift.

#### Changes proposed in this pull request:

- We are not using definitionsFile after this change. User has to use `env.config.
- If no config file found, it should throw exception instead of failing to some other place. So it's easy for user to debug it.


