### PR TITLE
Implement an openshift specific resource locator, with improved fmp s…

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResourceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResourceLocator.java
@@ -4,7 +4,7 @@ import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 
 import java.net.URL;
 
-public class DefaultKubernetesResouceLocator implements KubernetesResourceLocator {
+public class DefaultKubernetesResourceLocator implements KubernetesResourceLocator {
 
     private static final String ROOT = "/";
     private static final String[] RESOURCE_NAMES = new String[] { "kubernetes", "META-INF/fabric8/kubernetes" };
@@ -12,8 +12,8 @@ public class DefaultKubernetesResouceLocator implements KubernetesResourceLocato
 
     @Override
     public URL locate() {
-        for (String suffix : ALLOWED_SUFFIXES) {
-            for (String resource : RESOURCE_NAMES) {
+        for (String suffix : getAllowedSuffixes()) {
+            for (String resource : getResourceNames()) {
                 URL candidate = getResource(resource + suffix);
                 if (candidate != null) {
                     return candidate;
@@ -21,6 +21,14 @@ public class DefaultKubernetesResouceLocator implements KubernetesResourceLocato
             }
         }
         return null;
+    }
+
+    protected String[] getResourceNames() {
+        return RESOURCE_NAMES;
+    }
+
+    protected String[] getAllowedSuffixes() {
+        return getAllowedSuffixes();
     }
 
     URL getResource(String resource) {

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/KubernetesResourceLocatorRegistar.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/KubernetesResourceLocatorRegistar.java
@@ -18,7 +18,7 @@ public class KubernetesResourceLocatorRegistar {
     InstanceProducer<KubernetesResourceLocator> kubernetesResourceLocator;
 
     public void install(@Observes(precedence = 100) Configuration configuration) {
-        kubernetesResourceLocator.set(serviceLoader.get().onlyOne(KubernetesResourceLocator.class, DefaultKubernetesResouceLocator.class));
+        kubernetesResourceLocator.set(serviceLoader.get().onlyOne(KubernetesResourceLocator.class, DefaultKubernetesResourceLocator.class));
 
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -2,11 +2,13 @@ package org.arquillian.cube.openshift.impl;
 
 import org.arquillian.cube.impl.client.enricher.StandaloneCubeUrlResourceProvider;
 import org.arquillian.cube.kubernetes.api.ConfigurationFactory;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory;
 import org.arquillian.cube.kubernetes.impl.enricher.KuberntesServiceUrlResourceProvider;
 import org.arquillian.cube.kubernetes.impl.install.DefaultResourceInstaller;
+import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.impl.namespace.DefaultNamespaceService;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftRegistrar;
 import org.arquillian.cube.openshift.impl.client.CubeOpenshiftConfigurationFactory;
@@ -15,6 +17,7 @@ import org.arquillian.cube.openshift.impl.client.OpenShiftSuiteLifecycleControll
 import org.arquillian.cube.openshift.impl.enricher.DeploymentConfigListResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.DeploymentConfigResourceProvider;
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
+import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
 import org.jboss.arquillian.core.spi.LoadableExtension;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
@@ -33,6 +36,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
                 .override(ConfigurationFactory.class, DefaultConfigurationFactory.class, CubeOpenshiftConfigurationFactory.class)
                 .override(ResourceProvider.class, StandaloneCubeUrlResourceProvider.class, KuberntesServiceUrlResourceProvider.class)
                 .override(ResourceInstaller.class, DefaultResourceInstaller.class, OpenshiftResourceInstaller.class)
+                .override(KubernetesResourceLocator.class, DefaultKubernetesResourceLocator.class, OpenshiftKubernetesResourceLocator.class)
                 .override(NamespaceService.class, DefaultNamespaceService.class, OpenshiftNamespaceService.class);
     }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
@@ -1,0 +1,26 @@
+package org.arquillian.cube.openshift.impl.locator;
+
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
+import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
+
+
+public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourceLocator {
+
+    private static final String[] RESOURCE_NAMES = new String[] { "openshift", "META-INF/fabric8/openshift", "kubernetes", "META-INF/fabric8/kubernetes" };
+    private static final String[] ALLOWED_SUFFIXES = {".json", ".yml", ".yaml"};
+
+    @Override
+    protected String[] getResourceNames() {
+        return RESOURCE_NAMES;
+    }
+
+    @Override
+    protected String[] getAllowedSuffixes() {
+        return ALLOWED_SUFFIXES;
+    }
+
+    @Override
+    public KubernetesResourceLocator toImmutable() {
+        return this;
+    }
+}


### PR DESCRIPTION
In #633 it was mentioned that the openshift extension doesn't work great with fmp. 

In most cases fmp generates an opnehsift and kubernetes yml descriptor. This pull request makes sure that when the openshift extension is used we look for openshift first and fallback to kubernetes if not openshift yml/json/etc was not found.