### PR TITLE
Fixes #660. Gracefully handle ExecutionException in DockerRequirement

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerMachineRequirement.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerMachineRequirement.java
@@ -8,7 +8,15 @@ import org.arquillian.spacelift.execution.ExecutionException;
 
 public class DockerMachineRequirement implements Requirement<RequiresDockerMachine> {
 
-    private final CommandLineExecutor commandLineExecutor = new CommandLineExecutor();
+    private final CommandLineExecutor commandLineExecutor;
+
+    public DockerMachineRequirement() {
+        commandLineExecutor = new CommandLineExecutor();
+    }
+
+    public DockerMachineRequirement(CommandLineExecutor commandLineExecutor) {
+        this.commandLineExecutor = commandLineExecutor;
+    }
 
     @Override
     public void check(RequiresDockerMachine context) throws UnsatisfiedRequirementException {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerRequirement.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerRequirement.java
@@ -1,11 +1,13 @@
 package org.arquillian.cube.docker.impl.requirement;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import com.github.dockerjava.api.DockerClient;
 import com.github.dockerjava.api.model.Version;
 import com.github.dockerjava.core.DockerClientBuilder;
 import com.google.common.base.Strings;
-import java.util.HashMap;
-import java.util.Map;
+
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfigurationResolver;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
@@ -15,15 +17,26 @@ import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.spi.requirement.Requirement;
 import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
+import org.arquillian.spacelift.execution.ExecutionException;
 
 public class DockerRequirement implements Requirement<RequiresDocker> {
 
-    private final CommandLineExecutor commandLineExecutor = new CommandLineExecutor();
-    private final CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
-        new DockerMachine(commandLineExecutor),
-        new Boot2Docker(commandLineExecutor),
-        new OperatingSystemResolver().currentOperatingSystem().getFamily()
-    );
+    private final CommandLineExecutor commandLineExecutor;
+    private final CubeDockerConfigurationResolver resolver;
+
+    public DockerRequirement() {
+        this.commandLineExecutor = new CommandLineExecutor();
+        this.resolver = new CubeDockerConfigurationResolver(new Top(),
+            new DockerMachine(commandLineExecutor),
+            new Boot2Docker(commandLineExecutor),
+            new OperatingSystemResolver().currentOperatingSystem().getFamily()
+        );
+    }
+
+    public DockerRequirement(CommandLineExecutor commandLineExecutor, CubeDockerConfigurationResolver resolver) {
+        this.commandLineExecutor = commandLineExecutor;
+        this.resolver = resolver;
+    }
 
     /**
      * @param serverUrl
@@ -52,12 +65,18 @@ public class DockerRequirement implements Requirement<RequiresDocker> {
 
     @Override
     public void check(RequiresDocker context) throws UnsatisfiedRequirementException {
-        Map<String, String> config = resolver.resolve(new HashMap<String, String>());
-        String serverUrl = config.get(CubeDockerConfiguration.DOCKER_URI);
-        if (Strings.isNullOrEmpty(serverUrl)) {
-            throw new UnsatisfiedRequirementException("Could not resolve the docker server url.");
-        } else if (!isDockerRunning(serverUrl)) {
-            throw new UnsatisfiedRequirementException("No server is running on url:[" + serverUrl + "].");
+        try {
+            Map<String, String> config = resolver.resolve(new HashMap<String, String>());
+            String serverUrl = config.get(CubeDockerConfiguration.DOCKER_URI);
+            if (Strings.isNullOrEmpty(serverUrl)) {
+                throw new UnsatisfiedRequirementException("Could not resolve the docker server url.");
+            } else if (!isDockerRunning(serverUrl)) {
+                throw new UnsatisfiedRequirementException("No server is running on url:[" + serverUrl + "].");
+            }
+        } catch (ExecutionException e) {
+            throw new UnsatisfiedRequirementException("Cannot execute docker command.");
         }
     }
+
+
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerMachineRequirementTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerMachineRequirementTest.java
@@ -1,0 +1,76 @@
+package org.arquillian.cube.docker.impl.requirement;
+
+import java.lang.annotation.Annotation;
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
+import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
+import org.arquillian.spacelift.execution.ExecutionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DockerMachineRequirementTest {
+
+    @Mock
+    CommandLineExecutor commandLineExecutor;
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void estDockerMachineRequirementCheckWhenExecutionExceptionThrown() throws UnsatisfiedRequirementException {
+        when(commandLineExecutor.execCommandAsArray(anyVararg())).thenThrow(ExecutionException.class);
+
+        DockerMachineRequirement dockerMachineRequirement = new DockerMachineRequirement(commandLineExecutor);
+        dockerMachineRequirement.check(createContext("testing"));
+    }
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerMachineRequirementCheckNoMatchingNameFound() throws Exception {
+        when(commandLineExecutor.execCommandAsArray(anyVararg())).thenReturn(Collections.emptyList());
+
+        DockerMachineRequirement dockerMachineRequirement = new DockerMachineRequirement(commandLineExecutor);
+        dockerMachineRequirement.check(createContext("testing"));
+    }
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerMachineRequirementCheckNoMachineFound() throws Exception {
+        when(commandLineExecutor.execCommandAsArray(anyVararg())).thenReturn(Arrays.asList(new String[] {"foo", "bar"}));
+
+        DockerMachineRequirement dockerMachineRequirement = new DockerMachineRequirement(commandLineExecutor);
+        dockerMachineRequirement.check(createContext(""));
+    }
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerMachineRequirementCheckNoMatchingNameNotMatched() throws Exception {
+        when(commandLineExecutor.execCommandAsArray(anyVararg())).thenReturn(Arrays.asList(new String[] {"my-docker-machine"}));
+
+        DockerMachineRequirement dockerMachineRequirement = new DockerMachineRequirement(commandLineExecutor);
+        dockerMachineRequirement.check(createContext("testing"));
+    }
+
+    @Test
+    public void testDockerMachineRequirementCheckNoMatchingNameMatched() throws Exception {
+        when(commandLineExecutor.execCommandAsArray(anyVararg())).thenReturn(Arrays.asList(new String[] {"testing"}));
+
+        DockerMachineRequirement dockerMachineRequirement = new DockerMachineRequirement(commandLineExecutor);
+        dockerMachineRequirement.check(createContext("testing"));
+    }
+
+    private RequiresDockerMachine createContext(String machineName) {
+        return new RequiresDockerMachine() {
+            @Override
+            public Class<? extends Annotation> annotationType() {
+                return RequiresDockerMachine.class;
+            }
+
+            @Override
+            public String name() {
+                return machineName;
+            }
+        };
+    }
+}

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerRequirementTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerRequirementTest.java
@@ -1,0 +1,140 @@
+package org.arquillian.cube.docker.impl.requirement;
+
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.io.PrintWriter;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
+import org.arquillian.cube.docker.impl.client.CubeDockerConfigurationResolver;
+import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
+import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
+import org.arquillian.spacelift.execution.ExecutionException;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DockerRequirementTest {
+
+    @Mock
+    CubeDockerConfigurationResolver configResolver;
+
+    @Mock
+    CommandLineExecutor commandLineExecutor;
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerRequirementCheckWhenExecutionExceptionThrown() throws UnsatisfiedRequirementException {
+        when(configResolver.resolve(anyMap())).thenThrow(ExecutionException.class);
+
+        DockerRequirement requirement = new DockerRequirement(commandLineExecutor, configResolver);
+        requirement.check(null);
+    }
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerRequirementCheckWhenDockerURLIsNull() throws UnsatisfiedRequirementException {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(CubeDockerConfiguration.DOCKER_URI, null);
+
+        when(configResolver.resolve(anyMap())).thenReturn(configMap);
+
+        DockerRequirement requirement = new DockerRequirement(commandLineExecutor, configResolver);
+        requirement.check(null);
+    }
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerRequirementCheckWhenDockerURLIsEmpty() throws UnsatisfiedRequirementException {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(CubeDockerConfiguration.DOCKER_URI, "");
+
+        when(configResolver.resolve(anyMap())).thenReturn(configMap);
+
+        DockerRequirement requirement = new DockerRequirement(commandLineExecutor, configResolver);
+        requirement.check(null);
+    }
+
+    @Test(expected = UnsatisfiedRequirementException.class)
+    public void testDockerRequirementCheckWhenDockerURLIsInvalid() throws UnsatisfiedRequirementException {
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(CubeDockerConfiguration.DOCKER_URI, "tcp://nonexistanthostname:9999");
+
+        when(configResolver.resolve(anyMap())).thenReturn(configMap);
+
+        DockerRequirement requirement = new DockerRequirement(commandLineExecutor, configResolver);
+        requirement.check(null);
+    }
+
+    @Test
+    public void testDockerRequirementCheckDockerURLIsValid() throws Exception {
+        FakeDockerServer server = new FakeDockerServer();
+
+        Map<String, String> configMap = new HashMap<>();
+        configMap.put(CubeDockerConfiguration.DOCKER_URI, server.getConnectionString());
+
+        when(configResolver.resolve(anyMap())).thenReturn(configMap);
+
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        executorService.submit(server);
+
+        try {
+            DockerRequirement requirement = new DockerRequirement(commandLineExecutor, configResolver);
+            requirement.check(null);
+        } finally {
+            executorService.shutdownNow();
+        }
+    }
+
+    private class FakeDockerServer implements Runnable {
+
+        private final ServerSocket serverSocket;
+
+        private FakeDockerServer() throws IOException {
+            serverSocket = new ServerSocket(0);
+        }
+
+        public String getConnectionString() {
+            return "tcp://" + serverSocket.getInetAddress().getHostName() + ":" + serverSocket.getLocalPort();
+        }
+
+        @Override
+        public void run() {
+            PrintWriter writer = null;
+            Socket socket = null;
+            try {
+                socket = serverSocket.accept();
+                writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream()));
+
+                String versionJSON = "{\"Client\":{\"Version\":\"0.0.0\",\"ApiVersion\":\"0.00\"}}";
+                writer.println("HTTP/1.1 200 OK");
+                writer.println("Content-Type: application/json");
+                writer.println("Content-Length: " + versionJSON.length());
+                writer.println();
+                writer.println(versionJSON);
+            } catch (IOException e) {
+                writer.println("HTTP/1.1 500");
+                writer.println();
+            } finally {
+                if (writer != null) {
+                    writer.close();
+                }
+
+                if (socket != null) {
+                    try {
+                        socket.close();
+                    } catch (IOException e) {
+                        return;
+                    }
+                }
+            }
+            return;
+        }
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

Catching `org.arquillian.spacelift.execution.ExecutionException` in `DockerRequirement` so that a test can be skipped if none of the Docker, Docker Machine or Boot2Docker executables can be found on the host. 

Currently the uncaught exception causes any `@RequiresDocker` annotated tests to fail.