### PR TITLE
Adds extra operations to execute command and get log from container

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/Container.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/Container.java
@@ -1,13 +1,21 @@
 package org.arquillian.cube.docker.impl.client.containerobject.dsl;
 
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.model.Frame;
+import com.github.dockerjava.core.command.LogContainerResultCallback;
 import org.arquillian.cube.HostIpContext;
 import org.arquillian.cube.containerobject.ConnectionMode;
 import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeOutput;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.arquillian.cube.spi.metadata.HasPortBindings;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * Base class representing a container.
@@ -19,6 +27,9 @@ public class Container {
 
     @Inject
     Instance<CubeRegistry> cubeRegistryInstance;
+
+    @Inject
+    Instance<DockerClientExecutor> dockerClientExecutorInstance;
 
     private String containerName;
     private CubeContainer cubeContainer;
@@ -61,6 +72,23 @@ public class Container {
      */
     public int getBindPort(int exposedPort) {
         return getBindingPort(this.containerName, exposedPort);
+    }
+
+    /**
+     * Executes given command inside this container.
+     * @param commands to execute.
+     * @return Output of the execution.
+     */
+    public CubeOutput exec(String...commands) {
+        return this.dockerClientExecutorInstance.get().execStart(this.containerName, commands);
+    }
+
+    /**
+     * Gets current logs of this container.
+     * @return Current logs.
+     */
+    public String getLog() {
+        return this.dockerClientExecutorInstance.get().containerLog(this.containerName);
     }
 
     private int getBindingPort(String cubeId, int exposedPort) {

--- a/docker/ftest-docker-junit-rule/src/test/java/org/arquillian/cube/docker/junit/rule/RedisTest.java
+++ b/docker/ftest-docker-junit-rule/src/test/java/org/arquillian/cube/docker/junit/rule/RedisTest.java
@@ -38,7 +38,7 @@ public class RedisTest {
     }
 
     @Test
-    public void should_execute_ls() {
+    public void should_execute_uname() {
         assertThat(redis.exec("sh", "-c", "uname").getStandard())
             .isNotBlank()
             .isEqualToIgnoringWhitespace("Linux");

--- a/docker/ftest-docker-junit-rule/src/test/java/org/arquillian/cube/docker/junit/rule/RedisTest.java
+++ b/docker/ftest-docker-junit-rule/src/test/java/org/arquillian/cube/docker/junit/rule/RedisTest.java
@@ -2,16 +2,21 @@ package org.arquillian.cube.docker.junit.rule;
 
 import org.arquillian.cube.docker.impl.requirement.RequiresDockerMachine;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.arquillian.cube.requirement.RequirementRule;
+import org.arquillian.cube.spi.CubeOutput;
 import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import redis.clients.jedis.Jedis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@RunWith(ArquillianConditionalRunner.class)
 @RequiresDockerMachine(name = "dev")
 public class RedisTest {
+
+    @Rule
+    public RequirementRule requirementRule = new RequirementRule();
 
     @ClassRule
     public static ContainerDslRule redis = new ContainerDslRule("redis:3.2.6")
@@ -23,6 +28,21 @@ public class RedisTest {
         jedis.set("foo", "bar");
 
         assertThat(jedis.get("foo")).isEqualTo("bar");
+    }
+
+    @Test
+    public void should_get_logs() {
+        assertThat(redis.getLog())
+            .isNotBlank()
+            .contains("Redis");
+    }
+
+    @Test
+    public void should_execute_ls() {
+        assertThat(redis.exec("sh", "-c", "uname").getStandard())
+            .isNotBlank()
+            .isEqualToIgnoringWhitespace("Linux");
+
     }
 
 }

--- a/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/rule/ContainerDslRule.java
+++ b/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/rule/ContainerDslRule.java
@@ -15,6 +15,7 @@ import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.impl.model.LocalCubeRegistry;
+import org.arquillian.cube.spi.CubeOutput;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.arquillian.cube.spi.event.lifecycle.CubeLifecyleEvent;
 import org.jboss.arquillian.core.api.Event;
@@ -158,6 +159,14 @@ public class ContainerDslRule implements TestRule {
         return this.container.getBindPort(exposedPort);
     }
 
+    public String getLog() {
+        return this.container.getLog();
+    }
+
+    public CubeOutput exec(String... commands) {
+        return this.container.exec(commands);
+    }
+
     @Override
     public Statement apply(Statement base, Description description) {
         return new Statement() {
@@ -172,6 +181,12 @@ public class ContainerDslRule implements TestRule {
 
                 if (hostIpContextField.isPresent()) {
                     Reflections.injectObject(container, hostIpContextField.get(), (Instance) () -> new HostIpContext(dockerClientExecutor.getDockerServerIp()));
+                }
+
+                final Optional<Field> dockerClientExecutorField = Reflections.findFieldByGenericType(Container.class, Instance.class, DockerClientExecutor.class);
+
+                if (dockerClientExecutorField.isPresent()) {
+                    Reflections.injectObject(container, dockerClientExecutorField.get(), (Instance) () -> dockerClientExecutor);
                 }
 
                 DockerCube dockerCube = new DockerCube(container.getContainerName(), container.getCubeContainer(), dockerClientExecutor);


### PR DESCRIPTION
#### Short description of what this resolves:

Adds `getLog` and `exec` methods in container object dsl.

**Fixes**: #685 
