### PR TITLE
Don't start flv2mp4 container when recordingMode is NONE

### DIFF
--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VideoConversionLifecycleManager.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VideoConversionLifecycleManager.java
@@ -19,13 +19,16 @@ public class VideoConversionLifecycleManager {
     @Inject
     Instance<SeleniumContainers> seleniumContainersInstance;
 
-    public void startConversion(@Observes AfterSuite afterSuite, CubeRegistry cubeRegistry) {
+    public void startConversion(@Observes AfterSuite afterSuite, CubeDroneConfiguration cubeDroneConfiguration,
+        CubeRegistry cubeRegistry) {
 
-        initConversionCube(cubeRegistry);
-        flv2mp4.create();
-        flv2mp4.start();
-
-        afterConversionEvent.fire(new AfterConversion());
+        if (cubeDroneConfiguration.isRecording()) {
+            initConversionCube(cubeRegistry);
+            flv2mp4.create();
+            flv2mp4.start();
+    
+            afterConversionEvent.fire(new AfterConversion());
+        }
     }
 
     private void initConversionCube(CubeRegistry cubeRegistry) {


### PR DESCRIPTION
#### Short description of what this resolves:
Prevents "java.lang.IllegalArgumentException: Video conversion cube is not present in the registry." being thrown when recording is disabled.


**Fixes**: #804 
