### PR TITLE
add @AwaitRoute

### DIFF
--- a/docs/enrichers.adoc
+++ b/docs/enrichers.adoc
@@ -70,6 +70,10 @@ When running Arquillian Cube against a OpenShift's pod you can retrieve the rout
 @RouteURL("app-name")
 private URL url;
 ----
+When Arquillian Cube injects the route URL, it also checks that the URL is available.
+That is, it responds with a known good HTTP status code in given timeout.
+This can be configured using the `await` parameter of the `@RouteURL` annotation.
+
 If the route is not resolvable, you need to set the `routerHost` setting to the IP address of the OpenShift router.
 You can configure it in arquillian.xml:
 [source, xml]

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/AwaitRoute.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/AwaitRoute.java
@@ -1,0 +1,39 @@
+package org.arquillian.cube.openshift.impl.enricher;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.Target;
+import java.util.concurrent.TimeUnit;
+
+import javax.inject.Qualifier;
+
+import static java.lang.annotation.RetentionPolicy.RUNTIME;
+
+/**
+ * Used inside {@link RouteURL} to configure awating the route URL to be available.
+ * Availability is defined as returning a known good HTTP status code.
+ */
+@Qualifier
+@Documented
+@Retention(RUNTIME)
+@Target({})
+public @interface AwaitRoute {
+    /**
+     * Path that should be appended to the route URL for checking route availability.
+     * Useful when there's nothing exposed directly at the root route URL, only on some paths below.
+     * Defaults to {@code /}.
+     */
+    String path() default "/";
+
+    /**
+     * Set of HTTP status codes that are considered good. Defaults to a single value, {@code 200}.
+     */
+    int[] statusCode() default 200;
+
+    /**
+     * How long to wait for the route URL to become available. Defaults to 5 minutes.
+     */
+    int timeout() default 5;
+
+    TimeUnit timeoutUnit() default TimeUnit.MINUTES;
+}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
@@ -23,4 +23,9 @@ public @interface RouteURL {
      * @return the route name
      */
     String value() default "";
+
+    /**
+     * Allows configuring how to check if the route is available and how long to wait for that.
+     */
+    AwaitRoute await() default @AwaitRoute;
 }


### PR DESCRIPTION
The process that injects `@RouteURL`-s now awaits availability
of those routes. This can be configured using the `await`
parameter of the `@RouteURL` annotation.

I'm sending this PR just to start a discussion. I know Cube already awaits pod readiness, but this awaits the _route_. This is because there might be slight delay between pod becoming ready and being exposed on the router, and actually there's also a bug (I believe) on OpenShift Online where the delay between pod readiness and route availability can be several minutes!