### PR TITLE
Use current namespace and fix Openshift resource locator

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -51,6 +51,7 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 | kubernetes.master                   | URL            | Any | The URL to the Kubernetes master                                                 |
 | kubernetes.domain                   | String         | OSE | Domain to use for creating routes for services                                   |
 | docker.registry                     | String         | Any | The docker registry                                                              |
+| namespace.use.current               | Boolean (false)| Any | Don't generate a namespace use the current instead                               |
 | namespace.use.existing              | String         | Any | Don't generate a namespace use the specified one instead                         |
 | namespace.prefix                    | String (itest) | Any | If you don't specify a namespace, a random one will be created, with this prefix |
 | namespace.lazy.enabled              | Bool (true)    | Any | Should the specified namespace be created if not exists, or throw exception?     |
@@ -91,6 +92,14 @@ For debugging purposes, you can set the **namespace.cleanup.enabled** and **name
 In other cases you may find it useful to manually create and manage the environment rather than having **arquillian** do that for you.
 In this case you can use the **namespace.use.existing** option to select an existing namespace. This option goes hand in hand with **env.init.enabled** which can be
 used to prevent the extension from modifying the environment.
+
+Last but not least, you can just tell arquillian, that you are going to use the current namespace. In this case, arquillian cube will delegate to the link:https://github.com/fabric8io/kubernetes-client/[Kubernetes Client] that will use:
+
+- ~/.kube/config
+- /var/run/secrets/kubernetes.io/serviceaccount/namespace
+- the KUBERNETES_NAMESPACE environmnet variable
+
+to determine the current namespace.
 
 ### Creating the environment
 After creating or selecting an existing namespace, the next step is the environment preparation. This is the stage where all the required Kubernetes configuration will be applied.

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -29,6 +29,8 @@ public interface Configuration {
     String NAMESPACE_DESTROY_ENABLED = "namespace.destroy.enabled";
     String NAMESPACE_DESTROY_CONFIRM_ENABLED = "namespace.destroy.confirm.enabled";
     String NAMESPACE_DESTROY_TIMEOUT = "namespace.destroy.timeout";
+
+    String NAMESPACE_USE_CURRENT = "namespace.use.current";
     String NAMESPACE_TO_USE = "namespace.use.existing";
     String NAMESPACE_PREFIX = "namespace.prefix";
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -1,5 +1,7 @@
 package org.arquillian.cube.kubernetes.impl;
 
+import io.fabric8.kubernetes.clnt.v2_2.Config;
+import io.fabric8.kubernetes.clnt.v2_2.ConfigBuilder;
 import io.fabric8.kubernetes.clnt.v2_2.utils.Utils;
 import io.sundr.builder.annotations.Buildable;
 import java.net.MalformedURLException;
@@ -80,7 +82,9 @@ public class DefaultConfiguration implements Configuration {
     public static DefaultConfiguration fromMap(Map<String, String> map) {
         try {
             String sessionId = UUID.randomUUID().toString();
-            String namespace = getStringProperty(NAMESPACE_TO_USE, map, null);
+            String namespace = getBooleanProperty(NAMESPACE_USE_CURRENT, map, false)
+                ? new ConfigBuilder().build().getNamespace()
+                : getStringProperty(NAMESPACE_TO_USE, map, null);
 
             //When a namespace is provided we want to cleanup our stuff...
             // ... without destroying pre-existing stuff.

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesExtension.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesExtension.java
@@ -22,6 +22,7 @@ import org.arquillian.cube.kubernetes.api.AnnotationProvider;
 import org.arquillian.cube.kubernetes.api.ConfigurationFactory;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
 import org.arquillian.cube.kubernetes.api.FeedbackProvider;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.api.LabelProvider;
 import org.arquillian.cube.kubernetes.api.NamespaceService;
 import org.arquillian.cube.kubernetes.api.ResourceInstaller;
@@ -46,6 +47,7 @@ import org.arquillian.cube.kubernetes.impl.install.DefaultResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.install.ResourceInstallerRegistar;
 import org.arquillian.cube.kubernetes.impl.label.DefaultLabelProvider;
 import org.arquillian.cube.kubernetes.impl.label.LabelProviderRegistar;
+import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.impl.locator.KubernetesResourceLocatorRegistar;
 import org.arquillian.cube.kubernetes.impl.log.LoggerRegistar;
 import org.arquillian.cube.kubernetes.impl.namespace.DefaultNamespaceService;
@@ -80,6 +82,7 @@ public class KubernetesExtension implements LoadableExtension {
             .observer(SessionManagerLifecycle.class);
 
         builder.service(NamespaceService.class, DefaultNamespaceService.class)
+            .service(KubernetesResourceLocator.class, DefaultKubernetesResourceLocator.class)
             .service(ResourceInstaller.class, DefaultResourceInstaller.class)
             .service(LabelProvider.class, DefaultLabelProvider.class)
             .service(DependencyResolver.class, ShrinkwrapResolver.class)

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -75,7 +75,9 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
 
     public static CubeOpenShiftConfiguration fromMap(Map<String, String> map) {
         String sessionId = UUID.randomUUID().toString();
-        String namespace = getStringProperty(NAMESPACE_TO_USE, map, null);
+        String namespace = getBooleanProperty(NAMESPACE_USE_CURRENT, map, false)
+            ? new ConfigBuilder().build().getNamespace()
+            : getStringProperty(NAMESPACE_TO_USE, map, null);
 
         //When a namespace is provided we want to cleanup our stuff...
         // ... without destroying pre-existing stuff.


### PR DESCRIPTION
This pull request addresses two issues:

- adds the ability to use the current namespace (without requiring us to be explicit)
- fixes a minor glitch that prevented the Openshift resource locator to be properly registered.

both issues have been reported as part of: https://github.com/spring-cloud-incubator/spring-cloud-kubernetes/issues/52