### PR TITLE
Adds shortcuts for http and https await

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/HttpAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/HttpAwaitStrategy.java
@@ -18,7 +18,7 @@ public class HttpAwaitStrategy extends SleepingAwaitStrategyBase {
     public static final String TAG = "http";
 
     private static final String REGEXP_PREFIX = "regexp:";
-    private static final String DOCKER_HOST = "dockerHost";
+    public static final String DOCKER_HOST = "dockerHost";
     private static final int DEFAULT_POLL_ITERATIONS = 10;
 
     private int pollIterations = DEFAULT_POLL_ITERATIONS;

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/AwaitBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/AwaitBuilder.java
@@ -1,7 +1,9 @@
 package org.arquillian.cube.docker.impl.client.containerobject.dsl;
 
+import org.arquillian.cube.docker.impl.await.HttpAwaitStrategy;
 import org.arquillian.cube.docker.impl.client.config.Await;
 
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +28,26 @@ public class AwaitBuilder {
         await.setStdOut(true);
 
         return await;
+    }
+
+    public static HttpAwaitBuilder httpAwait(String path, int port) {
+        URL url = createUrl("http", path, port);
+        return httpAwait(url, null);
+    }
+
+    public static HttpAwaitBuilder httpsAwait(String path, int port) {
+        URL url = createUrl("https", path, port);
+        return httpAwait(url, null);
+    }
+
+    private static URL createUrl(String protocol, String path, int port) {
+        URL url;
+        try {
+            url = new URL(protocol, HttpAwaitStrategy.DOCKER_HOST, port, path);
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+        return url;
     }
 
     /**


### PR DESCRIPTION
#### Short description of what this resolves:

Adds shortcuts for http and https await

#### Changes proposed in this pull request:

- Added `httpAwait` and `httpsAwait` on `AwaitBuilder`


**Fixes**: #683 
