### PR TITLE
Fix potential NullPointerException

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/client/container/ContainerConfigurationController.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/container/ContainerConfigurationController.java
@@ -102,6 +102,9 @@ public class ContainerConfigurationController {
 
         try {
             Method method = fieldName.getReadMethod();
+            if (method == null) {
+                return -1;
+            }
             return (int) method.invoke(configurationInstance);
         } catch (SecurityException e) {
             throw new IllegalArgumentException(e);


### PR DESCRIPTION
This fixes a potential null pointer exception when getting default container ports.
Observed running against a remote glassfish container. 

https://github.com/arquillian/arquillian-cube/issues/789