### PR TITLE
fix(#730): Adds Docker Compose variable substitution to cube format

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ConfigUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/ConfigUtil.java
@@ -12,6 +12,7 @@ import org.arquillian.cube.docker.impl.client.config.Image;
 import org.arquillian.cube.docker.impl.client.config.Link;
 import org.arquillian.cube.docker.impl.client.config.Network;
 import org.arquillian.cube.docker.impl.client.config.PortBinding;
+import org.arquillian.cube.docker.impl.docker.compose.DockerComposeEnvironmentVarResolver;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
 import org.yaml.snakeyaml.introspector.Property;
@@ -64,8 +65,13 @@ public final class ConfigUtil {
     @SuppressWarnings("unchecked")
     public static DockerCompositions load(InputStream inputStream) {
         // TODO: Figure out how to map root Map<String, Type> objects. Workaround by mapping it to Map structure then dumping it into individual objects
+
+        //Apply Docker compose substitutions to cube format as well
+
+        final String content = DockerComposeEnvironmentVarResolver.replaceParameters(inputStream);
+
         Yaml yaml = new Yaml(new CubeConstructor());
-        Map<String, Object> rawLoad = (Map<String, Object>) yaml.load(inputStream);
+        Map<String, Object> rawLoad = (Map<String, Object>) yaml.load(content);
 
         DockerCompositions containers = new DockerCompositions();
 

--- a/docker/ftest-standalone-star-operator/src/test/java/org/arquillian/cube/StandaloneStarOperatorTestCase.java
+++ b/docker/ftest-standalone-star-operator/src/test/java/org/arquillian/cube/StandaloneStarOperatorTestCase.java
@@ -19,7 +19,7 @@ import static org.hamcrest.CoreMatchers.notNullValue;
 import static org.junit.Assert.assertThat;
 
 @RunWith(ArquillianConditionalRunner.class)
-@RequiresDocker
+//@RequiresDocker
 public class StandaloneStarOperatorTestCase {
 
     @HostIp

--- a/docker/ftest-standalone-star-operator/src/test/resources/arquillian.xml
+++ b/docker/ftest-standalone-star-operator/src/test/resources/arquillian.xml
@@ -6,12 +6,7 @@
 
   <extension qualifier="docker">
     <property name="definitionFormat">CUBE</property>
-    <property name="dockerContainers">
-      pingpong*:
-        image: jonmorehouse/ping-pong
-        exposedPorts: [8080/tcp]
-        portBindings: [8080/tcp]
-    </property>
+    <property name="dockerContainersFile">src/test/resources/containers.yml</property>
   </extension>
 
 </arquillian>

--- a/docker/ftest-standalone-star-operator/src/test/resources/containers.yml
+++ b/docker/ftest-standalone-star-operator/src/test/resources/containers.yml
@@ -1,4 +1,4 @@
 pingpong*:
-  image: jonmorehouse/ping-pong:${PING_PONG_VERSION}
+  image: jonmorehouse/ping-pong:${PING_PONG_VERSION:-latest}
   exposedPorts: [8080/tcp]
   portBindings: [8080/tcp]

--- a/docker/ftest-standalone-star-operator/src/test/resources/containers.yml
+++ b/docker/ftest-standalone-star-operator/src/test/resources/containers.yml
@@ -1,0 +1,4 @@
+pingpong*:
+  image: jonmorehouse/ping-pong:${PING_PONG_VERSION}
+  exposedPorts: [8080/tcp]
+  portBindings: [8080/tcp]


### PR DESCRIPTION
fix(#730): Adds Docker Compose variable substitution to cube format