### PR TITLE
fix(#829): Updates Docker Java client to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,7 +66,7 @@
     <version.arquillian_core>1.1.13.Final</version.arquillian_core>
     <version.junit>4.12</version.junit>
     <version.hamcrest>1.3</version.hamcrest>
-    <version.docker-java>3.0.6</version.docker-java>
+    <version.docker-java>3.0.14</version.docker-java>
     <version.kubernetes_client>2.6.3</version.kubernetes_client>
     <version.snakeyaml>1.18</version.snakeyaml>
     <version.shrinkwrap_resolver>3.0.0-alpha-4</version.shrinkwrap_resolver>


### PR DESCRIPTION
#### Short description of what this resolves:

Updates Docker Java client to latest version

#### Changes proposed in this pull request:

- Updates Docker Java client to latest version 3.0.14

Fixes #829 
