### PR TITLE
Move RouteURL functionality from ce-arq

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/util/ConfigUtil.java
+++ b/core/src/main/java/org/arquillian/cube/impl/util/ConfigUtil.java
@@ -5,6 +5,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static org.arquillian.cube.impl.util.SystemEnvironmentVariables.getPropertyOrEnvironmentVariable;
 
@@ -56,6 +57,14 @@ public class ConfigUtil {
             return Boolean.parseBoolean(map.get(name));
         } else {
             return getPropertyOrEnvironmentVariable(name, defaultValue);
+        }
+    }
+
+    public static int getIntProperty(String name, Optional<String> alternativeName, Map<String, String> map, int defaultValue) {
+        if (map.containsKey(name)) {
+            return Integer.parseInt(map.get(name));
+        } else {
+            return Integer.parseInt(String.valueOf(getPropertyOrEnvironmentVariable(alternativeName.isPresent() ? alternativeName.get() : name, defaultValue)));
         }
     }
 

--- a/openshift/openshift/pom.xml
+++ b/openshift/openshift/pom.xml
@@ -11,6 +11,7 @@
 
   <properties>
     <version.openshift_restclient>1.0.0-SNAPSHOT</version.openshift_restclient>
+    <version.javax.inject>1</version.javax.inject>
     <version.jgit>4.0.0.201506090130-r</version.jgit>
     <version.alpn>8.1.9.v20160720</version.alpn>
   </properties>
@@ -49,6 +50,12 @@
       <artifactId>arquillian-container-test-spi
       </artifactId> <!-- required to for container integration, but not standalone -->
       <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>javax.inject</groupId>
+      <artifactId>javax.inject</artifactId>
+      <version>${version.javax.inject}</version>
     </dependency>
 
     <dependency>

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -16,6 +16,7 @@ import org.arquillian.cube.openshift.impl.client.CubeOpenShiftRegistrar;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfigurationFactory;
 import org.arquillian.cube.openshift.impl.client.OpenShiftClientCreator;
 import org.arquillian.cube.openshift.impl.client.OpenShiftSuiteLifecycleController;
+import org.arquillian.cube.openshift.impl.enricher.RouteURLEnricher;
 import org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigListResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.internal.OpenshiftClientResourceProvider;
@@ -23,7 +24,10 @@ import org.arquillian.cube.openshift.impl.feedback.OpenshiftFeedbackProvider;
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
 import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
+import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
+import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentScenarioGenerator;
 import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.TestEnricher;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
 public class CubeOpenshiftExtension implements LoadableExtension {
@@ -44,6 +48,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
             .service(ResourceProvider.class, org.arquillian.cube.openshift.impl.enricher.external.DeploymentConfigResourceProvider.class)
             .service(ResourceProvider.class, org.arquillian.cube.openshift.impl.enricher.external.DeploymentConfigListResourceProvider.class)
 
+            .service(TestEnricher.class, RouteURLEnricher.class)
 
             .override(ConfigurationFactory.class, DefaultConfigurationFactory.class,
                 CubeOpenShiftConfigurationFactory.class)

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -7,6 +7,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.UUID;
 
@@ -20,6 +21,7 @@ import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
 
 import static org.arquillian.cube.impl.util.ConfigUtil.asURL;
 import static org.arquillian.cube.impl.util.ConfigUtil.getBooleanProperty;
+import static org.arquillian.cube.impl.util.ConfigUtil.getIntProperty;
 import static org.arquillian.cube.impl.util.ConfigUtil.getLongProperty;
 import static org.arquillian.cube.impl.util.ConfigUtil.getStringProperty;
 
@@ -40,6 +42,9 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String PROXIED_CONTAINER_PORTS = "proxiedContainerPorts";
     private static final String PORT_FORWARDER_BIND_ADDRESS = "portForwardBindAddress";
+    private static final String ROUTER_HOST = "routerHost";
+    private static final String OPENSHIFT_ROUTER_HTTP_PORT = "openshiftRouterHttpPort";
+    private static final String OPENSHIFT_ROUTER_HTTPS_PORT = "openshiftRouterHttpsPort";
 
     private static final String DEFAULT_OPENSHIFT_CONFIG_FILE_NAME = "openshift.json";
 
@@ -49,6 +54,9 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private final String[] autoStartContainers;
     private final Set<String> proxiedContainerPorts;
     private final String portForwardBindAddress;
+    private final String routerHost;
+    private final int openshiftRouterHttpPort;
+    private final int openshiftRouterHttpsPort;
 
     public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, URL environmentSetupScriptUrl,
         URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentConfigAdditionalUrls, List<URL> environmentDependencies,
@@ -58,7 +66,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
         List<String> waitForServiceList, boolean ansiLoggerEnabled, boolean environmentInitEnabled,
         String kubernetesDomain, String dockerRegistry, boolean keepAliveGitServer, String definitions,
         String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts,
-        String portForwardBindAddress) {
+        String portForwardBindAddress, String routerHost, int openshiftRouterHttpPort, int openshiftRouterHttpsPort) {
         super(sessionId, masterUrl, namespace, environmentSetupScriptUrl, environmentTeardownScriptUrl,
             environmentConfigUrl, environmentConfigAdditionalUrls, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
             namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled,
@@ -70,6 +78,9 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
         this.autoStartContainers = autoStartContainers;
         this.proxiedContainerPorts = proxiedContainerPorts;
         this.portForwardBindAddress = portForwardBindAddress;
+        this.routerHost = routerHost;
+        this.openshiftRouterHttpPort = openshiftRouterHttpPort;
+        this.openshiftRouterHttpsPort = openshiftRouterHttpsPort;
     }
 
     private static String[] split(String str, String regex) {
@@ -111,7 +122,6 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 }
             }
         }
-
 
         try {
             return new CubeOpenShiftConfigurationBuilder()
@@ -156,6 +166,9 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 .withAutoStartContainers(split(getStringProperty(AUTO_START_CONTAINERS, map, ""), ","))
                 .withProxiedContainerPorts(split(getStringProperty(PROXIED_CONTAINER_PORTS, map, ""), ","))
                 .withPortForwardBindAddress(getStringProperty(PORT_FORWARDER_BIND_ADDRESS, map, "127.0.0.1"))
+                .withRouterHost(getStringProperty(ROUTER_HOST, "openshift.router.host", map, null))
+                .withOpenshiftRouterHttpPort(getIntProperty(OPENSHIFT_ROUTER_HTTP_PORT, Optional.of("openshift.router.httpPort"), map, 80))
+                .withOpenshiftRouterHttpsPort(getIntProperty(OPENSHIFT_ROUTER_HTTPS_PORT, Optional.of("openshift.router.httpsPort"), map, 443))
                 .build();
         } catch (Throwable t) {
             if (t instanceof RuntimeException) {
@@ -202,5 +215,17 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
 
     public String getPortForwardBindAddress() {
         return portForwardBindAddress;
+    }
+
+    public String getRouterHost() {
+        return routerHost;
+    }
+
+    public int getOpenshiftRouterHttpPort() {
+        return openshiftRouterHttpPort;
+    }
+
+    public int getOpenshiftRouterHttpsPort() {
+        return openshiftRouterHttpsPort;
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
@@ -1,0 +1,29 @@
+package org.arquillian.cube.openshift.impl.enricher;
+
+import javax.inject.Qualifier;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * OpenShiftRouter
+ * <p/>
+ * Used with @ArquillianResource URL objects. Provides a URL to the OpenShift
+ * router configured on the ce-cube extension, u    e.g.
+ * arq.extension.openshift.routerHost, or through arquillian.xml using routerHost parameter, setting the hostname appropriately.
+ *
+ * @author Rob Cernich
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+@Target({ElementType.FIELD, ElementType.PARAMETER })
+public @interface RouteURL {
+    /**
+     * @return the route name
+     */
+    String value() default "";
+}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
@@ -1,0 +1,99 @@
+package org.arquillian.cube.openshift.impl.enricher;
+
+import io.fabric8.openshift.api.model.v2_5.Route;
+import org.arquillian.cube.impl.util.ReflectionUtil;
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.spi.TestEnricher;
+
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Field;
+import java.lang.reflect.Method;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+/**
+ * RouteProxyProvider
+ *
+ * @author Rob Cernich
+ */
+public class RouteURLEnricher implements TestEnricher {
+
+    @Inject
+    private Instance<OpenShiftClient> clientInstance;
+
+    @Inject
+    private Instance<Configuration> configurationInstance;
+
+    @Override
+    public void enrich(Object testCase) {
+        for (Field field : ReflectionUtil.getFieldsWithAnnotation(testCase.getClass(), RouteURL.class)) {
+            try {
+                if (!field.isAccessible()) {
+                    field.setAccessible(true);
+                }
+                field.set(testCase, lookup(getRouteURLAnnotation(field.getAnnotations())));
+            } catch (Exception e) {
+                throw new RuntimeException("Could not set RouteURL value on field " + field, e);
+            }
+        }
+    }
+
+    @Override
+    public Object[] resolve(Method method) {
+        Object[] values = new Object[method.getParameterTypes().length];
+        Class<?>[] parameterTypes = method.getParameterTypes();
+        for (int i = 0; i < parameterTypes.length; i++) {
+            RouteURL routeURL = getRouteURLAnnotation(method.getParameterAnnotations()[i]);
+            if (routeURL != null) {
+                values[i] = lookup(routeURL);
+            }
+        }
+        return values;
+    }
+
+    private RouteURL getRouteURLAnnotation(Annotation[] annotations) {
+        for (Annotation annotation : annotations) {
+            if (annotation.annotationType() == RouteURL.class) {
+                return (RouteURL) annotation;
+            }
+        }
+        return null;
+    }
+
+    private URL lookup(RouteURL routeURL) {
+
+        final String routeName = routeURL.value();
+        if (routeURL == null || routeName == null || routeName.length() == 0) {
+            throw new NullPointerException("RouteURL is null, must specify a route name!");
+        }
+
+        final CubeOpenShiftConfiguration config = (CubeOpenShiftConfiguration) configurationInstance.get();
+        if (config == null) {
+            throw new NullPointerException("CubeOpenShiftConfiguration is null.");
+        }
+
+        final String routerAddress = config.getRouterHost();
+        if (routerAddress == null || routerAddress.length() == 0) {
+            throw new IllegalArgumentException("Must specify routerHost!");
+        }
+
+        final OpenShiftClient client = clientInstance.get();
+        final Route route = client.getClient().routes().inNamespace(config.getNamespace()).withName(routeName).get();
+        if (route == null) {
+            throw new IllegalArgumentException("Could not resolve route: " + routeName);
+        }
+
+        final String protocol = route.getSpec().getTls() == null ? "http" : "https";
+        final int port = protocol.equals("http") ? config.getOpenshiftRouterHttpPort() : config.getOpenshiftRouterHttpsPort();
+
+        try {
+            return new URL(protocol, route.getSpec().getHost(), port, "/");
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException("Unable to create route URL", e);
+        }
+    }
+}


### PR DESCRIPTION
This commit aggregate a useful functionality ported from CE-ARQ (https://github.com/jboss-openshift/ce-arq) that allows user to get the routes to their services just by using the @RouteURL annotation in the test class, example:

```
@RouteURL("eap-app")
private URL routeToMyApp
```

**Fixes**: #744 
