### PR TITLE
Kubernetes/Openshift: Defaults "namespace.cleanup.enabled" to true

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -93,13 +93,10 @@ public class DefaultConfiguration implements Configuration {
 
             //When a namespace is provided we want to cleanup our stuff...
             // ... without destroying pre-existing stuff.
-            Boolean shouldCleanupNamespace = true;
             Boolean shouldDestroyNamespace = false;
             if (Strings.isNullOrEmpty(namespace)) {
-                //When we generate a namespace ourselves we to completely destroy it, so cleaning makes no sense.
                 namespace = getStringProperty(NAMESPACE_PREFIX, map, "itest") + "-" + sessionId;
                 shouldDestroyNamespace = true;
-                shouldCleanupNamespace = false;
             }
             return new DefaultConfigurationBuilder()
                 .withSessionId(sessionId)
@@ -116,7 +113,7 @@ public class DefaultConfiguration implements Configuration {
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
                     getBooleanProperty(NAMESPACE_LAZY_CREATE_ENABLED, map, DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED))
-                .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, shouldCleanupNamespace))
+                .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, true))
                 .withNamespaceCleanupConfirmationEnabled(
                     getBooleanProperty(NAMESPACE_CLEANUP_CONFIRM_ENABLED, map, false))
                 .withNamespaceCleanupTimeout(

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -88,13 +88,10 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
 
         //When a namespace is provided we want to cleanup our stuff...
         // ... without destroying pre-existing stuff.
-        Boolean shouldCleanupNamespace = true;
         Boolean shouldDestroyNamespace = false;
         if (Strings.isNullOrEmpty(namespace)) {
-            //When we generate a namespace ourselves we to completely destroy it, so cleaning makes no sense.
             namespace = getStringProperty(NAMESPACE_PREFIX, map, "itest") + "-" + sessionId;
             shouldDestroyNamespace = true;
-            shouldCleanupNamespace = false;
         }
 
         // Lets also try to load the image stream for the project.
@@ -133,7 +130,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
                     getBooleanProperty(NAMESPACE_LAZY_CREATE_ENABLED, map, DEFAULT_NAMESPACE_LAZY_CREATE_ENABLED))
-                .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, shouldCleanupNamespace))
+                .withNamespaceCleanupEnabled(getBooleanProperty(NAMESPACE_CLEANUP_ENABLED, map, true))
                 .withNamespaceCleanupConfirmationEnabled(
                     getBooleanProperty(NAMESPACE_CLEANUP_CONFIRM_ENABLED, map, false))
                 .withNamespaceCleanupTimeout(


### PR DESCRIPTION
We should keep the default value as "true" regardless of whether we
are going to destroy the namespace or not. This is to keep consistency
when users call "configuration.isNamespaceCleanupEnabled()".

Users of this library can rely on the above method to decide when
to cleanup stuff they have created. So, the library must be
consistent on their flags and documentation.

Closes #747.