### PR TITLE
Drone parallel test support

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/StarOperator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/StarOperator.java
@@ -59,7 +59,7 @@ public class StarOperator {
         return containerName + "_" + uuid;
     }
 
-    private static int generateRandomPrivatePort() {
+    public static int generateRandomPrivatePort() {
         final int randomPort = random.nextInt(16383);
         return randomPort + 49152;
     }

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/CubeDroneConfiguration.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/CubeDroneConfiguration.java
@@ -26,6 +26,15 @@ public class CubeDroneConfiguration {
      * @see org.arquillian.cube.docker.drone.CubeDroneConfiguration#browserImage
      */
     private String browserDockerfileLocation = null;
+    /**
+     * Strategy for naming of containers, either always the same name or static with a configurable
+     * prefix or a randomly generated, unique name.
+     */
+    private ContainerNameStrategy containerNameStrategy = ContainerNameStrategy.STATIC;
+    /**
+     * Prefix for STATIC_PREFIX container name strategy.
+     */
+    private String containerNamePrefix = null;
 
     public static CubeDroneConfiguration fromMap(Map<String, String> config) {
         CubeDroneConfiguration cubeDroneConfiguration = new CubeDroneConfiguration();
@@ -44,6 +53,14 @@ public class CubeDroneConfiguration {
 
         if (config.containsKey("browserDockerfileLocation")) {
             cubeDroneConfiguration.browserDockerfileLocation = config.get("browserDockerfileLocation");
+        }
+
+        if (config.containsKey("containerNameStrategy")) {
+            cubeDroneConfiguration.containerNameStrategy = ContainerNameStrategy.valueOf(config.get("containerNameStrategy"));
+        }
+
+        if (config.containsKey("containerNamePrefix")) {
+            cubeDroneConfiguration.containerNamePrefix = config.get("containerNamePrefix");
         }
 
         return cubeDroneConfiguration;
@@ -84,8 +101,20 @@ public class CubeDroneConfiguration {
     public String getBrowserDockerfileLocation() {
         return browserDockerfileLocation;
     }
+    
+    public ContainerNameStrategy getContainerNameStrategy(){
+        return this.containerNameStrategy;
+    }
 
+    public String getContainerNamePrefix(){
+        return this.containerNamePrefix;
+    }
+    
     public static enum RecordMode {
         ALL, ONLY_FAILING, NONE;
+    }
+    
+    public static enum ContainerNameStrategy {
+        STATIC, STATIC_PREFIX, RANDOM;
     }
 }

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -15,6 +15,7 @@ import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.client.config.Image;
 import org.arquillian.cube.docker.impl.client.config.Link;
 import org.arquillian.cube.docker.impl.client.config.PortBinding;
+import org.arquillian.cube.docker.impl.client.config.StarOperator;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 
@@ -53,12 +54,28 @@ public class SeleniumContainers {
     private SeleniumContainers(String browser, CubeDroneConfiguration cubeDroneConfiguration) {
         this.browser = browser;
         
-        UUID namePostfix = UUID.randomUUID();
-        this.seleniumContainerName = "browser_" + namePostfix;
-        this.vncContainerName = "vnc_" + namePostfix;
-        this.conversionContainerName = "flv2mp4_" + namePostfix;
-        
-        this.seleniumBoundedPort = 49152 + new Random().nextInt(16383);
+        switch(cubeDroneConfiguration.getContainerNameStrategy()) {
+            case RANDOM:
+                UUID uuid = UUID.randomUUID();
+                this.seleniumContainerName = StarOperator.generateNewName("browser", uuid);
+                this.vncContainerName = StarOperator.generateNewName("vnc", uuid);
+                this.conversionContainerName = StarOperator.generateNewName("flv2mp4", uuid);
+                this.seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
+                break;
+            case STATIC_PREFIX:
+                this.seleniumContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_browser";
+                this.vncContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_vnc";
+                this.conversionContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_flv2mp4";
+                this.seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
+                break;
+            case STATIC:
+            default:
+                this.seleniumContainerName = "browser";
+                this.vncContainerName = "vnc";
+                this.conversionContainerName = "flv2mp4";
+                this.seleniumBoundedPort = 14444;
+                break;
+        }
         
         this.videoRecordingFolder = VolumeCreator.createTemporaryVolume(DEFAULT_PASSWORD);
         

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -2,7 +2,6 @@ package org.arquillian.cube.docker.drone;
 
 import java.nio.file.Path;
 import java.util.Arrays;
-import java.util.Random;
 import java.util.UUID;
 import java.util.logging.Logger;
 
@@ -22,7 +21,10 @@ import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 public class SeleniumContainers {
 
     private static final Logger logger = Logger.getLogger(SeleniumContainers.class.getName());
-    
+
+    private static final String SELENIUM_CONTAINER_BASE_NAME = "browser";
+    private static final String VNC_CONTAINER_BASE_NAME = "vnc";
+    private static final String CONVERSION_CONTAINER_BASE_NAME = "flv2mp4";
     private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
     private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:%s";
     private static final String VNC_IMAGE = "richnorth/vnc-recorder:latest";
@@ -31,7 +33,6 @@ public class SeleniumContainers {
     private static final String VNC_HOSTNAME = "vnchost";
     private static final String VOLUME_DIR = "/recording";
     private static final int VNC_EXPOSED_PORT = 5900;
-    public static final int SELENIUM_EXPOSED_PORT = 4444;
     public static final String[] FLVREC_COMMAND = new String[] {
         "-o",
         VOLUME_DIR + "/screen.flv",
@@ -57,22 +58,22 @@ public class SeleniumContainers {
         switch(cubeDroneConfiguration.getContainerNameStrategy()) {
             case RANDOM:
                 UUID uuid = UUID.randomUUID();
-                this.seleniumContainerName = StarOperator.generateNewName("browser", uuid);
-                this.vncContainerName = StarOperator.generateNewName("vnc", uuid);
-                this.conversionContainerName = StarOperator.generateNewName("flv2mp4", uuid);
+                this.seleniumContainerName = StarOperator.generateNewName(SELENIUM_CONTAINER_BASE_NAME, uuid);
+                this.vncContainerName = StarOperator.generateNewName(VNC_CONTAINER_BASE_NAME, uuid);
+                this.conversionContainerName = StarOperator.generateNewName(CONVERSION_CONTAINER_BASE_NAME, uuid);
                 this.seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
                 break;
             case STATIC_PREFIX:
-                this.seleniumContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_browser";
-                this.vncContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_vnc";
-                this.conversionContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_flv2mp4";
+                this.seleniumContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + SELENIUM_CONTAINER_BASE_NAME;
+                this.vncContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + VNC_CONTAINER_BASE_NAME;
+                this.conversionContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + CONVERSION_CONTAINER_BASE_NAME;
                 this.seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
                 break;
             case STATIC:
             default:
-                this.seleniumContainerName = "browser";
-                this.vncContainerName = "vnc";
-                this.conversionContainerName = "flv2mp4";
+                this.seleniumContainerName = SELENIUM_CONTAINER_BASE_NAME;
+                this.vncContainerName = VNC_CONTAINER_BASE_NAME;
+                this.conversionContainerName = CONVERSION_CONTAINER_BASE_NAME;
                 this.seleniumBoundedPort = 14444;
                 break;
         }
@@ -222,7 +223,7 @@ public class SeleniumContainers {
 
     private static void setDefaultSeleniumCubeProperties(CubeContainer cubeContainer, int seleniumBoundedPort) {
         cubeContainer.setPortBindings(
-            Arrays.asList(PortBinding.valueOf(seleniumBoundedPort + "-> " + SELENIUM_EXPOSED_PORT))
+            Arrays.asList(PortBinding.valueOf(seleniumBoundedPort + "-> 4444"))
         );
 
         Await await = new Await();

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -2,6 +2,8 @@ package org.arquillian.cube.docker.drone;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.Random;
+import java.util.UUID;
 import java.util.logging.Logger;
 
 import org.arquillian.cube.docker.drone.util.SeleniumVersionExtractor;
@@ -20,9 +22,6 @@ public class SeleniumContainers {
 
     private static final Logger logger = Logger.getLogger(SeleniumContainers.class.getName());
     
-    public static final String SELENIUM_CONTAINER_NAME = "browser";
-    public static final String VNC_CONTAINER_NAME = "vnc";
-    public static final String CONVERSION_CONTAINER_NAME = "flv2mp4";
     private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
     private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:%s";
     private static final String VNC_IMAGE = "richnorth/vnc-recorder:latest";
@@ -30,8 +29,8 @@ public class SeleniumContainers {
     private static final String DEFAULT_PASSWORD = "secret";
     private static final String VNC_HOSTNAME = "vnchost";
     private static final String VOLUME_DIR = "/recording";
-    private static final int SELENIUM_BOUNDED_PORT = 14444;
     private static final int VNC_EXPOSED_PORT = 5900;
+    public static final int SELENIUM_EXPOSED_PORT = 4444;
     public static final String[] FLVREC_COMMAND = new String[] {
         "-o",
         VOLUME_DIR + "/screen.flv",
@@ -45,21 +44,33 @@ public class SeleniumContainers {
     private CubeContainer videoConverterContainer;
     private String browser;
     private Path videoRecordingFolder;
+    
+    private final String seleniumContainerName;
+    private final String vncContainerName;
+    private final String conversionContainerName;
+    private final int seleniumBoundedPort;
 
-    private SeleniumContainers(CubeContainer seleniumContainer, String browser, CubeContainer vncContainer,
-        CubeContainer videoConverterContainer, Path videoRecordingFolder) {
-        this.seleniumContainer = seleniumContainer;
-        this.vncContainer = vncContainer;
-        this.videoConverterContainer = videoConverterContainer;
+    private SeleniumContainers(String browser, CubeDroneConfiguration cubeDroneConfiguration) {
         this.browser = browser;
-        this.videoRecordingFolder = videoRecordingFolder;
+        
+        UUID namePostfix = UUID.randomUUID();
+        this.seleniumContainerName = "browser_" + namePostfix;
+        this.vncContainerName = "vnc_" + namePostfix;
+        this.conversionContainerName = "flv2mp4_" + namePostfix;
+        
+        this.seleniumBoundedPort = 49152 + new Random().nextInt(16383);
+        
+        this.videoRecordingFolder = VolumeCreator.createTemporaryVolume(DEFAULT_PASSWORD);
+        
+        this.seleniumContainer = createSeleniumContainer(browser, cubeDroneConfiguration, this.seleniumBoundedPort);
+        this.vncContainer = createVncContainer(this.videoRecordingFolder, this.seleniumContainerName);
+        final Path targetVolume = VideoFileDestination.resolveTargetDirectory(cubeDroneConfiguration);
+        this.videoConverterContainer = createVideoConverterContainer(targetVolume);
+        
     }
 
     public static SeleniumContainers create(String browser, CubeDroneConfiguration cubeDroneConfiguration) {
-        final Path temporaryVolume = VolumeCreator.createTemporaryVolume(DEFAULT_PASSWORD);
-        final Path targetVolume = VideoFileDestination.resolveTargetDirectory(cubeDroneConfiguration);
-        return new SeleniumContainers(createSeleniumContainer(browser, cubeDroneConfiguration), browser,
-            createVncContainer(temporaryVolume), createVideoConverterContainer(targetVolume), temporaryVolume);
+        return new SeleniumContainers(browser, cubeDroneConfiguration);
     }
 
     private static CubeContainer createVideoConverterContainer(Path dockerVolume) {
@@ -85,7 +96,7 @@ public class SeleniumContainers {
         return cubeContainer;
     }
 
-    private static CubeContainer createVncContainer(final Path dockerVolume) {
+    private static CubeContainer createVncContainer(final Path dockerVolume, String seleniumContainerName) {
 
         CubeContainer cubeContainer = new CubeContainer();
         cubeContainer.setImage(Image.valueOf(VNC_IMAGE));
@@ -94,7 +105,7 @@ public class SeleniumContainers {
             Arrays.asList(convertToBind(dockerVolume, VOLUME_DIR, "rw"))
         );
 
-        final Link link = Link.valueOf(SELENIUM_CONTAINER_NAME + ":" + VNC_HOSTNAME);
+        final Link link = Link.valueOf(seleniumContainerName + ":" + VNC_HOSTNAME);
         cubeContainer.setLinks(Arrays.asList(link));
 
         // Using sleeping strategy since VNC client is a CLI without exposing a port
@@ -146,62 +157,61 @@ public class SeleniumContainers {
         }
     }
 
-    private static CubeContainer createSeleniumContainer(String browser, CubeDroneConfiguration cubeDroneConfiguration) {
+    private static CubeContainer createSeleniumContainer(String browser, CubeDroneConfiguration cubeDroneConfiguration, int seleniumBoundedPort) {
 
         if (cubeDroneConfiguration.isBrowserDockerfileDirectorySet()) {
-            return createCube(cubeDroneConfiguration.getBrowserDockerfileLocation());
+            return createCube(cubeDroneConfiguration.getBrowserDockerfileLocation(), seleniumBoundedPort);
         } else {
             if (cubeDroneConfiguration.isBrowserImageSet()) {
-                return configureCube(cubeDroneConfiguration.getBrowserImage());
+                return configureCube(cubeDroneConfiguration.getBrowserImage(), seleniumBoundedPort);
             } else {
-                return useOfficialSeleniumImages(browser);
+                return useOfficialSeleniumImages(browser, seleniumBoundedPort);
             }
         }
     }
 
-    private static CubeContainer useOfficialSeleniumImages(String browser) {
+    private static CubeContainer useOfficialSeleniumImages(String browser, int seleniumBoundedPort) {
         String version = SeleniumVersionExtractor.fromClassPath();
 
         switch (browser) {
             case "firefox":
-                return configureCube(String.format(FIREFOX_IMAGE, version));
+                return configureCube(String.format(FIREFOX_IMAGE, version), seleniumBoundedPort);
             case "chrome":
-                return configureCube(String.format(CHROME_IMAGE, version));
+                return configureCube(String.format(CHROME_IMAGE, version), seleniumBoundedPort);
             default:
                 throw new UnsupportedOperationException(
                     "Unsupported browser " + browser + ". Only firefox and chrome are supported.");
         }
     }
 
-    private static CubeContainer createCube(String dockerFileLocation) {
+    private static CubeContainer createCube(String dockerFileLocation, int seleniumBoundedPort) {
         CubeContainer cubeContainer = new CubeContainer();
         BuildImage buildImage = new BuildImage(dockerFileLocation, null, true, true);
         cubeContainer.setBuildImage(buildImage);
 
-        setDefaultSeleniumCubeProperties(cubeContainer);
+        setDefaultSeleniumCubeProperties(cubeContainer, seleniumBoundedPort);
 
         return cubeContainer;
     }
 
-    private static CubeContainer configureCube(String image) {
+    private static CubeContainer configureCube(String image, int seleniumBoundedPort) {
         CubeContainer cubeContainer = new CubeContainer();
         cubeContainer.setImage(Image.valueOf(image));
 
-        setDefaultSeleniumCubeProperties(cubeContainer);
+        setDefaultSeleniumCubeProperties(cubeContainer, seleniumBoundedPort);
 
         return cubeContainer;
     }
 
-    private static void setDefaultSeleniumCubeProperties(CubeContainer cubeContainer) {
+    private static void setDefaultSeleniumCubeProperties(CubeContainer cubeContainer, int seleniumBoundedPort) {
         cubeContainer.setPortBindings(
-            Arrays.asList(PortBinding.valueOf(SELENIUM_BOUNDED_PORT + "-> 4444"))
+            Arrays.asList(PortBinding.valueOf(seleniumBoundedPort + "-> " + SELENIUM_EXPOSED_PORT))
         );
 
         Await await = new Await();
         await.setStrategy("http");
         await.setResponseCode(getSeleniumExpectedResponseCode());
-        await.setUrl("http://dockerHost:" + SELENIUM_BOUNDED_PORT);
-
+        await.setUrl("http://dockerHost:" + seleniumBoundedPort);
         cubeContainer.setAwait(await);
 
         cubeContainer.setKillContainer(true);
@@ -242,19 +252,19 @@ public class SeleniumContainers {
     }
 
     public int getSeleniumBoundedPort() {
-        return SELENIUM_BOUNDED_PORT;
+        return seleniumBoundedPort;
     }
 
     public String getSeleniumContainerName() {
-        return SELENIUM_CONTAINER_NAME;
+        return seleniumContainerName;
     }
 
     public String getVncContainerName() {
-        return VNC_CONTAINER_NAME;
+        return vncContainerName;
     }
 
     public String getVideoConverterContainerName() {
-        return CONVERSION_CONTAINER_NAME;
+        return conversionContainerName;
     }
 
     public String getBrowser() {

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VideoConversionLifecycleManager.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VideoConversionLifecycleManager.java
@@ -4,6 +4,7 @@ import org.arquillian.cube.docker.drone.event.AfterConversion;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
@@ -14,6 +15,9 @@ public class VideoConversionLifecycleManager {
 
     @Inject
     Event<AfterConversion> afterConversionEvent;
+
+    @Inject
+    Instance<SeleniumContainers> seleniumContainersInstance;
 
     public void startConversion(@Observes AfterSuite afterSuite, CubeRegistry cubeRegistry) {
 
@@ -26,11 +30,13 @@ public class VideoConversionLifecycleManager {
 
     private void initConversionCube(CubeRegistry cubeRegistry) {
         if (flv2mp4 == null) {
-            Cube conversionContainer = cubeRegistry.getCube(SeleniumContainers.CONVERSION_CONTAINER_NAME);
+            SeleniumContainers seleniumContainers = seleniumContainersInstance.get();
+            
+            Cube conversionContainer = cubeRegistry.getCube(seleniumContainers.getVideoConverterContainerName());
 
             if (conversionContainer == null) {
                 throw new IllegalArgumentException(
-                    SeleniumContainers.CONVERSION_CONTAINER_NAME + " cube is not present in the registry.");
+                        "Video conversion cube is not present in the registry.");
             }
 
             this.flv2mp4 = conversionContainer;

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManager.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManager.java
@@ -9,6 +9,7 @@ import org.arquillian.cube.docker.drone.util.VideoFileDestination;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.TestResult;
@@ -25,6 +26,9 @@ public class VncRecorderLifecycleManager {
     @Inject
     Event<AfterVideoRecorded> afterVideoRecordedEvent;
 
+    @Inject
+    Instance<SeleniumContainers> seleniumContainersInstance;
+    
     Cube vnc;
 
     public void startRecording(@Observes Before beforeTestMethod, CubeDroneConfiguration cubeDroneConfiguration,
@@ -42,7 +46,9 @@ public class VncRecorderLifecycleManager {
 
     private void initVncCube(CubeRegistry cubeRegistry) {
         if (vnc == null) {
-            Cube vncContainer = cubeRegistry.getCube(SeleniumContainers.VNC_CONTAINER_NAME);
+            SeleniumContainers seleniumContainers = seleniumContainersInstance.get();
+            
+            Cube vncContainer = cubeRegistry.getCube(seleniumContainers.getVncContainerName());
 
             if (vncContainer == null) {
                 throw new IllegalArgumentException("VNC cube is not present in registry.");

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/graphene/location/DockerCubeCustomizableURLResourceProvider.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/graphene/location/DockerCubeCustomizableURLResourceProvider.java
@@ -64,9 +64,6 @@ public class DockerCubeCustomizableURLResourceProvider implements ResourceProvid
     Instance<CubeDockerConfiguration> cubeDockerConfigurationInstance;
 
     @Inject
-    Instance<SeleniumContainers> seleniumContainersInstance;
-
-    @Inject
     Instance<CubeRegistry> cubeRegistryInstance;
 
     @Override

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.docker.drone;
 
+import org.arquillian.cube.docker.drone.CubeDroneConfiguration.ContainerNameStrategy;
 import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.hamcrest.CustomMatcher;
 import org.hamcrest.Matcher;
@@ -8,16 +9,18 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertThat;
 import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class SeleniumContainersTest {
 
-    private final static Matcher<PortBinding> SELENIUM_PORT_BINDING_MATCHER =
+    private final static Matcher<PortBinding> SELENIUM_RANDOM_PORT_BINDING_MATCHER =
             new CustomMatcher<PortBinding>("a port binding for Selenium exposed port"){
                 @Override
                 public boolean matches(Object item){
@@ -25,6 +28,18 @@ public class SeleniumContainersTest {
                         PortBinding portBinding = (PortBinding) item;
                         return portBinding.getExposedPort().getExposed() == SeleniumContainers.SELENIUM_EXPOSED_PORT 
                                 && portBinding.getBound() >= 49152 && portBinding.getBound() < 65535;
+                    }
+                    return false;
+                }
+            };
+
+    private final static Matcher<String> UUID_CONTAINER_NAME_MATCHER =
+            new CustomMatcher<String>("a String matching 'browser|vnc|flv2mp4_UUID'"){
+                @Override
+                public boolean matches(Object item){
+                    if (item instanceof String) {
+                        String string = (String) item;
+                        return string.matches("(browser|vnc|flv2mp4)_[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}");
                     }
                     return false;
                 }
@@ -38,11 +53,12 @@ public class SeleniumContainersTest {
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
         when(cubeDroneConfiguration.getBrowserImage()).thenReturn("mycompany/mybrowser:1.0");
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
 
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("mycompany/mybrowser:1.0"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
     }
 
     @Test
@@ -50,12 +66,13 @@ public class SeleniumContainersTest {
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(true);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
         when(cubeDroneConfiguration.getBrowserDockerfileLocation()).thenReturn("src/test/resources/browser");
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
 
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getBuildImage().getDockerfileLocation().toString(),
             is("src/test/resources/browser"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
     }
 
     @Test
@@ -63,24 +80,26 @@ public class SeleniumContainersTest {
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(true);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(true);
         when(cubeDroneConfiguration.getBrowserDockerfileLocation()).thenReturn("src/test/resources/browser");
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
 
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getBuildImage().getDockerfileLocation().toString(),
             is("src/test/resources/browser"));
         assertThat(firefox.getSeleniumContainer().getImage(), is(nullValue()));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
     }
 
     @Test
     public void shouldCreateContainerForFirefox() {
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
 
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:2.53.0"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
         assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
     }
 
@@ -89,11 +108,52 @@ public class SeleniumContainersTest {
 
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
 
         final SeleniumContainers firefox = SeleniumContainers.create("chrome", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("chrome"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-chrome-debug:2.53.0"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
         assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
+    }
+
+    @Test
+    public void shouldCreateRandomContainerNameAndPort() {
+        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
+        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.RANDOM);
+
+        final SeleniumContainers seleniumContainers = SeleniumContainers.create("firefox", cubeDroneConfiguration);
+        assertThat(seleniumContainers.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_RANDOM_PORT_BINDING_MATCHER));
+        assertThat(seleniumContainers.getSeleniumContainerName(), both(UUID_CONTAINER_NAME_MATCHER).and(startsWith("browser")));
+        assertThat(seleniumContainers.getVncContainerName(), both(UUID_CONTAINER_NAME_MATCHER).and(startsWith("vnc")));
+        assertThat(seleniumContainers.getVideoConverterContainerName(), both(UUID_CONTAINER_NAME_MATCHER).and(startsWith("flv2mp4")));
+    }
+
+    @Test
+    public void shouldCreateStaticPrefixedContainerNameAndPort() {
+        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
+        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC_PREFIX);
+        when(cubeDroneConfiguration.getContainerNamePrefix()).thenReturn("test");
+
+        final SeleniumContainers seleniumContainers = SeleniumContainers.create("firefox", cubeDroneConfiguration);
+        assertThat(seleniumContainers.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_RANDOM_PORT_BINDING_MATCHER));
+        assertThat(seleniumContainers.getSeleniumContainerName(), is("test_browser"));
+        assertThat(seleniumContainers.getVncContainerName(), is("test_vnc"));
+        assertThat(seleniumContainers.getVideoConverterContainerName(), is("test_flv2mp4"));
+    }
+
+    @Test
+    public void shouldCreateStaticContainerNameAndPort() {
+        when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
+        when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
+        when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
+
+        final SeleniumContainers seleniumContainers = SeleniumContainers.create("firefox", cubeDroneConfiguration);
+        assertThat(seleniumContainers.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(seleniumContainers.getSeleniumContainerName(), is("browser"));
+        assertThat(seleniumContainers.getVncContainerName(), is("vnc"));
+        assertThat(seleniumContainers.getVideoConverterContainerName(), is("flv2mp4"));
     }
 }

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -1,6 +1,8 @@
 package org.arquillian.cube.docker.drone;
 
 import org.arquillian.cube.docker.impl.client.config.PortBinding;
+import org.hamcrest.CustomMatcher;
+import org.hamcrest.Matcher;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -15,6 +17,19 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class SeleniumContainersTest {
 
+    private final static Matcher<PortBinding> SELENIUM_PORT_BINDING_MATCHER =
+            new CustomMatcher<PortBinding>("a port binding for Selenium exposed port"){
+                @Override
+                public boolean matches(Object item){
+                    if (item instanceof PortBinding) {
+                        PortBinding portBinding = (PortBinding) item;
+                        return portBinding.getExposedPort().getExposed() == SeleniumContainers.SELENIUM_EXPOSED_PORT 
+                                && portBinding.getBound() >= 49152 && portBinding.getBound() < 65535;
+                    }
+                    return false;
+                }
+            };
+    
     @Mock
     CubeDroneConfiguration cubeDroneConfiguration;
 
@@ -27,7 +42,7 @@ public class SeleniumContainersTest {
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("mycompany/mybrowser:1.0"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
     }
 
     @Test
@@ -40,7 +55,7 @@ public class SeleniumContainersTest {
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getBuildImage().getDockerfileLocation().toString(),
             is("src/test/resources/browser"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
     }
 
     @Test
@@ -54,7 +69,7 @@ public class SeleniumContainersTest {
         assertThat(firefox.getSeleniumContainer().getBuildImage().getDockerfileLocation().toString(),
             is("src/test/resources/browser"));
         assertThat(firefox.getSeleniumContainer().getImage(), is(nullValue()));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
     }
 
     @Test
@@ -65,7 +80,7 @@ public class SeleniumContainersTest {
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-firefox-debug:2.53.0"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
         assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
     }
 
@@ -78,7 +93,7 @@ public class SeleniumContainersTest {
         final SeleniumContainers firefox = SeleniumContainers.create("chrome", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("chrome"));
         assertThat(firefox.getSeleniumContainer().getImage().toString(), is("selenium/standalone-chrome-debug:2.53.0"));
-        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(PortBinding.valueOf("14444->4444")));
+        assertThat(firefox.getSeleniumContainer().getPortBindings(), hasItem(SELENIUM_PORT_BINDING_MATCHER));
         assertThat(firefox.getSeleniumContainer().getAwait().getResponseCode(), is(403));
     }
 }

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -26,7 +26,7 @@ public class SeleniumContainersTest {
                 public boolean matches(Object item){
                     if (item instanceof PortBinding) {
                         PortBinding portBinding = (PortBinding) item;
-                        return portBinding.getExposedPort().getExposed() == SeleniumContainers.SELENIUM_EXPOSED_PORT 
+                        return portBinding.getExposedPort().getExposed() == 4444 
                                 && portBinding.getBound() >= 49152 && portBinding.getBound() < 65535;
                     }
                     return false;

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManagerTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManagerTest.java
@@ -5,9 +5,12 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.UUID;
+
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.core.api.Event;
+import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.arquillian.test.spi.TestResult;
 import org.jboss.arquillian.test.spi.event.suite.After;
@@ -45,10 +48,19 @@ public class VncRecorderLifecycleManagerTest {
 
     @Test
     public void should_start_vnc_by_default() {
-
-        when(cubeRegistry.getCube(SeleniumContainers.VNC_CONTAINER_NAME)).thenReturn(cube);
+        String vncName = "vnc_" + UUID.randomUUID();
+        when(seleniumContainers.getVncContainerName()).thenReturn(vncName);
+        when(cubeRegistry.getCube(vncName)).thenReturn(cube);
 
         VncRecorderLifecycleManager vncRecorderLifecycleManager = new VncRecorderLifecycleManager();
+
+        vncRecorderLifecycleManager.seleniumContainersInstance = new Instance<SeleniumContainers>() {
+            @Override
+            public SeleniumContainers get() {
+                return seleniumContainers;
+            }
+        };
+        
         vncRecorderLifecycleManager.startRecording(null,
             CubeDroneConfiguration.fromMap(new HashMap<String, String>()),
             cubeRegistry);

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManagerTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManagerTest.java
@@ -48,9 +48,8 @@ public class VncRecorderLifecycleManagerTest {
 
     @Test
     public void should_start_vnc_by_default() {
-        String vncName = "vnc_" + UUID.randomUUID();
-        when(seleniumContainers.getVncContainerName()).thenReturn(vncName);
-        when(cubeRegistry.getCube(vncName)).thenReturn(cube);
+        when(seleniumContainers.getVncContainerName()).thenReturn("vnc");
+        when(cubeRegistry.getCube("vnc")).thenReturn(cube);
 
         VncRecorderLifecycleManager vncRecorderLifecycleManager = new VncRecorderLifecycleManager();
 

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManagerTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/VncRecorderLifecycleManagerTest.java
@@ -5,7 +5,6 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.UUID;
 
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.CubeRegistry;

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/graphene/location/CubeDockerCustomizableURLResourceProviderTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/graphene/location/CubeDockerCustomizableURLResourceProviderTest.java
@@ -49,9 +49,6 @@ public class CubeDockerCustomizableURLResourceProviderTest {
     private CubeDockerConfiguration cubeDockerConfiguration;
 
     @Mock
-    private SeleniumContainers seleniumContainers;
-
-    @Mock
     private CubeRegistry cubeRegistry;
 
     @Mock
@@ -65,8 +62,6 @@ public class CubeDockerCustomizableURLResourceProviderTest {
     @Before
     public void prepareCubeDockerConfiguration() {
         when(cubeDockerConfiguration.getDockerServerIp()).thenReturn(DOCKER_HOST);
-        when(seleniumContainers.getSeleniumContainerName()).thenReturn(SeleniumContainers.SELENIUM_CONTAINER_NAME);
-        when(seleniumContainers.getVncContainerName()).thenReturn(SeleniumContainers.VNC_CONTAINER_NAME);
 
         when(hasPortBindings.getInternalIP()).thenReturn("192.168.99.100");
         when(cube.hasMetadata(HasPortBindings.class)).thenReturn(true);
@@ -85,12 +80,6 @@ public class CubeDockerCustomizableURLResourceProviderTest {
             @Override
             public GrapheneConfiguration get() {
                 return grapheneConfiguration;
-            }
-        };
-        dockerCubeCustomizableURLResourceProvider.seleniumContainersInstance = new Instance<SeleniumContainers>() {
-            @Override
-            public SeleniumContainers get() {
-                return seleniumContainers;
             }
         };
         dockerCubeCustomizableURLResourceProvider.cubeRegistryInstance = new Instance<CubeRegistry>() {

--- a/docs/drone.adoc
+++ b/docs/drone.adoc
@@ -45,6 +45,8 @@ recordingMode:: Configures mode for recording. The valid values are: `ALL, ONLY_
 videoOutput:: Directory where videos are stored. By default is `target/reports/videos` or if target does not exists `build/reports/videos` and if not creates a `target/reports/videos` by default.
 browserImage:: Docker image to be used as custom browser image instead of the official one (https://github.com/SeleniumHQ/docker-selenium). Notice that browser property will be used for setting `WebDriver` capabilities.
 browserDockerfileLocation:: Dockerfile location to be used to built custom docker image instead of the official one. This property has preference over browserImage.
+containerNameStrategy:: Sets the strategy for generating the container name. Valid values are `STATIC, STATIC_PREFIX, RANDOM` with the default being `STATIC`. `STATIC` will always use the same name, `STATIC_PREFIX` lets you define a prefix and enables running different tests in parallel and `RANDOM` generates a unique container name on every test run enabling running the same test in parallel.
+containerNamePrefix:: The prefix for the `STATIC_PREFIX` container name strategy.
 
 IMPORTANT: Your custom images must expose the webdriver port `4444` and if you plan to use VNC, expose the default port `5900` as well
 


### PR DESCRIPTION
#### Short description of what this resolves:
Enables running tests using Cube Drone in parallel.

#### Changes proposed in this pull request:
- Two new cubedrone configuration options
  - containerNameStrategy
  - containerNamePrefix

- STATIC name strategy: same behaviour as before
- STATIC_PREFIX name strategy: Adds a configurable prefix to the static container name
- RANDOM name strategy: Adds a random UUID to the container name

STATIC_PREFIX and RANDOM also cause a random port being picked for the Selenium bound port.

**Fixes**: #791 
