### PR TITLE
Openshift: Fix @Observer parameter

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftSuiteLifecycleController.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftSuiteLifecycleController.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.openshift.impl.client;
 
+import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.spi.event.CreateCube;
 import org.arquillian.cube.spi.event.CubeControlEvent;
 import org.arquillian.cube.spi.event.DestroyCube;
@@ -17,7 +18,12 @@ public class OpenShiftSuiteLifecycleController {
     private Event<CubeControlEvent> controlEvent;
 
     public void startAutoContainers(@Observes(precedence = 99) BeforeSuite event,
-        CubeOpenShiftConfiguration openshiftConfiguration) {
+        Configuration conf) {
+        if (!(conf instanceof CubeOpenShiftConfiguration)) {
+            return;
+        }
+        CubeOpenShiftConfiguration openshiftConfiguration = (CubeOpenShiftConfiguration) conf;
+
         for (String cubeId : openshiftConfiguration.getAutoStartContainers()) {
             controlEvent.fire(new CreateCube(cubeId));
             controlEvent.fire(new StartCube(cubeId));
@@ -25,7 +31,12 @@ public class OpenShiftSuiteLifecycleController {
     }
 
     public void stopAutoContainers(@Observes(precedence = -99) AfterSuite event,
-        CubeOpenShiftConfiguration openshiftConfiguration) {
+        Configuration conf) {
+        if (!(conf instanceof CubeOpenShiftConfiguration)) {
+            return;
+        }
+        CubeOpenShiftConfiguration openshiftConfiguration = (CubeOpenShiftConfiguration) conf;
+
         String[] autostart = openshiftConfiguration.getAutoStartContainers();
         for (int i = autostart.length - 1; i > -1; i--) {
             String cubeId = autostart[i];


### PR DESCRIPTION
It's the Configuration class that gets injected, not
CubeOpenShiftConfiguration, so, this second parameter will
never be resolved and thus the method will never be invoked.

This suppresses the following warning:

WARNING: Argument 1 for OpenShiftSuiteLifecycleController.startAutoContainers is null. It won't be invoked.