### PR TITLE
improve route URL injection

### DIFF
--- a/docs/enrichers.adoc
+++ b/docs/enrichers.adoc
@@ -70,9 +70,9 @@ When running Arquillian Cube against a OpenShift's pod you can retrieve the rout
 @RouteURL("app-name")
 private URL url;
 ----
-When Arquillian Cube injects the route URL, it also checks that the URL is available.
+This annotation also has a `path` parameter which can change the path part of the injected URL.
+You can also use an additional annotation `@AwaitRoute` to wait until the route becomes available.
 That is, it responds with a known good HTTP status code in given timeout.
-This can be configured using the `await` parameter of the `@RouteURL` annotation.
 
 If the route is not resolvable, you need to set the `routerHost` setting to the IP address of the OpenShift router.
 You can configure it in arquillian.xml:

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/AwaitRoute.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/AwaitRoute.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.openshift.impl.enricher;
 
 import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.Target;
 import java.util.concurrent.TimeUnit;
@@ -10,20 +11,32 @@ import javax.inject.Qualifier;
 import static java.lang.annotation.RetentionPolicy.RUNTIME;
 
 /**
- * Used inside {@link RouteURL} to configure awating the route URL to be available.
- * Availability is defined as returning a known good HTTP status code.
+ * When this annotation is present alongside {@link RouteURL}, Arquillian Cube will wait
+ * until the route becomes availabile. Availability is defined as returning a known good HTTP status code.
  */
 @Qualifier
 @Documented
 @Retention(RUNTIME)
-@Target({})
+@Target({ElementType.FIELD, ElementType.PARAMETER })
 public @interface AwaitRoute {
+    String DEFAULT_PATH_FOR_ROUTE_AVAILABILITY_CHECK = "__DEFAULT PATH FOR ROUTE AVAILABILITY CHECK__";
+
     /**
-     * Path that should be appended to the route URL for checking route availability.
+     * Path that should be appended to the root route URL for checking route availability.
      * Useful when there's nothing exposed directly at the root route URL, only on some paths below.
-     * Defaults to {@code /}.
+     * Defaults to {@link RouteURL#path()}.
+     * <p/>
+     * If {@code RouteURL.path()} is set to a non-default value and this is also set to a non-default value,
+     * then these two values are <b>not</b> combined. For example:
+     * <pre>
+     * &#64;RouteURL(value = "my-route", path = "/api/info")
+     * &#64;AwaitRoute(path = "/api/health"))
+     * private URL myUrl;
+     * </pre>
+     * In this case, the injected route URL will be {@code http://route.host/api/info}, but the URL
+     * used for checking route availability will be {@code http://route.host/api/health}.
      */
-    String path() default "/";
+    String path() default DEFAULT_PATH_FOR_ROUTE_AVAILABILITY_CHECK;
 
     /**
      * Set of HTTP status codes that are considered good. Defaults to a single value, {@code 200}.

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURL.java
@@ -25,7 +25,8 @@ public @interface RouteURL {
     String value() default "";
 
     /**
-     * Allows configuring how to check if the route is available and how long to wait for that.
+     * The {@code path} part of the URL that will be appended to the root route URL. Useful if you only need a single URL
+     * to the application behind the route and don't want to construct that URL programmatically. Defaults to {@code /}.
      */
-    AwaitRoute await() default @AwaitRoute;
+    String path() default "/";
 }


### PR DESCRIPTION
This commit improves `@RouteURL` injection in these ways:
- The `@AwaitRoute` annotation is now external to `@RouteURL`, so
  that the entire route await mechanism is opt-in. This isn't
  a breaking change because the `@AwaitRoute` mechanism doesn't
  exist in any release.
- The `@RouteURL` annotation now has a parameter to customize
  the path portion of the injected URL.
- the `@RouteURL` injection now doesn't add a port number to the URL
  if it's the default value for given protocol. This means the URLs
  will be more inline with users expectations.

Fixes #837, fixes #838 and fixes #839.
