### PR TITLE
Stop VNC recorder before moving recording file

### DIFF
--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManager.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManager.java
@@ -56,7 +56,8 @@ public class VncRecorderLifecycleManager {
         CubeDroneConfiguration cubeDroneConfiguration, SeleniumContainers seleniumContainers) {
 
         if (this.vnc != null) {
-
+            vnc.stop();
+            
             Path finalLocation = null;
             if (shouldRecordOnlyOnFailure(testResult, cubeDroneConfiguration)) {
                 finalLocation =
@@ -68,7 +69,6 @@ public class VncRecorderLifecycleManager {
                 }
             }
 
-            vnc.stop();
             vnc.destroy();
 
             this.afterVideoRecordedEvent.fire(new AfterVideoRecorded(afterTestMethod, finalLocation));


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes FileSystemException when using vnc recording under Windows

#### Changes proposed in this pull request:

- Stop VNC recorder before moving recording file


**Fixes**: #761 
