### PR TITLE
k8s/openshift: Generate a smaller session id

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -86,7 +86,7 @@ public class DefaultConfiguration implements Configuration {
 
     public static DefaultConfiguration fromMap(Map<String, String> map) {
         try {
-            String sessionId = UUID.randomUUID().toString();
+            String sessionId = UUID.randomUUID().toString().split("-")[0];
             String namespace = getBooleanProperty(NAMESPACE_USE_CURRENT, map, false)
                 ? new ConfigBuilder().build().getNamespace()
                 : getStringProperty(NAMESPACE_TO_USE, map, null);

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -81,7 +81,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     }
 
     public static CubeOpenShiftConfiguration fromMap(Map<String, String> map) {
-        String sessionId = UUID.randomUUID().toString();
+        String sessionId = UUID.randomUUID().toString().split("-")[0];
         String namespace = getBooleanProperty(NAMESPACE_USE_CURRENT, map, false)
             ? new ConfigBuilder().build().getNamespace()
             : getStringProperty(NAMESPACE_TO_USE, map, null);


### PR DESCRIPTION
Having the whole UUID as the session id can lead to errors like
having a too big URL for a route, considering the default algorithm
to build a URL, which is: <routeName-projectName-routerSuffix>.

As the project/namespace name is built upon the session id, it can
sometimes generate a big URL.

So, instead of using the whole UUID random number, let's get only the
first part of it, which still gives us a reasonable random string.

Closes #763.