### PR TITLE
Now finding resources from META-INF/fabric8 using env.config.resource.name 

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -99,10 +99,13 @@ After creating or selecting an existing namespace, the next step is the environm
 1. Out of the box, the extension will use the classpath and try to find a resource named **kubernetes.json** or **kubernetes.yaml***. The name of the resource can be changed using the **env.config.resource.name**.
   Of course it is also possible to specify an external resource by URL using the **env.config.url**.
 
-2. Either way, it is possible that the kubernetes configuration used, depends on other configurations. It is also possible that your environment configuration is split in multiple files.
+2. While finding resource in classpath with property **env.config.resource.name**, cube will look into classpath with given name, if not found, then cube will continue to look into classpath under META-INF/fabric8/ directory.
+  Using this you can put multiple resources(openshift.json, openshift.yml) inside META-INF/fabric8, and choose only required one by specifying **env.config.resource.name** property.
+
+3. Either way, it is possible that the kubernetes configuration used, depends on other configurations. It is also possible that your environment configuration is split in multiple files.
   To cover cases like this the **env.dependencies** is provided which accepts a space separated list of URLs.
 
-3. There are cases, where instead of specifying the resources, you want to specify some shell scripts that will setup the environment. For those case you can use the **env.setup.script.url** / **env.teardown.script.url** to pass the
+4. There are cases, where instead of specifying the resources, you want to specify some shell scripts that will setup the environment. For those case you can use the **env.setup.script.url** / **env.teardown.script.url** to pass the
  scripts for setting up and tearing down the environment. Note that these scripts are going to be called right after the namespace is created and cleaned up respectively.
 
 (You can use any custom URL provided the appropriate URL stream handler.)

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -10,6 +10,7 @@ import java.util.UUID;
 import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.impl.util.SystemEnvironmentVariables;
 import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 
 import static org.arquillian.cube.impl.util.ConfigUtil.asURL;
 import static org.arquillian.cube.impl.util.ConfigUtil.getBooleanProperty;
@@ -18,6 +19,8 @@ import static org.arquillian.cube.impl.util.ConfigUtil.getStringProperty;
 
 @Buildable(builderPackage = "io.fabric8.kubernetes.api.builder.v2_2", generateBuilderPackage = false, editableEnabled = false)
 public class DefaultConfiguration implements Configuration {
+
+    public static final String ROOT = "/";
 
     private final String sessionId;
     private final String namespace;
@@ -170,7 +173,7 @@ public class DefaultConfiguration implements Configuration {
         } else if (Strings.isNotNullOrEmpty(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_URL, ""))) {
             return new URL(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_URL, ""));
         } else {
-            String defaultValue = "/" + DEFAULT_CONFIG_FILE_NAME;
+            String defaultValue = ROOT + DEFAULT_CONFIG_FILE_NAME;
             String resourceName = Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_RESOURCE_NAME, defaultValue);
             URL answer = findConfigResource(resourceName);
             if (answer == null) {
@@ -191,8 +194,27 @@ public class DefaultConfiguration implements Configuration {
         if (Strings.isNullOrEmpty(resourceName)) {
             return null;
         }
-        return resourceName.startsWith("/") ? DefaultConfiguration.class.getResource(resourceName)
-            : DefaultConfiguration.class.getResource("/" + resourceName);
+
+        final URL url = resourceName.startsWith(ROOT) ? DefaultConfiguration.class.getResource(resourceName)
+            : DefaultConfiguration.class.getResource(ROOT + resourceName);
+
+        if (url != null) {
+            return url;
+        }
+
+        // This is useful to get resource under META-INF directory
+        String[] resourceNamePrefix = new String[] {"META-INF/fabric8/", "META-INF/fabric8/"};
+
+        for (String resource : resourceNamePrefix) {
+            String fullResourceName = resource + resourceName;
+
+            URL candidate = KubernetesResourceLocator.class.getResource(fullResourceName.startsWith(ROOT) ? fullResourceName : ROOT + fullResourceName);
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+
+        return null;
     }
 
     /**


### PR DESCRIPTION
#### Short description of what this resolves:
Now setting environment config url by looking under META-INF/fabric8/ directory.

#### Changes proposed in this pull request:

- Cube is looking under META-INF/fabric8 directory as well while findingResource.



**Fixes**: #705 
