### PR TITLE
PortForwarder: Make sure to release the error channel latch

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/portforward/PortForwardServerConnection.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/portforward/PortForwardServerConnection.java
@@ -205,7 +205,8 @@ public class PortForwardServerConnection extends AbstractServerConnection {
         getChannel().getCloseSetter()
             .set(new ChainedChannelListener<CloseableChannel>(
                 new CancelTimerChannelListener(timer),
-                new LatchReleaseChannelListener(requestComplete)));
+                new LatchReleaseChannelListener(requestComplete),
+                new LatchReleaseChannelListener(errorComplete)));
 
         clientConnection.sendRequest(request, new ClientCallback<ClientExchange>() {
             @Override
@@ -224,7 +225,10 @@ public class PortForwardServerConnection extends AbstractServerConnection {
                     public void completed(final ClientExchange result) {
                         result.getResponseChannel()
                             .getCloseSetter()
-                            .set(new LatchReleaseChannelListener(requestComplete));
+                            .set(new ChainedChannelListener<CloseableChannel>(
+                                    new CancelTimerChannelListener(timer),
+                                    new LatchReleaseChannelListener(requestComplete),
+                                    new LatchReleaseChannelListener(errorComplete)));
                         getIoThread().execute(new Runnable() {
                             @Override
                             public void run() {


### PR DESCRIPTION
On every situation, so that it doesn't hang like the thread dump
below shows (PortForwardServerConnection.java:124 is the guilty
guy here):
```
"PortForwarding for cearq-amq63-2cec0671/testrunner task-4" #455 prio=5 os_prio=0 tid=0x00007f5a4433c000 nid=0x55ec waiting on condition [0x00007f59ea02b000]
   java.lang.Thread.State: WAITING (parking)
	at sun.misc.Unsafe.park(Native Method)
	- parking to wait for  <0x00000006ca0e7ed0> (a java.util.concurrent.CountDownLatch$Sync)
	at java.util.concurrent.locks.LockSupport.park(LockSupport.java:175)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.parkAndCheckInterrupt(AbstractQueuedSynchronizer.java:836)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.doAcquireSharedInterruptibly(AbstractQueuedSynchronizer.java:997)
	at java.util.concurrent.locks.AbstractQueuedSynchronizer.acquireSharedInterruptibly(AbstractQueuedSynchronizer.java:1304)
	at java.util.concurrent.CountDownLatch.await(CountDownLatch.java:231)
	at org.arquillian.cube.kubernetes.impl.portforward.PortForwardServerConnection.startForwarding(PortForwardServerConnection.java:124)
	at org.arquillian.cube.kubernetes.impl.portforward.PortForwardOpenListener$1.run(PortForwardOpenListener.java:90)
	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
	at java.lang.Thread.run(Thread.java:748)
```