### PR TITLE
Set alwaysPull through cubeSpecificProperties

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
@@ -116,6 +116,8 @@ public class DockerCompositions {
                 final CubeContainer overrideCubeContainer = overrideDockerCompositions.get(containerId);
 
                 cubeContainer.setRemoveVolumes(overrideCubeContainer.getRemoveVolumes());
+                
+                cubeContainer.setAlwaysPull(overrideCubeContainer.getAlwaysPull());
 
                 if (overrideCubeContainer.hasAwait()) {
                     cubeContainer.setAwait(overrideCubeContainer.getAwait());


### PR DESCRIPTION
#### Short description of what this resolves:
Allow specifying alwaysPull through cubeSpecificProperties when using Compose format.

**Fixes**: #800 
