### PR TITLE
Adds sleep annotation

### DIFF
--- a/api/src/main/java/org/arquillian/cube/Sleep.java
+++ b/api/src/main/java/org/arquillian/cube/Sleep.java
@@ -1,0 +1,21 @@
+package org.arquillian.cube;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.ElementType.TYPE;
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+@Target({TYPE})
+@Retention(RUNTIME)
+@Documented
+public @interface Sleep {
+
+    /**
+     * Sets the sleep time. By default if nothing is specified the value is considered in milliseconds, but you can also use a timespan form such as 1m30s
+     * @return Sleeping time.
+     */
+    String value();
+
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepBeforeClassObserver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/SleepBeforeClassObserver.java
@@ -1,0 +1,33 @@
+package org.arquillian.cube.docker.impl.await;
+
+import org.arquillian.cube.Sleep;
+import org.arquillian.cube.impl.util.ReflectionUtil;
+import org.arquillian.cube.impl.util.Timespan;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.test.spi.TestClass;
+import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
+
+import java.util.concurrent.TimeUnit;
+
+public class SleepBeforeClassObserver {
+
+    public void executeSleep(@Observes BeforeClass beforeClass) {
+        final TestClass testClass = beforeClass.getTestClass();
+        if (ReflectionUtil.isClassWithAnnotation(testClass.getJavaClass(), Sleep.class)) {
+
+            final Sleep sleep = testClass.getAnnotation(Sleep.class);
+            executeSleep(sleep);
+
+        }
+    }
+
+    private void executeSleep(Sleep sleep) {
+        final long milliseconds = Timespan.toMilliseconds(sleep.value());
+        try {
+            TimeUnit.MILLISECONDS.sleep(milliseconds);
+        } catch (InterruptedException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.docker.impl.client;
 
 import org.arquillian.cube.docker.impl.await.HealthCheckBeforeClassObserver;
+import org.arquillian.cube.docker.impl.await.SleepBeforeClassObserver;
 import org.arquillian.cube.docker.impl.client.container.DockerServerIPConfigurator;
 import org.arquillian.cube.docker.impl.client.containerobject.AfterClassContainerObjectObserver;
 import org.arquillian.cube.docker.impl.client.containerobject.ContainerObjectFactoryProvider;
@@ -32,7 +33,8 @@ public class CubeDockerExtension implements LoadableExtension {
             .observer(NetworkLifecycleController.class)
             .observer(ContainerObjectFactoryRegistrar.class)
             .observer(DockerImageController.class)
-            .observer(HealthCheckBeforeClassObserver.class);
+            .observer(HealthCheckBeforeClassObserver.class)
+            .observer(SleepBeforeClassObserver.class);
 
         builder.service(ResourceProvider.class, CubeResourceProvider.class);
         builder.service(ResourceProvider.class, ContainerObjectFactoryProvider.class);

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -424,6 +424,15 @@ TIP: Time attributes like `timeout` and `interval` uses `docker-compose` duratio
 
 TIP: If `containerName` is set to null `port` attribute is used, otherwise `port` is considered an exposed port and it is resolved against the given container.
 
+==== `@Sleep` annotation
+
+Sometimes you need to sleep your execution for some specific amount of time and you have no way to do it using an http health check.
+In this situations a sleep might do the work.
+
+To avoid this problem and continue using default `await` strategy you can annotate your test class with `@Sleep` annotation which receives as value an string that represents a timespan.
+
+By default the time specified is in milliseconds so annotating the test class with `@Sleep("1000")` makes your test class sleeps 1 second before executing all test methods.
+You can also use the timespan format and write something like `@Sleep("1m30s")` which makes your test class sleeps for one minute and a half before executing all test methods.
 
 === Inferring exposedPorts from portBinding
 


### PR DESCRIPTION
#### Short description of what this resolves:

Adds `@sleep` annotation to pause a test the specified timespan before executing all the test methods.


#### Changes proposed in this pull request:

-
-
-


**Fixes**: #681 
