### PR TITLE
637

### DIFF
--- a/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/utils/Secrets.java
+++ b/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/utils/Secrets.java
@@ -13,7 +13,7 @@
  *  implied.  See the License for the specific language governing
  *  permissions and limitations under the License.
  */
-package org.arquillian.cube.kubernetes.impl.utils;
+package org.arquillian.cube.kubernetes.fabric8.impl.utils;
 
 import org.arquillian.cube.impl.util.Strings;
 

--- a/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/visitor/SecretsAndServiceAccountVisitor.java
+++ b/kubernetes/fabric8/src/main/java/org/arquillian/cube/kubernetes/fabric8/impl/visitor/SecretsAndServiceAccountVisitor.java
@@ -10,7 +10,7 @@ import io.fabric8.kubernetes.api.model.Secret;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.fabric8.impl.SecretKeys;
-import org.arquillian.cube.kubernetes.impl.utils.Secrets;
+import org.arquillian.cube.kubernetes.fabric8.impl.utils.Secrets;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/FeedbackProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/FeedbackProvider.java
@@ -1,0 +1,8 @@
+package org.arquillian.cube.kubernetes.api;
+
+import io.fabric8.kubernetes.api.model.HasMetadata;
+
+public interface FeedbackProvider extends WithToImmutable<FeedbackProvider> {
+
+    <T extends HasMetadata> void onResourceNotReady(T resource);
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesExtension.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesExtension.java
@@ -23,6 +23,7 @@ import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.kubernetes.api.AnnotationProvider;
 import org.arquillian.cube.kubernetes.api.ConfigurationFactory;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
 import org.arquillian.cube.kubernetes.api.LabelProvider;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
@@ -41,6 +42,8 @@ import org.arquillian.cube.kubernetes.impl.enricher.ReplicationControllerResourc
 import org.arquillian.cube.kubernetes.impl.enricher.ServiceListResourceProvider;
 import org.arquillian.cube.kubernetes.impl.enricher.ServiceResourceProvider;
 import org.arquillian.cube.kubernetes.impl.enricher.SessionResourceProvider;
+import org.arquillian.cube.kubernetes.impl.feedback.DefaultFeedbackProvider;
+import org.arquillian.cube.kubernetes.impl.feedback.FeedbackProviderServiceRegistar;
 import org.arquillian.cube.kubernetes.impl.install.DefaultResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.install.ResourceInstallerRegistar;
 import org.arquillian.cube.kubernetes.impl.label.DefaultLabelProvider;
@@ -72,6 +75,7 @@ public class KubernetesExtension implements LoadableExtension {
                 .observer(AnnotationProviderRegistar.class)
                 .observer(LoggerRegistar.class)
                 .observer(ResourceInstallerRegistar.class)
+                .observer(FeedbackProviderServiceRegistar.class)
                 .observer(getClientCreator())
                 .observer(SuiteListener.class)
                 .observer(TestListener.class)
@@ -82,6 +86,7 @@ public class KubernetesExtension implements LoadableExtension {
                 .service(LabelProvider.class, DefaultLabelProvider.class)
                 .service(DependencyResolver.class, ShrinkwrapResolver.class)
                 .service(AnnotationProvider.class, DefaultAnnotationProvider.class)
+                .service(FeedbackProvider.class, DefaultFeedbackProvider.class)
                 .service(Visitor.class, LoggingVisitor.class)
                 .service(Visitor.class, DockerRegistryVisitor.class)
                 .service(Visitor.class, ServiceAccountVisitor.class)

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManagerLifecycle.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManagerLifecycle.java
@@ -3,6 +3,7 @@ package org.arquillian.cube.kubernetes.impl;
 import org.arquillian.cube.kubernetes.api.AnnotationProvider;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
 import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
@@ -14,13 +15,9 @@ import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
-import org.jboss.arquillian.core.spi.ServiceLoader;
 
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.atomic.AtomicReference;
 
-import io.fabric8.kubernetes.api.builder.Visitor;
 import io.fabric8.kubernetes.client.KubernetesClient;
 
 public class SessionManagerLifecycle {
@@ -47,6 +44,9 @@ public class SessionManagerLifecycle {
     Instance<ResourceInstaller> resourceInstaller;
 
     @Inject
+    Instance<FeedbackProvider> feedbackProvider;
+
+    @Inject
     Event<AfterStart> afterStartEvent;
 
     AtomicReference<SessionManager> sessionManagerRef = new AtomicReference<>();
@@ -58,7 +58,7 @@ public class SessionManagerLifecycle {
                 annotationProvider.get(),
                 namespaceService.get().toImmutable(),
                 kubernetesResourceLocator.get().toImmutable(),
-                dependencyResolver.get().toImmutable(), resourceInstaller.get().toImmutable());
+                dependencyResolver.get().toImmutable(), resourceInstaller.get().toImmutable(), feedbackProvider.get().toImmutable());
 
         sessionManagerRef.set(sessionManager);
         sessionManager.start();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/feedback/DefaultFeedbackProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/feedback/DefaultFeedbackProvider.java
@@ -1,0 +1,232 @@
+package org.arquillian.cube.kubernetes.impl.feedback;
+
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
+import org.arquillian.cube.kubernetes.api.Logger;
+import org.arquillian.cube.kubernetes.api.WithToImmutable;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.Container;
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.Event;
+import io.fabric8.kubernetes.api.model.EventList;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.LabelSelectorRequirement;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.kubernetes.client.Watch;
+import io.fabric8.kubernetes.client.Watcher;
+import io.fabric8.kubernetes.client.dsl.FilterWatchListDeletable;
+
+public class DefaultFeedbackProvider implements FeedbackProvider {
+
+    protected FeedbackProvider delegate;
+
+    @Inject
+    protected Instance<KubernetesClient> client;
+
+    @Inject
+    protected Instance<Logger> logger;
+
+
+    @Override
+    public <T extends HasMetadata> void onResourceNotReady(T resource) {
+
+    }
+
+    @Override
+    public FeedbackProvider toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                delegate = new ImmutableFeedbackProvider(client.get(),
+                        logger.get().toImmutable());
+            }
+        }
+        return delegate;
+    }
+
+    public static class ImmutableFeedbackProvider implements FeedbackProvider, WithToImmutable<FeedbackProvider> {
+
+        @Inject
+        protected final KubernetesClient client;
+
+        @Inject
+        protected final Logger logger;
+
+        public ImmutableFeedbackProvider(KubernetesClient client, Logger logger) {
+            this.client = client;
+            this.logger = logger;
+        }
+
+
+        @Override
+        public <T extends HasMetadata> void onResourceNotReady(T resource) {
+            try {
+                PodList podList = podsOf(resource);
+                if (podList == null) {
+                    return;
+                }
+
+                for (Pod pod : podList.getItems()) {
+                    //That should only happen in tests.
+                    if (pod.getSpec() == null || pod.getSpec().getContainers() == null) {
+                        continue;
+                    }
+
+                    displayPodEvents(pod);
+
+                    for (Container container : pod.getSpec().getContainers()) {
+                        displayContainerLogs(pod, container);
+                    }
+                }
+            } catch (Throwable t) {
+                //ignore
+            }
+        }
+
+        protected void displayContainerLogs(Pod pod, Container container) {
+            try {
+                logger.warn("Tailing logs of matching pod: [" + pod.getMetadata().getName() + "], container: [" + container.getName() + "]");
+                logger.info(client.pods()
+                        .inNamespace(pod.getMetadata().getNamespace())
+                        .withName(pod.getMetadata().getName())
+                        .inContainer(container.getName())
+                        .tailingLines(100)
+                        .withPrettyOutput()
+                        .getLog());
+            } catch (Throwable t) {
+                logger.error("Failed to read logs, due to:" + t.getMessage());
+            } finally {
+                logger.warn("---");
+            }
+        }
+
+        protected void displayPodEvents(Pod pod) {
+            try {
+                Map<String, String> fields = new HashMap<>();
+                fields.put("involvedObject.uid", pod.getMetadata().getUid());
+                fields.put("involvedObject.name", pod.getMetadata().getName());
+                fields.put("involvedObject.namespace", pod.getMetadata().getNamespace());
+
+                EventList eventList = client.events().withFields(fields).list();
+                if (eventList == null) {
+                    return;
+                }
+                logger.warn("Events of matching pod: [" + pod.getMetadata().getName() + "]");
+                for (Event event : eventList.getItems()) {
+                    logger.info(String.format("%s\t\t%s", event.getReason(), event.getMessage()));
+                }
+            } catch (Throwable t) {
+                logger.error("Failed to read events, due to:" + t.getMessage());
+            } finally {
+                logger.warn("---");
+            }
+        }
+
+        /**
+         * Finds the pod that correspond to the specified resource.
+         * @param resource      The resource.
+         * @param <T>
+         * @return              The podList with the matching pods.
+         */
+        public <T extends HasMetadata> PodList podsOf(T resource) {
+            if (resource instanceof Pod) {
+                return new PodListBuilder().withItems((Pod) resource).build();
+            } else if (resource instanceof Endpoints) {
+                return podsOf(client.services().inNamespace(resource.getMetadata().getNamespace()).withName(resource.getMetadata().getName()).get());
+            } else if (resource instanceof Service) {
+                return client.pods().inNamespace(resource.getMetadata().getNamespace()).withLabels(((Service)resource).getSpec().getSelector()).list();
+            } else if (resource instanceof ReplicationController) {
+                return client.pods().inNamespace(resource.getMetadata().getNamespace()).withLabels(((ReplicationController)resource).getSpec().getSelector()).list();
+            } else if (resource instanceof ReplicaSet) {
+                return findMatching((ReplicaSet) resource);
+            } else if (resource instanceof Deployment){
+                return findMatching((Deployment) resource);
+            } else {
+                return new PodListBuilder().build();
+            }
+        }
+
+
+        /**
+         * Returns the {@link PodList} that match the specified {@link Deployment}.
+         * @param deployment    The {@link Deployment}
+         * @return
+         */
+        public PodList findMatching(Deployment deployment) {
+            FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister =  client.pods().inNamespace(deployment.getMetadata().getNamespace());
+            if (deployment.getSpec().getSelector().getMatchLabels() != null) {
+                podLister.withLabels(deployment.getSpec().getSelector().getMatchLabels());
+            }
+            if (deployment.getSpec().getSelector().getMatchExpressions() != null) {
+                for (LabelSelectorRequirement req : deployment.getSpec().getSelector().getMatchExpressions()) {
+                    switch (req.getOperator()) {
+                        case "In":
+                            podLister.withLabelIn(req.getKey(), req.getValues().toArray(new String[]{}));
+                            break;
+                        case "NotIn":
+                            podLister.withLabelNotIn(req.getKey(), req.getValues().toArray(new String[]{}));
+                            break;
+                        case "DoesNotExist":
+                            podLister.withoutLabel(req.getKey());
+                            break;
+                        case "Exists":
+                            podLister.withLabel(req.getKey());
+                            break;
+                    }
+                }
+            }
+            return podLister.list();
+        }
+
+        /**
+         * Returns the {@link PodList} that match the specified {@link ReplicaSet}.
+         * @param replicaSet    The {@link ReplicaSet}
+         * @return
+         */
+        public PodList findMatching(ReplicaSet replicaSet) {
+            FilterWatchListDeletable<Pod, PodList, Boolean, Watch, Watcher<Pod>> podLister =  client.pods().inNamespace(replicaSet.getMetadata().getNamespace());
+            if (replicaSet.getSpec().getSelector().getMatchLabels() != null) {
+                podLister.withLabels(replicaSet.getSpec().getSelector().getMatchLabels());
+            }
+            if (replicaSet.getSpec().getSelector().getMatchExpressions() != null) {
+                for (LabelSelectorRequirement req : replicaSet.getSpec().getSelector().getMatchExpressions()) {
+                    switch (req.getOperator()) {
+                        case "In":
+                            podLister.withLabelIn(req.getKey(), req.getValues().toArray(new String[]{}));
+                            break;
+                        case "NotIn":
+                            podLister.withLabelNotIn(req.getKey(), req.getValues().toArray(new String[]{}));
+                            break;
+                        case "DoesNotExist":
+                            podLister.withoutLabel(req.getKey());
+                            break;
+                        case "Exists":
+                            podLister.withLabel(req.getKey());
+                            break;
+                    }
+                }
+            }
+            return podLister.list();
+        }
+
+
+        @Override
+        public FeedbackProvider toImmutable() {
+            return this;
+        }
+    }
+
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/feedback/FeedbackProviderServiceRegistar.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/feedback/FeedbackProviderServiceRegistar.java
@@ -1,0 +1,24 @@
+package org.arquillian.cube.kubernetes.impl.feedback;
+
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.spi.ServiceLoader;
+
+public class FeedbackProviderServiceRegistar {
+
+    @Inject
+    private Instance<ServiceLoader> serviceLoader;
+
+    @Inject @ApplicationScoped
+    InstanceProducer<FeedbackProvider> namespaceService;
+
+    public void install(@Observes(precedence = 100) Configuration configuration) {
+        namespaceService.set(serviceLoader.get().onlyOne(FeedbackProvider.class, DefaultFeedbackProvider.class));
+
+    }
+}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -2,11 +2,13 @@ package org.arquillian.cube.openshift.impl;
 
 import org.arquillian.cube.impl.client.enricher.StandaloneCubeUrlResourceProvider;
 import org.arquillian.cube.kubernetes.api.ConfigurationFactory;
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
 import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory;
 import org.arquillian.cube.kubernetes.impl.enricher.KuberntesServiceUrlResourceProvider;
+import org.arquillian.cube.kubernetes.impl.feedback.DefaultFeedbackProvider;
 import org.arquillian.cube.kubernetes.impl.install.DefaultResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.impl.namespace.DefaultNamespaceService;
@@ -16,6 +18,7 @@ import org.arquillian.cube.openshift.impl.client.OpenShiftClientCreator;
 import org.arquillian.cube.openshift.impl.client.OpenShiftSuiteLifecycleController;
 import org.arquillian.cube.openshift.impl.enricher.DeploymentConfigListResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.DeploymentConfigResourceProvider;
+import org.arquillian.cube.openshift.impl.feedback.OpenshiftFeedbackProvider;
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
 import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
@@ -36,6 +39,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
                 .override(ConfigurationFactory.class, DefaultConfigurationFactory.class, CubeOpenshiftConfigurationFactory.class)
                 .override(ResourceProvider.class, StandaloneCubeUrlResourceProvider.class, KuberntesServiceUrlResourceProvider.class)
                 .override(ResourceInstaller.class, DefaultResourceInstaller.class, OpenshiftResourceInstaller.class)
+                .override(FeedbackProvider.class, DefaultFeedbackProvider.class, OpenshiftFeedbackProvider.class)
                 .override(KubernetesResourceLocator.class, DefaultKubernetesResourceLocator.class, OpenshiftKubernetesResourceLocator.class)
                 .override(NamespaceService.class, DefaultNamespaceService.class, OpenshiftNamespaceService.class);
     }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/feedback/OpenshiftFeedbackProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/feedback/OpenshiftFeedbackProvider.java
@@ -1,0 +1,86 @@
+package org.arquillian.cube.openshift.impl.feedback;
+
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
+import org.arquillian.cube.kubernetes.api.Logger;
+import org.arquillian.cube.kubernetes.api.WithToImmutable;
+import org.arquillian.cube.kubernetes.impl.feedback.DefaultFeedbackProvider;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+
+import io.fabric8.kubernetes.api.model.Endpoints;
+import io.fabric8.kubernetes.api.model.HasMetadata;
+import io.fabric8.kubernetes.api.model.Pod;
+import io.fabric8.kubernetes.api.model.PodList;
+import io.fabric8.kubernetes.api.model.PodListBuilder;
+import io.fabric8.kubernetes.api.model.ReplicationController;
+import io.fabric8.kubernetes.api.model.Service;
+import io.fabric8.kubernetes.api.model.extensions.Deployment;
+import io.fabric8.kubernetes.api.model.extensions.ReplicaSet;
+import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.DeploymentConfig;
+
+public class OpenshiftFeedbackProvider implements FeedbackProvider {
+
+    protected FeedbackProvider delegate;
+
+    @Inject
+    protected Instance<KubernetesClient> client;
+
+    @Inject
+    protected Instance<Logger> logger;
+
+
+    @Override
+    public <T extends HasMetadata> void onResourceNotReady(T resource) {
+
+    }
+
+    @Override
+    public FeedbackProvider toImmutable() {
+        if (delegate != null) {
+            return delegate;
+        }
+        synchronized (this) {
+            if (delegate == null) {
+                delegate = new ImmutableFeedbackProvider(client.get(),
+                        logger.get().toImmutable());
+            }
+        }
+        return delegate;
+    }
+
+    public static class ImmutableFeedbackProvider extends DefaultFeedbackProvider.ImmutableFeedbackProvider implements FeedbackProvider, WithToImmutable<FeedbackProvider> {
+
+        public ImmutableFeedbackProvider(KubernetesClient client, Logger logger) {
+            super(client, logger);
+        }
+
+
+        public <T extends HasMetadata> PodList podsOf(T resource) {
+            if (resource instanceof Pod) {
+                return new PodListBuilder().withItems((Pod) resource).build();
+            } else if (resource instanceof Endpoints) {
+                return podsOf(client.services().inNamespace(resource.getMetadata().getNamespace()).withName(resource.getMetadata().getName()).get());
+            } else if (resource instanceof Service) {
+                return client.pods().inNamespace(resource.getMetadata().getNamespace()).withLabels(((Service)resource).getSpec().getSelector()).list();
+            } else if (resource instanceof ReplicationController) {
+                return client.pods().inNamespace(resource.getMetadata().getNamespace()).withLabels(((ReplicationController)resource).getSpec().getSelector()).list();
+            } else if (resource instanceof ReplicaSet) {
+                return findMatching((ReplicaSet) resource);
+            } else if (resource instanceof Deployment){
+                return findMatching((Deployment) resource);
+            } else if (resource instanceof DeploymentConfig) {
+                return client.pods().inNamespace(resource.getMetadata().getName()).withLabel("deploymentconfig",
+                        resource.getMetadata().getName()).list();
+            } else {
+                return new PodListBuilder().build();
+            }
+        }
+
+        @Override
+        public FeedbackProvider toImmutable() {
+            return this;
+        }
+    }
+
+}


### PR DESCRIPTION
This pull request add the notion of FeedbackProvider which is responsible for providing feedback when `waitUntilReady` timesout. 

The feedback includes logs and events of the pods that correspond to resource that timedout (e.g. pods of deploymentconfig or pods replicationcontroller and so on).