### PR TITLE
fix: #725 Allow arquillian descriptor properties prefixed with env. a…

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -64,12 +64,13 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 | env.init.enabled                    | Bool (true)    | Any | Flag to initialize the environment (apply kubernetes resources)                  |
 | env.config.url                      | URL            | Any | URL to the Kubernetes JSON/YAML (defaults to classpath resource kubernetes.json) |
 | env.config.resource.name            | String         | Any | Option to select a different classpath resource (other than kubernetes.json)     |
+| env.script.env                      | String         | Any | Key/Value pairs to pass to setup scripts as environment variables                |
 | env.setup.script.url                | URL            | Any | Option to select a shell script that will setup the environment                  |
 | env.teardown.script.url             | URL            | Any | Option to select a shell script to tear down / cleanup the environment           |
 | env.dependencies                    | List           | Any | Whitespace separated list of URLs to more dependency kubernetes.json             |
 | wait.timeout                        | Long (5mins)   | Any | The total amount of time to wait until the env is ready                          |
 | wait.poll.interval                  | Long (5secs)   | Any | The poll interval to use for checking if the environment is ready                |
-| wait.for.service.list               | List           | Any | Explicitly specify a list of services to wait upon                                |
+| wait.for.service.list               | List           | Any | Explicitly specify a list of services to wait upon                               |
 | ansi.logger.enabled                 | Bool (true)    | Any | Flag to enable colorful output                                                   |
 | kubernetes.client.creator.class.name| Bool (true)    | Any | Fully qualified class name of a kubernetes client creator class (byon)           |
 |===============================================================================================================================================
@@ -79,7 +80,7 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 [width="80%"]
 |===============================================================================================================================================
 | Option                              | Type           | Env | Description                                                                      |
-| autoStartContainers                 | List           | Any | Comma Separated List of Pods which you want to auto start                       |
+| autoStartContainers                 | List           | Any | Comma Separated List of Pods which you want to auto start                        |
 | definitionsFile                     | String         | Any | Definitions file path                                                            |
 | proxiedContainerPorts               | List           | Any | Comma Separated List following Pod:containerPort OR Pod:MappedPort:ContainerPort |                                        |
 |===============================================================================================================================================
@@ -114,8 +115,16 @@ After creating or selecting an existing namespace, the next step is the environm
 3. Either way, it is possible that the kubernetes configuration used, depends on other configurations. It is also possible that your environment configuration is split in multiple files.
   To cover cases like this the **env.dependencies** is provided which accepts a space separated list of URLs.
 
-4. There are cases, where instead of specifying the resources, you want to specify some shell scripts that will setup the environment. For those case you can use the **env.setup.script.url** / **env.teardown.script.url** to pass the
+4. There are cases, where instead of specifying the resources, you want to specify some shell scripts that will setup the environment. For those cases you can use the **env.setup.script.url** / **env.teardown.script.url** to pass the
  scripts for setting up and tearing down the environment. Note that these scripts are going to be called right after the namespace is created and cleaned up respectively.
+ Both scripts will be executed using visible environment variables the following:
+
+ * KUBERNETES_MASTER
+ * KUBERNETES_NAMESPACE
+ * KUBERNETES_DOMAIN
+ * DOCKER_REGISTRY
+ * all host environment variables
+ * all environment variables in arquillian.xml via env.script.env (as properties).
 
 (You can use any custom URL provided the appropriate URL stream handler.)
 

--- a/kubernetes/kubernetes/pom.xml
+++ b/kubernetes/kubernetes/pom.xml
@@ -76,6 +76,11 @@
 
     <!-- Test Dependencies -->
     <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.jboss.arquillian.junit</groupId>
       <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -4,6 +4,7 @@ import io.fabric8.kubernetes.clnt.v2_5.Config;
 import io.fabric8.kubernetes.clnt.v2_5.ConfigBuilder;
 import java.net.URL;
 import java.util.List;
+import java.util.Map;
 
 public interface Configuration {
 
@@ -36,6 +37,7 @@ public interface Configuration {
 
     String ENVIRONMENT_INIT_ENABLED = "env.init.enabled";
 
+    String ENVIRONMENT_SCRIPT_ENV = "env.script.env";
     String ENVIRONMENT_SETUP_SCRIPT_URL = "env.setup.script.url";
     String ENVIRONMENT_TEARDOWN_SCRIPT_URL = "env.teardown.script.url";
     String ENVIRONMENT_CONFIG_URL = "env.config.url";
@@ -60,6 +62,8 @@ public interface Configuration {
     Config FALLBACK_CLIENT_CONFIG = new ConfigBuilder().build();
 
     URL getMasterUrl();
+
+    Map<String, String> getScriptEnvironmentVariables();
 
     URL getEnvironmentSetupScriptUrl();
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -308,6 +308,7 @@ public class SessionManager implements SessionCreatedListener {
     private Map<String, String> createScriptEnvironment() {
         Map<String, String> env = new HashMap<>();
         env.putAll(System.getenv());
+        env.putAll(configuration.getScriptEnvironmentVariables());
         env.put(propertyToEnvironmentVariableName(Configuration.KUBERNETES_NAMESPACE), configuration.getNamespace());
         env.put(propertyToEnvironmentVariableName(Configuration.KUBERNETES_DOMAIN), configuration.getKubernetesDomain());
         env.put(propertyToEnvironmentVariableName(Configuration.KUBERNETES_MASTER),

--- a/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationTest.java
+++ b/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationTest.java
@@ -1,0 +1,46 @@
+package org.arquillian.cube.kubernetes.impl;
+
+import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.*;
+
+
+public class DefaultConfigurationTest {
+
+    @Test
+    public void shouldParseNullMap() throws Exception {
+        Map<String, String> result = DefaultConfiguration.parseMap(null);
+        assertThat(result).hasSize(0);
+    }
+
+    @Test
+    public void shouldParseEmptyMap() throws Exception {
+        Map<String, String> result = DefaultConfiguration.parseMap("");
+        assertThat(result).hasSize(0);
+    }
+
+    @Test //We just want to know it won't barf
+    public void shouldParseJustAKey() throws Exception {
+        String s = "KEY1";
+
+        Map<String, String> result = DefaultConfiguration.parseMap(s);
+        assertThat(result).hasSize(1);
+    }
+
+    @Test
+    public void shouldParseNormalMap() throws Exception {
+       String s = "KEY1=VALUE1\n" +
+        "KEY_TWO=VALUE2\n" +
+        "KEY3=VALUE3\n" +
+        "key4=VALUE4\n" +
+        "KEY_5=VALUE5";
+
+        Map<String, String> result = DefaultConfiguration.parseMap(s);
+        assertThat(result).hasSize(5).containsKeys("KEY3", "key4", "KEY_5");
+    }
+
+}
+

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -50,7 +50,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private final Set<String> proxiedContainerPorts;
     private final String portForwardBindAddress;
 
-    public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentSetupScriptUrl,
+    public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables, URL environmentSetupScriptUrl,
         URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentConfigAdditionalUrls, List<URL> environmentDependencies,
         boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
         boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled, long namespaceDestroyTimeout,
@@ -59,7 +59,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
         String kubernetesDomain, String dockerRegistry, boolean keepAliveGitServer, String definitions,
         String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts,
         String portForwardBindAddress) {
-        super(sessionId, masterUrl, namespace, environmentSetupScriptUrl, environmentTeardownScriptUrl,
+        super(sessionId, masterUrl, namespace, scriptEnvironmentVariables, environmentSetupScriptUrl, environmentTeardownScriptUrl,
             environmentConfigUrl, environmentConfigAdditionalUrls, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
             namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled,
             namespaceDestroyConfirmationEnabled, namespaceDestroyTimeout, waitTimeout, waitPollInterval,
@@ -119,6 +119,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 .withNamespace(namespace)
                 .withMasterUrl(
                     new URL(getStringProperty(MASTER_URL, KUBERNETES_MASTER, map, FALLBACK_CLIENT_CONFIG.getMasterUrl())))
+                .withScriptEnvironmentVariables(parseMap(map.get(ENVIRONMENT_SCRIPT_ENV)))
                 .withEnvironmentInitEnabled(getBooleanProperty(ENVIRONMENT_INIT_ENABLED, map, true))
                 .withEnvironmentSetupScriptUrl(
                     asUrlOrResource(getStringProperty(ENVIRONMENT_SETUP_SCRIPT_URL, map, null)))


### PR DESCRIPTION
…s env variables to setup/teardown scripts in k8s/openshift.

<!-- 
Many thanks for contributing to Arquillian! Together we can make the testing world better.

Please tell us what this PR brings following the template we provided. 
And don't forget to link to the issue (or create one if there is none).

If you are still working on the change please prefix this pull request title with "WIP"

YOU CAN DELETE THIS COMMENT :)
-->

#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-


**Fixes**: #
