### PR TITLE
Namespace destroy and cleanup shouldn't be mutually exclusive, as cle…

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -53,8 +53,16 @@ public class DefaultConfiguration implements Configuration {
         try {
             String sessionId = UUID.randomUUID().toString();
             String namespace = getStringProperty(NAMESPACE_TO_USE, map, null);
+
+            //When a namespace is provided we want to cleanup our stuff...
+            // ... without destroying pre-existing stuff.
+            Boolean shouldCleanupNamespace = true;
+            Boolean shouldDestroyNamespace = false;
             if (Strings.isNullOrEmpty(namespace)) {
+                //When we generate a namespace ourselves we to completely destroy it, so cleaning makes no sense.
                 namespace = getStringProperty(NAMESPACE_PREFIX, map, "itest") + "-" + sessionId;
+                shouldDestroyNamespace = true;
+                shouldCleanupNamespace = false;
             }
             return new DefaultConfigurationBuilder()
                     .withSessionId(sessionId)
@@ -66,11 +74,11 @@ public class DefaultConfiguration implements Configuration {
                     .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
                     .withEnvironmentDependencies(asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), " ")))
                     .withNamespaceLazyCreateEnabled(getBooleanProperty(NAMESPACE_LAZY_CREATE_ENABLED, map, DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED))
-                    .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, namespace.contains(sessionId)))
+                    .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, shouldCleanupNamespace))
                     .withNamespaceCleanupConfirmationEnabled(getBooleanProperty(NAMESPACE_CLEANUP_CONFIRM_ENABLED, map, false))
                     .withNamespaceCleanupTimeout(getLongProperty(NAMESPACE_CLEANUP_TIMEOUT, map, DEFAULT_NAMESPACE_CLEANUP_TIMEOUT))
 
-                    .withNamespaceDestroyEnabled(getBooleanProperty(NAMESPACE_DESTROY_ENABLED, map, namespace.contains(sessionId)))
+                    .withNamespaceDestroyEnabled(getBooleanProperty(NAMESPACE_DESTROY_ENABLED, map, shouldDestroyNamespace))
                     .withNamespaceDestroyConfirmationEnabled(getBooleanProperty(NAMESPACE_DESTROY_CONFIRM_ENABLED, map, false))
                     .withNamespaceDestroyTimeout(getLongProperty(NAMESPACE_DESTROY_TIMEOUT, map, DEFAULT_NAMESPACE_DESTROY_TIMEOUT))
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -194,7 +194,15 @@ public class SessionManager implements SessionCreatedListener {
         try {
             if (configuration.isNamespaceCleanupEnabled()) {
                 resourceInstaller.uninstall(resources);
-            } else if (configuration.isNamespaceDestroyEnabled()) {
+            }
+
+            /*
+             * While it does make perfect sense to either clean or destroy,
+             * in some cases clean is implicit-ly defined. That can implict-ly disable namespace destruction.
+             * So, its more clean if we check of both conditions (double if vs if/else).
+             *
+             */
+            if (configuration.isNamespaceDestroyEnabled()) {
                 namespaceService.destroy(namespace);
             } else {
                 try {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -108,8 +108,16 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     public static CubeOpenShiftConfiguration fromMap(Map<String , String> map) {
         String sessionId = UUID.randomUUID().toString();
         String namespace = getStringProperty(NAMESPACE_TO_USE, map, null);
+
+        //When a namespace is provided we want to cleanup our stuff...
+        // ... without destroying pre-existing stuff.
+        Boolean shouldCleanupNamespace = true;
+        Boolean shouldDestroyNamespace = false;
         if (Strings.isNullOrEmpty(namespace)) {
+            //When we generate a namespace ourselves we to completely destroy it, so cleaning makes no sense.
             namespace = getStringProperty(NAMESPACE_PREFIX, map, "itest") + "-" + sessionId;
+            shouldDestroyNamespace = true;
+            shouldCleanupNamespace = false;
         }
         try {
         return new CubeOpenShiftConfigurationBuilder()
@@ -122,11 +130,11 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
                 .withEnvironmentDependencies(asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), " ")))
                 .withNamespaceLazyCreateEnabled(getBooleanProperty(NAMESPACE_LAZY_CREATE_ENABLED, map, DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED))
-                .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, namespace.contains(sessionId)))
+                .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, shouldCleanupNamespace))
                 .withNamespaceCleanupConfirmationEnabled(getBooleanProperty(NAMESPACE_CLEANUP_CONFIRM_ENABLED, map, false))
                 .withNamespaceCleanupTimeout(getLongProperty(NAMESPACE_CLEANUP_TIMEOUT, map, DEFAULT_NAMESPACE_CLEANUP_TIMEOUT))
 
-                .withNamespaceDestroyEnabled(getBooleanProperty(NAMESPACE_DESTROY_ENABLED, map, namespace.contains(sessionId)))
+                .withNamespaceDestroyEnabled(getBooleanProperty(NAMESPACE_DESTROY_ENABLED, map, shouldDestroyNamespace))
                 .withNamespaceDestroyConfirmationEnabled(getBooleanProperty(NAMESPACE_DESTROY_CONFIRM_ENABLED, map, false))
                 .withNamespaceDestroyTimeout(getLongProperty(NAMESPACE_DESTROY_TIMEOUT, map, DEFAULT_NAMESPACE_DESTROY_TIMEOUT))
 


### PR DESCRIPTION
In some cases the namespace is not deleted, but its not obvious why.

This happens that we only delete a namespace when we namespace cleanup is disabled. But namespace cleanup can be disabled for no obvious reasons (based on whether we specify an existing namespace or not). 
