### PR TITLE
Add support for network aliases

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
@@ -51,6 +51,7 @@ public class CubeContainer {
     private Collection<String> extraHosts;
     private Collection<String> entryPoint;
     private Collection<String> networks;
+    private Collection<String> aliases;
     private String domainName;
     private Boolean alwaysPull = Boolean.FALSE;
     private boolean manual = false;
@@ -473,6 +474,14 @@ public class CubeContainer {
 
     public void setNetworks(Collection<String> networks) {
         this.networks = networks;
+    }
+
+    public Collection<String> getAliases(){
+        return aliases;
+    }
+
+    public void setAliases(Collection<String> aliases){
+        this.aliases = aliases;
     }
 
     public Collection<String> getDependingContainers() {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -490,6 +490,10 @@ public class DockerClientExecutor {
                 createContainerCmd.withIpv6Address(containerConfiguration.getIpv6Address());
             }
 
+            if (containerConfiguration.getAliases() != null) {
+                createContainerCmd.withAliases(containerConfiguration.getAliases().toArray(new String[0]));
+            }
+
             boolean alwaysPull = false;
 
             if (containerConfiguration.getAlwaysPull() != null) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ComposeBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ComposeBuilder.java
@@ -25,6 +25,7 @@ public class ComposeBuilder {
     private static final String NETWORKS = "networks";
     private static final String IP_V4_Address = "ipv4_address";
     private static final String IP_V6_Address = "ipv6_address";
+    private static final String ALIASES = "aliases";
 
     private static final String NETWORK_NAME_SUFFIX = "_default";
 
@@ -121,6 +122,9 @@ public class ComposeBuilder {
             }
             if (networkOption.containsKey(IP_V6_Address)) {
                 cubeContainer.setIpv6Address(asString(networkOption, IP_V6_Address));
+            }
+            if (networkOption.containsKey(ALIASES)) {
+                cubeContainer.setAliases(asListOfString(networkOption, ALIASES));
             }
         }
     }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
@@ -247,4 +247,16 @@ public class DockerComposeConverterTest {
     assertThat(webapp.getBuildImage(), is(notNullValue()));
   }
 
+  @Test
+  public void shouldTransformSimpleDockerComposeV2FormatNetworkAliases() throws URISyntaxException {
+    URI simpleDockerCompose = DockerComposeConverterTest.class.getResource("/simple-docker-compose-network-aliases-v2.yml").toURI();
+    DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(simpleDockerCompose));
+
+    DockerCompositions convert = dockerComposeConverter.convert();
+    CubeContainer webapp = convert.get("webapp");
+    assertThat(webapp, is(notNullValue()));
+    assertThat(webapp.getNetworks()).contains("front-tier");
+    assertThat(webapp.getAliases()).containsOnly("foo", "bar");
+  }
+
 }

--- a/docker/docker/src/test/resources/simple-docker-compose-network-aliases-v2.yml
+++ b/docker/docker/src/test/resources/simple-docker-compose-network-aliases-v2.yml
@@ -1,0 +1,13 @@
+version: '2'
+services:
+  webapp:
+    image: ubuntu
+    ports:
+      - "8080:8080"
+    networks:
+      front-tier:
+        aliases:
+          - foo
+          - bar
+networks:
+  front-tier:

--- a/docker/ftest-docker-machine-network/docker-compose.yml
+++ b/docker/ftest-docker-machine-network/docker-compose.yml
@@ -9,8 +9,20 @@ services:
       app_net:
         ipv4_address: 172.16.238.10
         ipv6_address: 2001:3984:3989::10
+        aliases:
+          - ping
+          - foo
       front:
       back:
+
+  pingpong2:
+    image: jonmorehouse/ping-pong
+    expose:
+      - "8080"
+    networks:
+      app_net:
+        aliases:
+          - pong
 
 networks:
   front:


### PR DESCRIPTION
#### Short description of what this resolves:
Adds support for configuring network aliases similiar to ip4/6 address support (taken from first network of a service)


**Fixes**: #793 
