### PR TITLE
Fix Kubernetes-Openshift compatibility

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -86,7 +86,7 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 | definitionsFile                     | String         | Any | Definitions file path
 | proxiedContainerPorts               | List           | Any | Comma Separated List following Pod:containerPort OR Pod:MappedPort:ContainerPort
 | routerHost                          | String         | Any | Define OpenShift router address thats is used to resolve the pod's address and to get its route
-| enableImageStreamDetection          | Bool (true)    | Any | Define if you want that Arquillian Cube apply Image Stream files (`*-is.yml`) before deploying
+| enableImageStreamDetection          | Bool (true)    | Any | Define if you want that Arquillian Cube apply Image Stream files (`*-is.yml`) to Openshift before deploying
 |===============================================================================================================================================
 
 

--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -86,7 +86,7 @@ For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 | definitionsFile                     | String         | Any | Definitions file path
 | proxiedContainerPorts               | List           | Any | Comma Separated List following Pod:containerPort OR Pod:MappedPort:ContainerPort
 | routerHost                          | String         | Any | Define OpenShift router address thats is used to resolve the pod's address and to get its route
-| enableImageStreamDetection          | Bool (false)   | Any | Define if you want that Arquillian Cube apply Image Stream files (`*-is.yml`) before deploying
+| enableImageStreamDetection          | Bool (true)    | Any | Define if you want that Arquillian Cube apply Image Stream files (`*-is.yml`) before deploying
 |===============================================================================================================================================
 
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -73,8 +73,6 @@ public interface Configuration {
 
     URL getEnvironmentConfigUrl();
 
-    List<URL> getEnvironmentConfigAdditionalUrls();
-
     List<URL> getEnvironmentDependencies();
 
     String getSessionId();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/KubernetesResourceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/KubernetesResourceLocator.java
@@ -1,13 +1,22 @@
 package org.arquillian.cube.kubernetes.api;
 
 import java.net.URL;
+import java.util.Collection;
 
 public interface KubernetesResourceLocator extends WithToImmutable<KubernetesResourceLocator> {
 
     /**
-     * Locates the kubernetes resource.
+     * Locates the main kubernetes resource.
      *
      * @return Returns the url that points to the resource.
      */
     URL locate();
+
+    /**
+     * Locate additional resources (such as ImageStreams) that
+     * should be created in the test namespace.
+     *
+     * @return a collection of urls to additional resources.
+     */
+    Collection<URL> locateAdditionalResources();
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -130,7 +130,7 @@ public class DefaultConfiguration implements Configuration {
                     asUrlOrResource(getStringProperty(ENVIRONMENT_SETUP_SCRIPT_URL, map, null)))
                 .withEnvironmentTeardownScriptUrl(
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
-                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map, DEFAULT_CONFIG_FILE_NAME))
+                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
                 .withEnvironmentDependencies(
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
@@ -201,7 +201,8 @@ public class DefaultConfiguration implements Configuration {
             String resourceName = map.get(ENVIRONMENT_CONFIG_RESOURCE_NAME);
             return findConfigResource(resourceName);
         } else {
-            return findConfigResource(defaultFileName);
+            // Let the resource locator find the resource
+            return null;
         }
     }
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -187,7 +187,7 @@ public class DefaultConfiguration implements Configuration {
      * @param map
      *     The arquillian configuration.
      */
-    public static URL getKubernetesConfigurationUrl(Map<String, String> map, String defaultFileName) throws MalformedURLException {
+    public static URL getKubernetesConfigurationUrl(Map<String, String> map) throws MalformedURLException {
         if (Strings.isNotNullOrEmpty(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_URL, ""))) {
             return new URL(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_URL, ""));
         } else if (Strings.isNotNullOrEmpty(Utils.getSystemPropertyOrEnvVar(ENVIRONMENT_CONFIG_RESOURCE_NAME, ""))) {

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -46,7 +46,6 @@ public class DefaultConfiguration implements Configuration {
     private final URL environmentTeardownScriptUrl;
 
     private final URL environmentConfigUrl;
-    private final List<URL> environmentConfigAdditionalUrls;
     private final List<URL> environmentDependencies;
 
     private final boolean namespaceLazyCreateEnabled;
@@ -70,7 +69,7 @@ public class DefaultConfiguration implements Configuration {
     private final String dockerRegistry;
 
     public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables,  URL environmentSetupScriptUrl,
-        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentConfigAdditionalUrls, List<URL> environmentDependencies,
+        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies,
         boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
         boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled,
         boolean namespaceDestroyConfirmationEnabled, long namespaceDestroyTimeout, long waitTimeout,
@@ -82,7 +81,6 @@ public class DefaultConfiguration implements Configuration {
         this.environmentTeardownScriptUrl = environmentTeardownScriptUrl;
         this.environmentDependencies = environmentDependencies;
         this.environmentConfigUrl = environmentConfigUrl;
-        this.environmentConfigAdditionalUrls = environmentConfigAdditionalUrls;
         this.sessionId = sessionId;
         this.namespace = namespace;
         this.namespaceLazyCreateEnabled = namespaceLazyCreateEnabled;
@@ -310,11 +308,6 @@ public class DefaultConfiguration implements Configuration {
     @Override
     public URL getEnvironmentConfigUrl() {
         return environmentConfigUrl;
-    }
-
-    @Override
-    public List<URL> getEnvironmentConfigAdditionalUrls() {
-        return environmentConfigAdditionalUrls;
     }
 
     @Override

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -140,15 +140,14 @@ public class SessionManager implements SessionCreatedListener {
                     setupEnvironment();
                 }
 
-                List<URL> additionalUrls = configuration.getEnvironmentConfigAdditionalUrls();
-                if (additionalUrls != null) {
-                    for (URL url : additionalUrls) {
-                        log.status("Applying additional kubernetes configuration from: " + url);
-                        try (InputStream is = url.openStream()) {
-                            resources.addAll(resourceInstaller.install(url));
-                        }
+                Collection<URL> additionalUrls = kubernetesResourceLocator.locateAdditionalResources();
+                for (URL url : additionalUrls) {
+                    log.status("Applying additional kubernetes configuration from: " + url);
+                    try (InputStream is = url.openStream()) {
+                        resources.addAll(resourceInstaller.install(url));
                     }
                 }
+
 
                 for (URL dependencyUrl : dependencyUrls) {
                     log.info("Found dependency: " + dependencyUrl);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResourceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResourceLocator.java
@@ -1,6 +1,9 @@
 package org.arquillian.cube.kubernetes.impl.locator;
 
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+
 import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 
 public class DefaultKubernetesResourceLocator implements KubernetesResourceLocator {
@@ -20,6 +23,11 @@ public class DefaultKubernetesResourceLocator implements KubernetesResourceLocat
             }
         }
         return null;
+    }
+
+    @Override
+    public Collection<URL> locateAdditionalResources() {
+        return Collections.emptyList();
     }
 
     protected String[] getResourceNames() {

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResourceLocator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/locator/DefaultKubernetesResourceLocator.java
@@ -11,8 +11,8 @@ public class DefaultKubernetesResourceLocator implements KubernetesResourceLocat
 
     @Override
     public URL locate() {
-        for (String suffix : getAllowedSuffixes()) {
-            for (String resource : getResourceNames()) {
+        for (String resource : getResourceNames()) {
+            for (String suffix : getAllowedSuffixes()) {
                 URL candidate = getResource(resource + suffix);
                 if (candidate != null) {
                     return candidate;

--- a/kubernetes/reporter/src/main/java/org/arquillian/cube/kubernetes/reporter/TakeKubernetesResourcesInformation.java
+++ b/kubernetes/reporter/src/main/java/org/arquillian/cube/kubernetes/reporter/TakeKubernetesResourcesInformation.java
@@ -10,6 +10,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.kubernetes.impl.event.AfterStart;
 import org.arquillian.cube.kubernetes.impl.event.Start;
@@ -35,6 +36,9 @@ public class TakeKubernetesResourcesInformation {
 
     @Inject
     Instance<DependencyResolver> dependencyResolver;
+
+    @Inject
+    Instance<KubernetesResourceLocator> resourceLocator;
 
     public void reportKubernetesConfiguration(@Observes Start start, Configuration configuration,
         org.arquillian.reporter.config.ReporterConfiguration reporterConfiguration) throws IOException {
@@ -124,6 +128,13 @@ public class TakeKubernetesResourcesInformation {
         org.arquillian.reporter.config.ReporterConfiguration reporterConfiguration) throws IOException {
         final List<FileEntry> fileEntries = new ArrayList<>();
         URL environmentConfigUrl = configuration.getEnvironmentConfigUrl();
+
+        if (environmentConfigUrl == null) {
+            KubernetesResourceLocator kubernetesResourceLocator = resourceLocator.get();
+            if (kubernetesResourceLocator != null) {
+                environmentConfigUrl = kubernetesResourceLocator.locate();
+            }
+        }
 
         if (environmentConfigUrl != null) {
             fileEntries.add(getFileForResourcesConfiguration(environmentConfigUrl, reporterConfiguration));

--- a/kubernetes/reporter/src/test/java/org/arquillian/cube/kubernetes/reporter/TakeKubernetesResourcesInformationTest.java
+++ b/kubernetes/reporter/src/test/java/org/arquillian/cube/kubernetes/reporter/TakeKubernetesResourcesInformationTest.java
@@ -13,6 +13,8 @@ import io.fabric8.kubernetes.api.model.v2_6.ServiceListBuilder;
 import io.fabric8.kubernetes.clnt.v2_6.server.mock.KubernetesMockServer;
 import java.io.IOException;
 import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -438,6 +440,11 @@ public class TakeKubernetesResourcesInformationTest {
             @Override
             public URL locate() {
                 return getClass().getResource("/kubernetes.json");
+            }
+
+            @Override
+            public Collection<URL> locateAdditionalResources() {
+                return Collections.emptyList();
             }
 
             @Override

--- a/kubernetes/reporter/src/test/java/org/arquillian/cube/kubernetes/reporter/TakeKubernetesResourcesInformationTest.java
+++ b/kubernetes/reporter/src/test/java/org/arquillian/cube/kubernetes/reporter/TakeKubernetesResourcesInformationTest.java
@@ -12,11 +12,13 @@ import io.fabric8.kubernetes.api.model.v2_6.ServiceBuilder;
 import io.fabric8.kubernetes.api.model.v2_6.ServiceListBuilder;
 import io.fabric8.kubernetes.clnt.v2_6.server.mock.KubernetesMockServer;
 import java.io.IOException;
+import java.net.URL;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
 import org.arquillian.cube.kubernetes.impl.DefaultSession;
@@ -168,6 +170,7 @@ public class TakeKubernetesResourcesInformationTest {
         TakeKubernetesResourcesInformation takeKubernetesResourcesInformation = new TakeKubernetesResourcesInformation();
         takeKubernetesResourcesInformation.sectionEvent = sectionEvent;
         takeKubernetesResourcesInformation.dependencyResolver = getDependencyResolverInstance();
+        takeKubernetesResourcesInformation.resourceLocator = getKubernetesResourceLocator();
 
         //when
         takeKubernetesResourcesInformation.reportKubernetesConfiguration(new Start(getDefaultSession(configuration)),
@@ -194,6 +197,7 @@ public class TakeKubernetesResourcesInformationTest {
         TakeKubernetesResourcesInformation takeKubernetesResourcesInformation = new TakeKubernetesResourcesInformation();
         takeKubernetesResourcesInformation.sectionEvent = sectionEvent;
         takeKubernetesResourcesInformation.dependencyResolver = getDependencyResolverInstance();
+        takeKubernetesResourcesInformation.resourceLocator = getKubernetesResourceLocator();
 
         //when
         takeKubernetesResourcesInformation.reportKubernetesConfiguration(new Start(getDefaultSession(configuration)),
@@ -222,6 +226,7 @@ public class TakeKubernetesResourcesInformationTest {
         TakeKubernetesResourcesInformation takeKubernetesResourcesInformation = new TakeKubernetesResourcesInformation();
         takeKubernetesResourcesInformation.sectionEvent = sectionEvent;
         takeKubernetesResourcesInformation.dependencyResolver = getDependencyResolverInstance();
+        takeKubernetesResourcesInformation.resourceLocator = getKubernetesResourceLocator();
 
         //when
         takeKubernetesResourcesInformation.reportKubernetesConfiguration(new Start(getDefaultSession(configuration)),
@@ -252,7 +257,8 @@ public class TakeKubernetesResourcesInformationTest {
         Configuration configuration = DefaultConfiguration.fromMap(addEnvironmentDependencies(getConfig(), resouceName));
         TakeKubernetesResourcesInformation takeKubernetesResourcesInformation = new TakeKubernetesResourcesInformation();
         takeKubernetesResourcesInformation.sectionEvent = sectionEvent;
-        takeKubernetesResourcesInformation.dependencyResolver = (() -> new ShrinkwrapResolver("pom.xml", false));
+        takeKubernetesResourcesInformation.dependencyResolver = getDependencyResolverInstance();
+        takeKubernetesResourcesInformation.resourceLocator = getKubernetesResourceLocator();
 
         //when
         takeKubernetesResourcesInformation.reportKubernetesConfiguration(new Start(getDefaultSession(configuration)),
@@ -425,6 +431,20 @@ public class TakeKubernetesResourcesInformationTest {
 
     private Instance<DependencyResolver> getDependencyResolverInstance() {
         return () -> new ShrinkwrapResolver("pom.xml", false);
+    }
+
+    private Instance<KubernetesResourceLocator> getKubernetesResourceLocator() {
+        return () -> new KubernetesResourceLocator() {
+            @Override
+            public URL locate() {
+                return getClass().getResource("/kubernetes.json");
+            }
+
+            @Override
+            public KubernetesResourceLocator toImmutable() {
+                return this;
+            }
+        };
     }
 
     public ReporterConfiguration getReporterConfiguration() {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -46,8 +46,6 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private static final String OPENSHIFT_ROUTER_HTTP_PORT = "openshiftRouterHttpPort";
     private static final String OPENSHIFT_ROUTER_HTTPS_PORT = "openshiftRouterHttpsPort";
 
-    private static final String DEFAULT_OPENSHIFT_CONFIG_FILE_NAME = "openshift.json";
-
     private final boolean keepAliveGitServer;
     private final String definitions;
     private final String definitionsFile;
@@ -141,7 +139,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                     asUrlOrResource(getStringProperty(ENVIRONMENT_SETUP_SCRIPT_URL, map, null)))
                 .withEnvironmentTeardownScriptUrl(
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
-                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map, DEFAULT_OPENSHIFT_CONFIG_FILE_NAME))
+                .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
                 .withEnvironmentConfigAdditionalUrls(additionalUrls)
                 .withEnvironmentDependencies(
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -55,18 +55,19 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
     private final String routerHost;
     private final int openshiftRouterHttpPort;
     private final int openshiftRouterHttpsPort;
+    private final boolean enableImageStreamDetection;
 
     public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables, URL environmentSetupScriptUrl,
-                                      URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentConfigAdditionalUrls, List<URL> environmentDependencies,
+                                      URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies,
                                       boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
                                       boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled, long namespaceDestroyTimeout,
                                       boolean namespaceDestroyConfirmationEnabled, long waitTimeout, long waitPollInterval,
                                       List<String> waitForServiceList, boolean ansiLoggerEnabled, boolean environmentInitEnabled, boolean logCopyEnabled,
                                       String logPath, String kubernetesDomain, String dockerRegistry, boolean keepAliveGitServer, String definitions,
                                       String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts,
-                                      String portForwardBindAddress, String routerHost, int openshiftRouterHttpPort, int openshiftRouterHttpsPort) {
+                                      String portForwardBindAddress, String routerHost, int openshiftRouterHttpPort, int openshiftRouterHttpsPort, boolean enableImageStreamDetection) {
         super(sessionId, masterUrl, namespace, scriptEnvironmentVariables, environmentSetupScriptUrl, environmentTeardownScriptUrl,
-            environmentConfigUrl, environmentConfigAdditionalUrls, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
+            environmentConfigUrl, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
             namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled,
             namespaceDestroyConfirmationEnabled, namespaceDestroyTimeout, waitTimeout, waitPollInterval,
             waitForServiceList, ansiLoggerEnabled, environmentInitEnabled, logCopyEnabled, logPath, kubernetesDomain, dockerRegistry);
@@ -79,6 +80,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
         this.routerHost = routerHost;
         this.openshiftRouterHttpPort = openshiftRouterHttpPort;
         this.openshiftRouterHttpsPort = openshiftRouterHttpsPort;
+        this.enableImageStreamDetection = enableImageStreamDetection;
     }
 
     private static String[] split(String str, String regex) {
@@ -103,28 +105,6 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
             shouldDestroyNamespace = true;
         }
 
-        // Lets also try to load the image stream for the project.
-        List<URL> additionalUrls = new LinkedList<>();
-        final boolean enableImageStreamDetection = getBooleanProperty(ENABLE_IMAGE_STREAM_DETECTION, map, true);
-
-        if (enableImageStreamDetection) {
-            File targetDir = new File(System.getProperty("basedir", ".") + "/target");
-            if (targetDir.exists() && targetDir.isDirectory()) {
-                File[] files = targetDir.listFiles();
-                if (files != null) {
-                    for (File file : files) {
-                        if (file.getName().endsWith("-is.yml")) {
-                            try {
-                                additionalUrls.add(file.toURI().toURL());
-                            } catch (MalformedURLException e) {
-                                // ignore
-                            }
-                        }
-                    }
-                }
-            }
-        }
-
         try {
             return new CubeOpenShiftConfigurationBuilder()
                 .withSessionId(sessionId)
@@ -140,7 +120,6 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 .withEnvironmentTeardownScriptUrl(
                     asUrlOrResource(getStringProperty(ENVIRONMENT_TEARDOWN_SCRIPT_URL, map, null)))
                 .withEnvironmentConfigUrl(getKubernetesConfigurationUrl(map))
-                .withEnvironmentConfigAdditionalUrls(additionalUrls)
                 .withEnvironmentDependencies(
                     asURL(Strings.splitAndTrimAsList(getStringProperty(ENVIRONMENT_DEPENDENCIES, map, ""), "\\s+")))
                 .withNamespaceLazyCreateEnabled(
@@ -174,6 +153,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
                 .withRouterHost(getStringProperty(ROUTER_HOST, "openshift.router.host", map, null))
                 .withOpenshiftRouterHttpPort(getIntProperty(OPENSHIFT_ROUTER_HTTP_PORT, Optional.of("openshift.router.httpPort"), map, 80))
                 .withOpenshiftRouterHttpsPort(getIntProperty(OPENSHIFT_ROUTER_HTTPS_PORT, Optional.of("openshift.router.httpsPort"), map, 443))
+                .withEnableImageStreamDetection(getBooleanProperty(ENABLE_IMAGE_STREAM_DETECTION, map, true))
                 .build();
         } catch (Throwable t) {
             if (t instanceof RuntimeException) {
@@ -232,5 +212,9 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
 
     public int getOpenshiftRouterHttpsPort() {
         return openshiftRouterHttpsPort;
+    }
+
+    public boolean isEnableImageStreamDetection() {
+        return enableImageStreamDetection;
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -107,7 +107,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration {
 
         // Lets also try to load the image stream for the project.
         List<URL> additionalUrls = new LinkedList<>();
-        final boolean enableImageStreamDetection = getBooleanProperty(ENABLE_IMAGE_STREAM_DETECTION, map, false);
+        final boolean enableImageStreamDetection = getBooleanProperty(ENABLE_IMAGE_STREAM_DETECTION, map, true);
 
         if (enableImageStreamDetection) {
             File targetDir = new File(System.getProperty("basedir", ".") + "/target");

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
@@ -2,9 +2,19 @@ package org.arquillian.cube.openshift.impl.locator;
 
 import io.fabric8.kubernetes.clnt.v2_6.KubernetesClient;
 import io.fabric8.openshift.clnt.v2_6.OpenShiftClient;
+import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
+
+import java.io.File;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.List;
 
 public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourceLocator {
 
@@ -14,6 +24,9 @@ public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourc
     @Inject
     protected Instance<KubernetesClient> client;
 
+    @Inject
+    protected Instance<Configuration> configuration;
+
     @Override
     protected String[] getResourceNames() {
         if (!client.get().isAdaptable(OpenShiftClient.class)) {
@@ -22,4 +35,33 @@ public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourc
         return RESOURCE_NAMES;
     }
 
+    @Override
+    public Collection<URL> locateAdditionalResources() {
+        if (!client.get().isAdaptable(OpenShiftClient.class)) {
+            return super.locateAdditionalResources();
+        }
+
+        Configuration config = configuration.get();
+        if (config instanceof CubeOpenShiftConfiguration && ((CubeOpenShiftConfiguration) config).isEnableImageStreamDetection()) {
+            List<URL> additionalUrls = new LinkedList<>();
+            File targetDir = new File(System.getProperty("basedir", ".") + "/target");
+            if (targetDir.exists() && targetDir.isDirectory()) {
+                File[] files = targetDir.listFiles();
+                if (files != null) {
+                    for (File file : files) {
+                        if (file.getName().endsWith("-is.yml")) {
+                            try {
+                                additionalUrls.add(file.toURI().toURL());
+                            } catch (MalformedURLException e) {
+                                // ignore
+                            }
+                        }
+                    }
+                }
+            }
+            return additionalUrls;
+        }
+
+        return Collections.emptyList();
+    }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
@@ -1,26 +1,25 @@
 package org.arquillian.cube.openshift.impl.locator;
 
-import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
+import io.fabric8.kubernetes.clnt.v2_6.KubernetesClient;
+import io.fabric8.openshift.clnt.v2_6.OpenShiftClient;
 import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
 
 public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourceLocator {
 
     private static final String[] RESOURCE_NAMES =
         new String[] {"openshift", "META-INF/fabric8/openshift", "kubernetes", "META-INF/fabric8/kubernetes"};
-    private static final String[] ALLOWED_SUFFIXES = {".json", ".yml", ".yaml"};
+
+    @Inject
+    protected Instance<KubernetesClient> client;
 
     @Override
     protected String[] getResourceNames() {
+        if (!client.get().isAdaptable(OpenShiftClient.class)) {
+            return super.getResourceNames();
+        }
         return RESOURCE_NAMES;
     }
 
-    @Override
-    protected String[] getAllowedSuffixes() {
-        return ALLOWED_SUFFIXES;
-    }
-
-    @Override
-    public KubernetesResourceLocator toImmutable() {
-        return this;
-    }
 }


### PR DESCRIPTION
This fixes #815.

Defaulted the imagestream detection to `true` when running on Openshift.

Deferred the choice of `kubernetes.json`/`openshift.json` file to a later stage (if not explicitly set by the user) when it's known if we are connected to a Kubernetes or Openshift cluster.