### PR TITLE
Fix for #736: Expect response code 200 for Selenium containers version >= 3

### DIFF
--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -159,7 +159,6 @@ public class SeleniumContainers {
 
         Await await = new Await();
         await.setStrategy("http");
-
         await.setResponseCode(getSeleniumExpectedResponseCode());
         await.setUrl("http://dockerHost:" + SELENIUM_BOUNDED_PORT);
 

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -159,8 +159,19 @@ public class SeleniumContainers {
 
         Await await = new Await();
         await.setStrategy("http");
-        // Doing an http request to selenium node returns a 403 if Jetty is up and running
-        await.setResponseCode(403);
+
+        // Selenium from 3.x onwards returns 200 if started
+        int expectedResponseCode = 200;
+        String imageTag = cubeContainer.getImage().getTag();
+        if(imageTag!=null && imageTag.matches("[0-9]+\\.?.*")) {
+            int seleniumMajorVersion = Integer.parseInt(imageTag.substring(0, imageTag.indexOf('.')));
+            if(seleniumMajorVersion < 3) {
+                // Doing an http request to selenium node returns a 403 if Jetty is up and running for Selenium < 3
+                expectedResponseCode=403;
+            }
+        }
+        
+        await.setResponseCode(expectedResponseCode);
         await.setUrl("http://dockerHost:" + SELENIUM_BOUNDED_PORT);
 
         cubeContainer.setAwait(await);

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -160,9 +160,7 @@ public class SeleniumContainers {
         Await await = new Await();
         await.setStrategy("http");
 
-        int expectedResponseCode = getSeleniumExpectedResponseCode();
-        
-        await.setResponseCode(expectedResponseCode);
+        await.setResponseCode(getSeleniumExpectedResponseCode());
         await.setUrl("http://dockerHost:" + SELENIUM_BOUNDED_PORT);
 
         cubeContainer.setAwait(await);

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -160,16 +160,7 @@ public class SeleniumContainers {
         Await await = new Await();
         await.setStrategy("http");
 
-        // Selenium from 3.x onwards returns 200 if started
-        int expectedResponseCode = 200;
-        String imageTag = cubeContainer.getImage().getTag();
-        if(imageTag!=null && imageTag.matches("[0-9]+\\.?.*")) {
-            int seleniumMajorVersion = Integer.parseInt(imageTag.substring(0, imageTag.indexOf('.')));
-            if(seleniumMajorVersion < 3) {
-                // Doing an http request to selenium node returns a 403 if Jetty is up and running for Selenium < 3
-                expectedResponseCode=403;
-            }
-        }
+        int expectedResponseCode = getSeleniumExpectedResponseCode();
         
         await.setResponseCode(expectedResponseCode);
         await.setUrl("http://dockerHost:" + SELENIUM_BOUNDED_PORT);
@@ -177,6 +168,20 @@ public class SeleniumContainers {
         cubeContainer.setAwait(await);
 
         cubeContainer.setKillContainer(true);
+    }
+
+    private static int getSeleniumExpectedResponseCode(){
+        // Selenium from 3.x onwards returns 200 if started
+        int expectedResponseCode = 200;
+            String seleniumVersion = SeleniumVersionExtractor.fromClassPath();
+            if(seleniumVersion.matches("[0-9]+\\.?.*")){
+                int seleniumMajorVersion = Integer.parseInt(seleniumVersion.substring(0, seleniumVersion.indexOf('.')));
+                if(seleniumMajorVersion < 3){
+                    // Doing an http request to selenium node returns a 403 if Jetty is up and running for Selenium < 3
+                    expectedResponseCode = 403;
+                }
+        }
+        return expectedResponseCode;
     }
 
     public CubeContainer getSeleniumContainer() {

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -66,40 +66,6 @@ public class SeleniumContainersTest {
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:2.53.0"));
         assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
-    }
-
-    @Test
-    public void shouldAwait200ResponseCodeForSelenium3() {
-        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
-        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
-        when(cubeDroneConfiguration.getBrowserImage()).thenReturn("selenium/standalone-firefox-debug:3.4.0");
-
-        final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
-        assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:3.4.0"));
-        assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(200));
-    }
-
-    @Test
-    public void shouldAwait200ResponseCodeForLatestSelenium() {
-        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
-        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
-        when(cubeDroneConfiguration.getBrowserImage()).thenReturn("selenium/standalone-firefox-debug:latest");
-
-        final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
-        assertThat(firefox.getBrowser(), is("firefox"));
-        assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:latest"));
-        assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(200));
-    }
-
-    @Test
-    public void shouldAwait403ResponseCodeForSelenium2() {
-        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
-        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
-        when(cubeDroneConfiguration.getBrowserImage()).thenReturn("selenium/standalone-firefox-debug:2.53.0");
-
-        final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
-        assertThat(firefox.getBrowser(), is("firefox"));
-        assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:2.53.0"));
         assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
     }
 
@@ -113,5 +79,6 @@ public class SeleniumContainersTest {
         assertThat(firefox.getBrowser(), is("chrome"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-chrome-debug:2.53.0"));
         assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
     }
 }

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -69,6 +69,41 @@ public class SeleniumContainersTest {
     }
 
     @Test
+    public void shouldAwait200ResponseCodeForSelenium3() {
+        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
+        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
+        when(cubeDroneConfiguration.getBrowserImage()).thenReturn("selenium/standalone-firefox-debug:3.4.0");
+
+        final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
+        assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:3.4.0"));
+        assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(200));
+    }
+
+    @Test
+    public void shouldAwait200ResponseCodeForLatestSelenium() {
+        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
+        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
+        when(cubeDroneConfiguration.getBrowserImage()).thenReturn("selenium/standalone-firefox-debug:latest");
+
+        final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
+        assertThat(firefox.getBrowser(), is("firefox"));
+        assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:latest"));
+        assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(200));
+    }
+
+    @Test
+    public void shouldAwait403ResponseCodeForSelenium2() {
+        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
+        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
+        when(cubeDroneConfiguration.getBrowserImage()).thenReturn("selenium/standalone-firefox-debug:2.53.0");
+
+        final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
+        assertThat(firefox.getBrowser(), is("firefox"));
+        assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:2.53.0"));
+        assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
+    }
+
+    @Test
     public void shouldCreateContainerForChrome() {
 
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);


### PR DESCRIPTION
#### Short description of what this resolves:
Docker drone is expecting the wrong responseCode for Selenium from version 3 onwards

#### Changes proposed in this pull request:

- Retrieve Selenium major version from image tag
- For version >= 3 and as default (e.g. to cover "latest" tag) expect 200 response code
- For versions < 3 expect 403 response code


**Fixes**: #736 
