### PR TITLE
Port remaining fixes from fabric8 to cube (#704)

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -159,11 +159,11 @@ The resource providers available, can be used to inject to your test cases the f
 
 - A kubernetes client as an instance of KubernetesClient
 - Session object that contains information (e.g. the namespace) or the uuid of the test session.
-- Deployments *(by id or as a list of all deployments created during the session)*
-- Pods *(by id or as a list of all pods created during the session)*
-- Replication Controllers *(by id or as a list of all replication controllers created during the session)*
-- Replica Sets *(by id or as a list of all replica sets created during the session)*
-- Services *(by id or as a list of all services created during the session)*
+- Deployments *(by id or as a list of all deployments created during the session, optionally filtered by label)*
+- Pods *(by id or as a list of all pods created during the session, optionally filtered by label)*
+- Replication Controllers *(by id or as a list of all replication controllers created during the session, optionally filtered by label)*
+- Replica Sets *(by id or as a list of all replica sets created during the session, optionally filtered by label)*
+- Services *(by id or as a list of all services created during the session, optionally filtered by label)*
 
 The Openshift extension also provides:
 
@@ -220,6 +220,34 @@ The next example is intended to how you can inject a resource by id.
     }
 ----
 
+The next example shows how to inject a resource filtering by label.
+
+[source, java]
+.ResourceByLabelTest.java
+----
+
+    @RunWith(Arquillian.class)
+    public class ResourceByLabelTest {
+
+     @ArquillianResource
+     @WithLabel(name="app", value="my-app")
+     Service service;
+
+     @ArquillianResource
+     @WithLabel(name="app", value="my-app")
+     Pod pod;
+
+     @ArquillianResource
+     @WithLabel(name="app", value="my-app")
+     ReplicationController controller;
+
+      @Test
+      public void testStuff() throws Exception {
+       //Do stuff...
+      }
+    }
+----
+
 The next example is intended to how you can inject a resource list.
 
 [source, java]
@@ -236,7 +264,7 @@ The next example is intended to how you can inject a resource list.
      PodList pods;
 
      @ArquillianResource
-     ReplicationControllers controllers;
+     ReplicationControllerList controllers;
 
       @Test
       public void testStuff() throws Exception {

--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -201,15 +201,15 @@ The next example is intended to how you can inject a resource by id.
     @RunWith(Arquillian.class)
     public class ResourceByIdTest {
 
-     @ArquillianResouce
+     @ArquillianResource
      @Named("my-serivce")
      Service service;
 
-     @ArquillianResouce
+     @ArquillianResource
      @Named("my-pod")
      Pod pod;
 
-     @ArquillianResouce
+     @ArquillianResource
      @Named("my-contoller")
      ReplicationController controller;
 
@@ -229,13 +229,13 @@ The next example is intended to how you can inject a resource list.
     @RunWith(Arquillian.class)
     public class ResourceListExample {
 
-     @ArquillianResouce
+     @ArquillianResource
      ServiceList services;
 
-     @ArquillianResouce
+     @ArquillianResource
      PodList pods;
 
-     @ArquillianResouce
+     @ArquillianResource
      ReplicationControllers controllers;
 
       @Test

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/annotations/WithLabel.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/annotations/WithLabel.java
@@ -1,0 +1,18 @@
+package org.arquillian.cube.kubernetes.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Documented
+// @Repeatable(WithLabels.class) // TODO: once we are on Java 8
+public @interface WithLabel {
+
+    String name();
+    String value();
+
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/annotations/WithLabels.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/annotations/WithLabels.java
@@ -1,0 +1,15 @@
+package org.arquillian.cube.kubernetes.annotations;
+
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD, ElementType.FIELD, ElementType.PARAMETER})
+@Documented
+public @interface WithLabels {
+    WithLabel[] value();
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -67,6 +67,8 @@ public interface Configuration {
 
     URL getEnvironmentConfigUrl();
 
+    List<URL> getEnvironmentConfigAdditionalUrls();
+
     List<URL> getEnvironmentDependencies();
 
     String getSessionId();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -111,7 +111,7 @@ public class DefaultConfiguration implements Configuration {
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
                 .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
                 .withEnvironmentDependencies(
-                    asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), " ")))
+                    asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
                     getBooleanProperty(NAMESPACE_LAZY_CREATE_ENABLED, map, DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED))
                 .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, shouldCleanupNamespace))
@@ -129,7 +129,7 @@ public class DefaultConfiguration implements Configuration {
                 .withWaitTimeout(getLongProperty(WAIT_TIMEOUT, map, DEFAULT_WAIT_TIMEOUT))
                 .withWaitPollInterval(getLongProperty(WAIT_POLL_INTERVAL, map, DEFAULT_WAIT_POLL_INTERVAL))
                 .withWaitForServiceList(
-                    Strings.splitAndTrimAsList(getStringProperty(WAIT_FOR_SERVICE_LIST, map, ""), " "))
+                    Strings.splitAndTrimAsList(getStringProperty(WAIT_FOR_SERVICE_LIST, map, ""), "\\s+"))
                 .withAnsiLoggerEnabled(getBooleanProperty(ANSI_LOGGER_ENABLED, map, true))
                 .withKubernetesDomain(getStringProperty(DOMAIN, KUBERNETES_DOMAIN, map, null))
                 .withDockerRegistry(getDockerRegistry(map))

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -32,6 +32,7 @@ public class DefaultConfiguration implements Configuration {
     private final URL environmentTeardownScriptUrl;
 
     private final URL environmentConfigUrl;
+    private final List<URL> environmentConfigAdditionalUrls;
     private final List<URL> environmentDependencies;
 
     private final boolean namespaceLazyCreateEnabled;
@@ -53,7 +54,7 @@ public class DefaultConfiguration implements Configuration {
     private final String dockerRegistry;
 
     public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentSetupScriptUrl,
-        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies,
+        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentConfigAdditionalUrls, List<URL> environmentDependencies,
         boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
         boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled,
         boolean namespaceDestroyConfirmationEnabled, long namespaceDestroyTimeout, long waitTimeout,
@@ -64,6 +65,7 @@ public class DefaultConfiguration implements Configuration {
         this.environmentTeardownScriptUrl = environmentTeardownScriptUrl;
         this.environmentDependencies = environmentDependencies;
         this.environmentConfigUrl = environmentConfigUrl;
+        this.environmentConfigAdditionalUrls = environmentConfigAdditionalUrls;
         this.sessionId = sessionId;
         this.namespace = namespace;
         this.namespaceLazyCreateEnabled = namespaceLazyCreateEnabled;
@@ -109,7 +111,7 @@ public class DefaultConfiguration implements Configuration {
                     asUrlOrResource(getStringProperty(ENVIRONMENT_SETUP_SCRIPT_URL, map, null)))
                 .withEnvironmentTeardownScriptUrl(
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
-                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
+                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map, DEFAULT_CONFIG_FILE_NAME))
                 .withEnvironmentDependencies(
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
@@ -168,7 +170,7 @@ public class DefaultConfiguration implements Configuration {
      * @param map
      *     The arquillian configuration.
      */
-    public static URL getKubernetesConfigurationUrl(Map<String, String> map) throws MalformedURLException {
+    public static URL getKubernetesConfigurationUrl(Map<String, String> map, String defaultFileName) throws MalformedURLException {
         if (map.containsKey(ENVIRONMENT_CONFIG_URL)) {
             return new URL(map.get(ENVIRONMENT_CONFIG_URL));
         } else if (map.containsKey(ENVIRONMENT_CONFIG_RESOURCE_NAME)) {
@@ -177,7 +179,7 @@ public class DefaultConfiguration implements Configuration {
         } else if (Strings.isNotNullOrEmpty(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_URL, ""))) {
             return new URL(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_URL, ""));
         } else {
-            String defaultValue = ROOT + DEFAULT_CONFIG_FILE_NAME;
+            String defaultValue = ROOT + defaultFileName;
             String resourceName = Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_RESOURCE_NAME, defaultValue);
             URL answer = findConfigResource(resourceName);
             if (answer == null) {
@@ -269,6 +271,11 @@ public class DefaultConfiguration implements Configuration {
     @Override
     public URL getEnvironmentConfigUrl() {
         return environmentConfigUrl;
+    }
+
+    @Override
+    public List<URL> getEnvironmentConfigAdditionalUrls() {
+        return environmentConfigAdditionalUrls;
     }
 
     @Override

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -135,6 +135,16 @@ public class SessionManager implements SessionCreatedListener {
                     log.warn("Did not find any kubernetes configuration.");
                 }
 
+                List<URL> additionalUrls = configuration.getEnvironmentConfigAdditionalUrls();
+                if (additionalUrls != null) {
+                    for (URL url : additionalUrls) {
+                        log.status("Applying additional kubernetes configuration from: " + url);
+                        try (InputStream is = url.openStream()) {
+                            resources.addAll(resourceInstaller.install(url));
+                        }
+                    }
+                }
+
                 List<HasMetadata> resourcesToWait = new ArrayList<>(resources);
 
                 //Also handle services externally specified

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ClientResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ClientResourceProvider.java
@@ -1,13 +1,11 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Constructor;
+
 import io.fabric8.kubernetes.clnt.v2_2.Config;
 import io.fabric8.kubernetes.clnt.v2_2.DefaultKubernetesClient;
 import io.fabric8.kubernetes.clnt.v2_2.KubernetesClient;
-import io.fabric8.kubernetes.clnt.v2_2.utils.Serialization;
-
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Method;
 
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -30,11 +28,11 @@ public class ClientResourceProvider extends AbstractKubernetesResourceProvider {
         if (client == null) {
             throw new IllegalStateException("Unable to inject Kubernetes client into test.");
         }
-        return createUserClinet(client);
+        return createUserClient(client);
     }
 
 
-    private Object createUserClinet(KubernetesClient client) {
+    private Object createUserClient(KubernetesClient client) {
         Config config = client.getConfiguration();
 
         Object userConfig = toUsersResource(config);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/DeploymentListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/DeploymentListResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link DeploymentList}.
  * It refers to deplotments that have been created during the current session.
  */
-public class DeploymentListResourceProvider extends AbstractKubernetesResourceProvider {
+public class DeploymentListResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.DeploymentListResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +20,6 @@ public class DeploymentListResourceProvider extends AbstractKubernetesResourcePr
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().extensions().deployments().inNamespace(getSession().getNamespace()).list());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/DeploymentResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/DeploymentResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.extensions.Deployment;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.extensions.Deployment;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link Deployment}.
  * It refers to deployments that have been created during the current session.
  */
-public class DeploymentResourceProvider extends AbstractKubernetesResourceProvider {
+public class DeploymentResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.DeploymentResourceProvider {
     @Override
     public boolean canProvide(Class<?> type) {
         return internalToUserType(Deployment.class.getName()).equals(type.getName());
@@ -19,10 +19,6 @@ public class DeploymentResourceProvider extends AbstractKubernetesResourceProvid
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().extensions()
-            .deployments()
-            .inNamespace(getSession().getNamespace())
-            .withName(getName(qualifiers))
-            .get());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/PodListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/PodListResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.PodList;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.PodList;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link PodList}.
  * It refers to pods that have been created during the current session.
  */
-public class PodListResourceProvider extends AbstractKubernetesResourceProvider {
+public class PodListResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.PodListResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +20,6 @@ public class PodListResourceProvider extends AbstractKubernetesResourceProvider 
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().pods().inNamespace(getSession().getNamespace()).list());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/PodResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/PodResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.Pod;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.Pod;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link io.fabric8.kubernetes.api.model.v2_2.PodList}.
  * It refers to pods that have been created during the current session.
  */
-public class PodResourceProvider extends AbstractKubernetesResourceProvider {
+public class PodResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.PodResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +20,6 @@ public class PodResourceProvider extends AbstractKubernetesResourceProvider {
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().pods().inNamespace(getSession().getNamespace()).withName(getName(qualifiers)).get());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicaSetListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicaSetListResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSetList;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSetList;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSetList}.
  * It refers to replica sets that have been created during the current session.
  */
-public class ReplicaSetListResourceProvider extends AbstractKubernetesResourceProvider {
+public class ReplicaSetListResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.ReplicaSetListResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +20,6 @@ public class ReplicaSetListResourceProvider extends AbstractKubernetesResourcePr
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().extensions().replicaSets().inNamespace(getSession().getNamespace()).list());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicaSetResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicaSetResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSet;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSet;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSet}.
  * It refers to replica sets that have been created during the current session.
  */
-public class ReplicaSetResourceProvider extends AbstractKubernetesResourceProvider {
+public class ReplicaSetResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.ReplicaSetResourceProvider {
     @Override
     public boolean canProvide(Class<?> type) {
         return internalToUserType(ReplicaSet.class.getName()).equals(type.getName());
@@ -19,10 +19,6 @@ public class ReplicaSetResourceProvider extends AbstractKubernetesResourceProvid
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().extensions()
-            .replicaSets()
-            .inNamespace(getSession().getNamespace())
-            .withName(getName(qualifiers))
-            .get());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicationControllerListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicationControllerListResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link ReplicationControllerList}.
  * It refers to replication controllers that have been created during the current session.
  */
-public class ReplicationControllerListResourceProvider extends AbstractKubernetesResourceProvider {
+public class ReplicationControllerListResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.ReplicationControllerListResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +20,6 @@ public class ReplicationControllerListResourceProvider extends AbstractKubernete
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().replicationControllers().inNamespace(getSession().getNamespace()).list());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicationControllerResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ReplicationControllerResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.ReplicationController;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.ReplicationController;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList}.
  * It refers to replication controllers that have been created during the current session.
  */
-public class ReplicationControllerResourceProvider extends AbstractKubernetesResourceProvider {
+public class ReplicationControllerResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.ReplicationControllerResourceProvider {
     @Override
     public boolean canProvide(Class<?> type) {
         return internalToUserType(ReplicationController.class.getName()).equals(type.getName());
@@ -19,9 +19,6 @@ public class ReplicationControllerResourceProvider extends AbstractKubernetesRes
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().replicationControllers()
-            .inNamespace(getSession().getNamespace())
-            .withName(getName(qualifiers))
-            .get());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ServiceListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ServiceListResourceProvider.java
@@ -1,7 +1,8 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.ServiceList;
 import java.lang.annotation.Annotation;
+
+import io.fabric8.kubernetes.api.model.v2_2.ServiceList;
 
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -11,7 +12,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link ServiceList}.
  * It refers to services that have been created during the current session.
  */
-public class ServiceListResourceProvider extends AbstractKubernetesResourceProvider {
+public class ServiceListResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.ServiceListResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +21,6 @@ public class ServiceListResourceProvider extends AbstractKubernetesResourceProvi
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().services().inNamespace(getSession().getNamespace()).list());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ServiceResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/ServiceResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.enricher.external;
 
-import io.fabric8.kubernetes.api.model.v2_2.Service;
 import java.lang.annotation.Annotation;
 
-import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
+import io.fabric8.kubernetes.api.model.v2_2.Service;
+
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
@@ -11,7 +11,7 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
  * A {@link ResourceProvider} for {@link io.fabric8.kubernetes.api.model.v2_2.ServiceList}.
  * It refers to services that have been created during the current session.
  */
-public class ServiceResourceProvider extends AbstractKubernetesResourceProvider {
+public class ServiceResourceProvider extends org.arquillian.cube.kubernetes.impl.enricher.internal.ServiceResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -20,6 +20,6 @@ public class ServiceResourceProvider extends AbstractKubernetesResourceProvider 
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getClient().services().inNamespace(getSession().getNamespace()).withName(getName(qualifiers)).get());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/DeploymentListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/DeploymentListResourceProvider.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.kubernetes.impl.enricher.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
+
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
-import java.lang.annotation.Annotation;
-
-import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
 
 /**
  * A {@link ResourceProvider} for {@link DeploymentList}.
@@ -21,6 +22,11 @@ public class DeploymentListResourceProvider extends AbstractKubernetesResourcePr
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getClient().extensions().deployments().inNamespace(getSession().getNamespace()).list();
+        Map<String, String> labels = getLabels(qualifiers);
+        if (labels.isEmpty()) {
+            return getClient().extensions().deployments().inNamespace(getSession().getNamespace()).list();
+        } else {
+            return getClient().extensions().deployments().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/PodListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/PodListResourceProvider.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.kubernetes.impl.enricher.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.v2_2.PodList;
+
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
-import java.lang.annotation.Annotation;
-
-import io.fabric8.kubernetes.api.model.v2_2.PodList;
 
 /**
  * A {@link ResourceProvider} for {@link PodList}.
@@ -21,6 +22,11 @@ public class PodListResourceProvider extends AbstractKubernetesResourceProvider 
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getClient().pods().inNamespace(getSession().getNamespace()).list();
+        Map<String, String> labels = getLabels(qualifiers);
+        if( labels.isEmpty() ) {
+            return getClient().pods().inNamespace(getSession().getNamespace()).list();
+        } else {
+            return getClient().pods().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ReplicaSetListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ReplicaSetListResourceProvider.java
@@ -5,6 +5,7 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
 import java.lang.annotation.Annotation;
+import java.util.Map;
 
 import io.fabric8.kubernetes.api.model.v2_2.extensions.ReplicaSetList;
 
@@ -21,6 +22,11 @@ public class ReplicaSetListResourceProvider extends AbstractKubernetesResourcePr
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getClient().extensions().replicaSets().inNamespace(getSession().getNamespace()).list();
+        Map<String, String> labels = getLabels(qualifiers);
+        if (labels.isEmpty()) {
+            return getClient().extensions().replicaSets().inNamespace(getSession().getNamespace()).list();
+        } else {
+            return getClient().extensions().replicaSets().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ReplicationControllerListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ReplicationControllerListResourceProvider.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.kubernetes.impl.enricher.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList;
+
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
-import java.lang.annotation.Annotation;
-
-import io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList;
 
 /**
  * A {@link ResourceProvider} for {@link ReplicationControllerList}.
@@ -21,6 +22,11 @@ public class ReplicationControllerListResourceProvider extends AbstractKubernete
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getClient().replicationControllers().inNamespace(getSession().getNamespace()).list();
+        Map<String, String> labels = getLabels(qualifiers);
+        if (labels.isEmpty()) {
+            return getClient().replicationControllers().inNamespace(getSession().getNamespace()).list();
+        } else {
+            return getClient().replicationControllers().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        }
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ReplicationControllerResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ReplicationControllerResourceProvider.java
@@ -1,12 +1,15 @@
 package org.arquillian.cube.kubernetes.impl.enricher.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.v2_2.ReplicationController;
+import io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList;
+
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
-import java.lang.annotation.Annotation;
-
-import io.fabric8.kubernetes.api.model.v2_2.ReplicationController;
 
 /**
  * A {@link ResourceProvider} for {@link io.fabric8.kubernetes.api.model.v2_2.ReplicationControllerList}.
@@ -20,9 +23,22 @@ public class ReplicationControllerResourceProvider extends AbstractKubernetesRes
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getClient().replicationControllers()
-            .inNamespace(getSession().getNamespace())
-            .withName(getName(qualifiers))
-            .get();
+        String name = getName(qualifiers);
+        if (name != null) {
+            return getClient().replicationControllers()
+                .inNamespace(getSession().getNamespace())
+                .withName(getName(qualifiers))
+                .get();
+        }
+
+        // Gets the first replication controller found that matches the labels.
+        Map<String, String> labels = getLabels(qualifiers);
+        ReplicationControllerList list = getClient().replicationControllers().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        List<ReplicationController> replicationControllers = list.getItems();
+        if( !replicationControllers.isEmpty() ) {
+            return replicationControllers.get(0);
+        }
+
+        return null;
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ServiceListResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/internal/ServiceListResourceProvider.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.kubernetes.impl.enricher.internal;
 
+import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.v2_2.ServiceList;
+
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
-import java.lang.annotation.Annotation;
-
-import io.fabric8.kubernetes.api.model.v2_2.ServiceList;
 
 /**
  * A {@link ResourceProvider} for {@link ServiceList}.
@@ -21,6 +22,11 @@ public class ServiceListResourceProvider extends AbstractKubernetesResourceProvi
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getClient().services().inNamespace(getSession().getNamespace()).list();
+        Map<String, String> labels = getLabels(qualifiers);
+        if (labels.isEmpty()) {
+            return getClient().services().inNamespace(getSession().getNamespace()).list();
+        } else {
+            return getClient().services().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        }
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -1,15 +1,20 @@
 package org.arquillian.cube.openshift.impl.client;
 
-import io.fabric8.kubernetes.clnt.v2_2.Config;
-import io.fabric8.kubernetes.clnt.v2_2.ConfigBuilder;
-import io.sundr.builder.annotations.Buildable;
-import io.sundr.builder.annotations.BuildableReference;
+import java.io.File;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Collections;
+import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+
+import io.fabric8.kubernetes.clnt.v2_2.Config;
+import io.fabric8.kubernetes.clnt.v2_2.ConfigBuilder;
+import io.sundr.builder.annotations.Buildable;
+import io.sundr.builder.annotations.BuildableReference;
+
 import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
 
@@ -36,6 +41,8 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private static final String PROXIED_CONTAINER_PORTS = "proxiedContainerPorts";
     private static final String PORT_FORWARDER_BIND_ADDRESS = "portForwardBindAddress";
 
+    private static final String DEFAULT_OPENSHIFT_CONFIG_FILE_NAME = "openshift.json";
+
     private final boolean keepAliveGitServer;
     private final String definitions;
     private final String definitionsFile;
@@ -44,7 +51,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private final String portForwardBindAddress;
 
     public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentSetupScriptUrl,
-        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies,
+        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentConfigAdditionalUrls, List<URL> environmentDependencies,
         boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
         boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled, long namespaceDestroyTimeout,
         boolean namespaceDestroyConfirmationEnabled, long waitTimeout, long waitPollInterval,
@@ -53,7 +60,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
         String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts,
         String portForwardBindAddress) {
         super(sessionId, masterUrl, namespace, environmentSetupScriptUrl, environmentTeardownScriptUrl,
-            environmentConfigUrl, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
+            environmentConfigUrl, environmentConfigAdditionalUrls, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
             namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled,
             namespaceDestroyConfirmationEnabled, namespaceDestroyTimeout, waitTimeout, waitPollInterval,
             waitForServiceList, ansiLoggerEnabled, environmentInitEnabled, kubernetesDomain, dockerRegistry);
@@ -89,6 +96,26 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
             shouldDestroyNamespace = true;
             shouldCleanupNamespace = false;
         }
+
+        // Lets also try to load the image stream for the project.
+        List<URL> additionalUrls = new LinkedList<>();
+        File targetDir = new File(System.getProperty("basedir", ".") + "/target");
+         if (targetDir.exists() && targetDir.isDirectory()) {
+            File[]files = targetDir.listFiles();
+             if (files != null) {
+                 for (File file : files) {
+                     if (file.getName().endsWith("-is.yml")) {
+                         try {
+                             additionalUrls.add(file.toURI().toURL());
+                         } catch (MalformedURLException e) {
+                             // ignore
+                         }
+                    }
+                }
+            }
+        }
+
+
         try {
             return new CubeOpenShiftConfigurationBuilder()
                 .withSessionId(sessionId)
@@ -100,7 +127,8 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                     asUrlOrResource(getStringProperty(ENVIRONMENT_SETUP_SCRIPT_URL, map, null)))
                 .withEnvironmentTeardownScriptUrl(
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
-                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
+                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map, DEFAULT_OPENSHIFT_CONFIG_FILE_NAME))
+                .withEnvironmentConfigAdditionalUrls(additionalUrls)
                 .withEnvironmentDependencies(
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -102,7 +102,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
                 .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
                 .withEnvironmentDependencies(
-                    asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), " ")))
+                    asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
                     getBooleanProperty(NAMESPACE_LAZY_CREATE_ENABLED, map, DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED))
                 .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, shouldCleanupNamespace))
@@ -120,7 +120,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 .withWaitTimeout(getLongProperty(WAIT_TIMEOUT, map, DEFAULT_WAIT_TIMEOUT))
                 .withWaitPollInterval(getLongProperty(WAIT_POLL_INTERVAL, map, DEFAULT_WAIT_POLL_INTERVAL))
                 .withWaitForServiceList(
-                    Strings.splitAndTrimAsList(getStringProperty(WAIT_FOR_SERVICE_LIST, map, ""), " "))
+                    Strings.splitAndTrimAsList(getStringProperty(WAIT_FOR_SERVICE_LIST, map, ""), "\\s+"))
                 .withAnsiLoggerEnabled(getBooleanProperty(ANSI_LOGGER_ENABLED, map, true))
                 .withKubernetesDomain(getStringProperty(DOMAIN, KUBERNETES_DOMAIN, map, null))
                 .withDockerRegistry(getDockerRegistry(map))

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/DeploymentConfigListResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/DeploymentConfigListResourceProvider.java
@@ -1,19 +1,18 @@
 package org.arquillian.cube.openshift.impl.enricher.external;
 
-import org.arquillian.cube.openshift.impl.enricher.AbstractOpenshiftResourceProvider;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
 import java.lang.annotation.Annotation;
 
 import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
 import io.fabric8.openshift.api.model.v2_2.DeploymentConfigList;
 
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
 /**
  * A {@link ResourceProvider} for {@link DeploymentList}.
  * It refers to deployment configs that have been created during the current session.
  */
-public class DeploymentConfigListResourceProvider extends AbstractOpenshiftResourceProvider {
+public class DeploymentConfigListResourceProvider extends org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigListResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
@@ -22,6 +21,6 @@ public class DeploymentConfigListResourceProvider extends AbstractOpenshiftResou
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getOpenshiftClient().deploymentConfigs().inNamespace(getSession().getNamespace()).list());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/DeploymentConfigResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/DeploymentConfigResourceProvider.java
@@ -1,18 +1,17 @@
 package org.arquillian.cube.openshift.impl.enricher.external;
 
-import org.arquillian.cube.openshift.impl.enricher.AbstractOpenshiftResourceProvider;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
 import java.lang.annotation.Annotation;
 
 import io.fabric8.openshift.api.model.v2_2.DeploymentConfig;
+
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
 /**
  * A {@link ResourceProvider} for {@link DeploymentConfig}.
  * It refers to deployment configs that have been created during the current session.
  */
-public class DeploymentConfigResourceProvider extends AbstractOpenshiftResourceProvider {
+public class DeploymentConfigResourceProvider extends org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigResourceProvider {
     @Override
     public boolean canProvide(Class<?> type) {
         return internalToUserType(DeploymentConfig.class.getName()).equals(type.getName());
@@ -20,9 +19,6 @@ public class DeploymentConfigResourceProvider extends AbstractOpenshiftResourceP
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return toUsersResource(getOpenshiftClient().deploymentConfigs()
-            .inNamespace(getSession().getNamespace())
-            .withName(getName(qualifiers))
-            .get());
+        return toUsersResource(super.lookup(resource, qualifiers));
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/internal/DeploymentConfigListResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/internal/DeploymentConfigListResourceProvider.java
@@ -1,7 +1,9 @@
 package org.arquillian.cube.openshift.impl.enricher.internal;
 
-import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
 import java.lang.annotation.Annotation;
+import java.util.Map;
+
+import io.fabric8.kubernetes.api.model.v2_2.extensions.DeploymentList;
 
 import org.arquillian.cube.openshift.impl.enricher.AbstractOpenshiftResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -20,6 +22,11 @@ public class DeploymentConfigListResourceProvider extends AbstractOpenshiftResou
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getOpenshiftClient().deploymentConfigs().inNamespace(getSession().getNamespace()).list();
+        Map<String, String> labels = getLabels(qualifiers);
+        if( labels.isEmpty() ) {
+            return getOpenshiftClient().deploymentConfigs().inNamespace(getSession().getNamespace()).list();
+        } else {
+            return getOpenshiftClient().deploymentConfigs().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        }
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/internal/DeploymentConfigResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/internal/DeploymentConfigResourceProvider.java
@@ -1,7 +1,11 @@
 package org.arquillian.cube.openshift.impl.enricher.internal;
 
-import io.fabric8.openshift.api.model.v2_2.DeploymentConfig;
 import java.lang.annotation.Annotation;
+import java.util.List;
+import java.util.Map;
+
+import io.fabric8.openshift.api.model.v2_2.DeploymentConfig;
+import io.fabric8.openshift.api.model.v2_2.DeploymentConfigList;
 
 import org.arquillian.cube.openshift.impl.enricher.AbstractOpenshiftResourceProvider;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -19,9 +23,22 @@ public class DeploymentConfigResourceProvider extends AbstractOpenshiftResourceP
 
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        return getOpenshiftClient().deploymentConfigs()
-            .inNamespace(getSession().getNamespace())
-            .withName(getName(qualifiers))
-            .get();
+        String name = getName(qualifiers);
+        if (name != null) {
+            return getOpenshiftClient().deploymentConfigs()
+                .inNamespace(getSession().getNamespace())
+                .withName(getName(qualifiers))
+                .get();
+        }
+
+        // Gets the first deployment config that matches the labels.
+        Map<String, String> labels = getLabels(qualifiers);
+        DeploymentConfigList list = getOpenshiftClient().deploymentConfigs().inNamespace(getSession().getNamespace()).withLabels(labels).list();
+        List<DeploymentConfig> deploymentConfigs = list.getItems();
+        if( !deploymentConfigs.isEmpty() ) {
+            return deploymentConfigs.get(0);
+        }
+
+        return null;
     }
 }


### PR DESCRIPTION
Porting:
- OSFUSE-488
- OSFUSE-534
- OSFUSE 324

The implementation is a bit different (since many classes changed) from the fabric8io version (especially for 324), but it should be equivalent.

I've verified that the following issues are already fixed in arquillian cube:
- OSFUSE-487
- OSFUSE-486
- OSFUSE-317

If @astefanutti confirms the other 2 remaining issues, #704 can be closed.