### PR TITLE
skip the routerHost check in RouteURLEnricher

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
@@ -9,11 +9,8 @@ import java.lang.annotation.Target;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * OpenShiftRouter
- * <p/>
- * Used with @ArquillianResource URL objects. Provides a URL to the OpenShift
- * router configured on the ce-cube extension, u    e.g.
- * arq.extension.openshift.routerHost, or through arquillian.xml using routerHost parameter, setting the hostname appropriately.
+ * Provides a URL of given OpenShift route. If the route is not resolvable, you need to set the {@code routerHost} setting
+ * to the IP address of the OpenShift router.
  *
  * @author Rob Cernich
  */

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
@@ -76,11 +76,6 @@ public class RouteURLEnricher implements TestEnricher {
             throw new NullPointerException("CubeOpenShiftConfiguration is null.");
         }
 
-        final String routerAddress = config.getRouterHost();
-        if (routerAddress == null || routerAddress.length() == 0) {
-            throw new IllegalArgumentException("Must specify routerHost!");
-        }
-
         final OpenShiftClient client = clientInstance.get();
         final Route route = client.getClient().routes().inNamespace(config.getNamespace()).withName(routeName).get();
         if (route == null) {


### PR DESCRIPTION
#### Short description of what this resolves:

With this change, `@RouteURL` injection works even if `routerHost` isn't configured.

#### Changes proposed in this pull request:

- Remove the check for `routerHost` in `RouteURLEnricher`.
- Remove unreadable text in `@RouteURL` javadoc.

**Fixes**: #802
