### PR TITLE
Added condition to cover also a possible specification of the mount permission (i.e. /source:/target:ro)

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -1065,7 +1065,7 @@ public class DockerClientExecutor {
         for (String volume : volumesList) {
             String[] volumeSection = volume.split(":");
 
-            if (volumeSection.length == 2) {
+            if (volumeSection.length == 2 || volumeSection.length == 3) {
                 volumes[i] = new Volume(volumeSection[1]);
             } else {
                 volumes[i] = new Volume(volumeSection[0]);


### PR DESCRIPTION
Hi, 

thanks for adding the volume mount fix so quickly. This small change covers also a possible specification of the mount permission (i.e. /source:/target:ro) and ensures that in that case also the volume is taken from element 1 of the split result.

Best regards.