### PR TITLE
chore: fixes typos and formatting in kubernetes.adoc

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -4,9 +4,12 @@ The kubernetes extension helps you write and run integration tests for your Kube
 
 === Overview
 
-This extension, wll create and manage a temporary namespace for your tests, apply all Kubernetes resources required to create your environment and once everything is ready it will run your tests. The tests will be enriched with resources required to access services. Finally when testing is over it will cleanup everything.
+This extension will create and manage a temporary namespace for your tests, apply all Kubernetes resources required to 
+create your environment and once everything is ready it will run your tests. The tests will be enriched with resources 
+required to access services. Finally when testing is over it will cleanup everything.
 
-This extension, will not mutate neither your containers *(by deploying, reconfiguring etc)* nor your Kubernetes resources, and takes a black box approach to testing.
+This extension  will neither mutate your containers *(by deploying, reconfiguring etc)* nor your Kubernetes resources 
+and takes a black box approach to testing.
 
 === Modules
 The main modules of this extension are the following:
@@ -21,13 +24,13 @@ The main modules of this extension are the following:
 - Dependency management *(for maven based projects)*
 - Auto align with Docker Registry
 - Enrichers for:
-    - Kubernetes/Openshift client
-    - Pods
-    - Replication Controllers
-    - Services
+    ** Kubernetes/Openshift client
+    ** Pods
+    ** Replication Controllers
+    ** Services
 - Integration with Fabric8 Modules:
-    - link:https://fabric8.io/guide/mavenPlugin.html[Fabric8 Maven Plugin]
-    - link:https://fabric8.io/guide/fabric8DevOps.html[Microservices Platform]
+    ** link:https://fabric8.io/guide/mavenPlugin.html[Fabric8 Maven Plugin]
+    ** link:https://fabric8.io/guide/fabric8DevOps.html[Microservices Platform]
 - "Bring your own client" support
 
 === Pre-requisites
@@ -36,69 +39,82 @@ The main modules of this extension are the following:
 
 === Configuring the extension
 
-The plugin can be configured using the traditional arquillian.xml, via system properties or environment variables (in that particular order).
-Which means that for every supported configuration parameter, the arquillian.xml will be looked up first, if it doesn't contain an entry, the system properties will be used.
+The plugin can be configured using the traditional arquillian.xml, via system properties or environment variables
+(in that particular order).
+Which means that for every supported configuration parameter, the arquillian.xml will be looked up first, if it doesn't 
+contain an entry, the system properties will be used.
 If no result has been found so far the environment variables will be used.
 
-**Note:** When checking for environment variables, property names will get capitalized, and symbols like "." will be converted to "_".
+**Note:** When checking for environment variables, property names will get capitalized, and symbols like "." will be 
+converted to "_".
 For example **foo.bar.baz** will be converted to **FOO_BAR_BAZ**.
 
 ==== Kubernetes Configuration Parameters
 
-[width="80%"]
-|===============================================================================================================================================
-| Option                              | Type           | Env | Description
-| kubernetes.master                   | URL            | Any | The URL to the Kubernetes master
-| kubernetes.domain                   | String         | OSE | Domain to use for creating routes for services
-| docker.registry                     | String         | Any | The docker registry
-| namespace.use.current               | Boolean (false)| Any | Don't generate a namespace use the current instead
-| namespace.use.existing              | String         | Any | Don't generate a namespace use the specified one instead
-| namespace.prefix                    | String (itest) | Any | If you don't specify a namespace, a random one will be created, with this prefix
-| namespace.lazy.enabled              | Bool (true)    | Any | Should the specified namespace be created if not exists, or throw exception?
-| namespace.destroy.enabled           | Bool (true)    | Any | Flag to destroy the namespace after the end of the test suite
-| namespace.destroy.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to delete the namespace
-| namespace.destroy.timeout           | Long           | Any | Time to wait before destroying the namespace
-| namespace.cleanup.enabled           | Bool (true)    | Any | Flag to clean (delete resources) the namespace after the end of the test suite
-| namespace.cleanup.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to clean the namespace
-| namespace.cleanup.timeout           | Long           | Any | Time to wait when cleaning up the namespace
-| env.init.enabled                    | Bool (true)    | Any | Flag to initialize the environment (apply kubernetes resources)
-| env.config.url                      | URL            | Any | URL to the Kubernetes JSON/YAML (defaults to classpath resource kubernetes.json)
-| env.config.resource.name            | String         | Any | Option to select a different classpath resource (other than kubernetes.json)
-| env.script.env                      | String         | Any | Key/Value pairs to pass to setup scripts as environment variables
-| env.setup.script.url                | URL            | Any | Option to select a shell script that will setup the environment
-| env.teardown.script.url             | URL            | Any | Option to select a shell script to tear down / cleanup the environment
-| env.dependencies                    | List           | Any | Whitespace separated list of URLs to more dependency kubernetes.json
-| wait.timeout                        | Long (5mins)   | Any | The total amount of time to wait until the env is ready
-| wait.poll.interval                  | Long (5secs)   | Any | The poll interval to use for checking if the environment is ready
-| wait.for.service.list               | List           | Any | Explicitly specify a list of services to wait upon
-| ansi.logger.enabled                 | Bool (true)    | Any | Flag to enable colorful output
-| logs.copy                           | Bool (false)   | Any | Whether to capture the pods logs and save them into the filesystem - as individual files, one for each pod. Filenames will be "ClassName-[MethodName-]-PodName[-ContainerName].log". If the pod has multiple containers, one log file for each container will be created. Kubernetes events (`kubectl get events`) will also be captured if this flag is enabled. Filenames will end with `-KUBE_EVENTS.log`
-| logs.path                           | String         | Any | Directory where to save the pods logs. Defaults to "target/surefire-reports".
-| kubernetes.client.creator.class.name| Bool (true)    | Any | Fully qualified class name of a kubernetes client creator class (byon)
-|===============================================================================================================================================
+[cols="2,1,1,3", options="header"]
+|===
+| Options                             | Type           | Env | Description                                                   
+| kubernetes.master                   | URL            | Any | The URL to the Kubernetes master                               
+| kubernetes.domain                   | String         | OSE | Domain to use for creating routes for services                 
+| docker.registry                     | String         | Any | The docker registry     
+| namespace.use.current               | Boolean (false)| Any | Don't generate a namespace use the current instead             
+| namespace.use.existing              | String         | Any | Don't generate a namespace use the specified one instead       
+| namespace.prefix                    | String (itest) | Any | If you don't specify a namespace, a random one will be 
+created, with this prefix 
+| namespace.lazy.enabled              | Bool (true)    | Any | Should the specified namespace be created if not exists,
+or throw exception?
+| namespace.destroy.enabled           | Bool (true)    | Any | Flag to destroy the namespace after the end of the test
+suite
+| namespace.destroy.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to delete the namespace           
+| namespace.destroy.timeout           | Long           | Any | Time to wait before destroying the namespace                   
+| namespace.cleanup.enabled           | Bool (true)    | Any | Flag to clean (delete resources) the namespace after the
+end of the test suite
+| namespace.cleanup.confirm.enabled   | Bool (false)   | Any | Flag to ask for confirmation to clean the namespace           
+| namespace.cleanup.timeout           | Long           | Any | Time to wait when cleaning up the namespace                   
+| env.init.enabled                    | Bool (true)    | Any | Flag to initialize the environment (apply kubernetes 
+resources)                  
+| env.config.url                      | URL            | Any | URL to the Kubernetes JSON/YAML (defaults to classpath 
+resource kubernetes.json) 
+| env.config.resource.name            | String         | Any | Option to select a different classpath resource (other
+than kubernetes.json)
+| env.setup.script.url                | URL            | Any | Option to select a shell script that will setup the 
+environment                  
+| env.teardown.script.url             | URL            | Any | Option to select a shell script to tear down / cleanup
+the environment
+| env.dependencies                    | List           | Any | Whitespace separated list of URLs to more dependency 
+kubernetes.json             
+| wait.timeout                        | Long (5mins)   | Any | The total amount of time to wait until the env is ready       
+| wait.poll.interval                  | Long (5secs)   | Any | The poll interval to use for checking if the environment
+is ready
+| wait.for.service.list               | List           | Any | Explicitly specify a list of services to wait upon             
+| ansi.logger.enabled                 | Bool (true)    | Any | Flag to enable colorful output                                 
+| kubernetes.client.creator.class.name| Bool (true)    | Any | Fully qualified class name of a kubernetes client
+creator class (byon)
+|===
 
 ==== Openshift Configuration Parameters
 
-[width="80%"]
-|===============================================================================================================================================
-| Option                              | Type           | Env | Description
-| autoStartContainers                 | List           | Any | Comma Separated List of Pods which you want to auto start
-| definitionsFile                     | String         | Any | Definitions file path
-| proxiedContainerPorts               | List           | Any | Comma Separated List following Pod:containerPort OR Pod:MappedPort:ContainerPort
-| routerHost                          | String         | Any | Define OpenShift router address thats is used to resolve the pod's address and to get its route
-| enableImageStreamDetection          | Bool (true)    | Any | Define if you want that Arquillian Cube apply Image Stream files (`*-is.yml`) to Openshift before deploying
-|===============================================================================================================================================
+[cols="2,1,1,3", options="header"]
+|===
+| Option                              | Type           | Env | Description                                                   
+| autoStartContainers                 | List           | Any | Comma Separated List of Pods which you want to auto
+start
+| definitionsFile                     | String         | Any | Definitions file path                                         
+| proxiedContainerPorts               | List           | Any | Comma Separated List following Pod:containerPort OR 
+Pod:MappedPort:ContainerPort 
+|===
 
 
 ==== Openshift DNS Naming Service
 The OpenShift module provides a easy way to run tests against your public application's route.
 The Arquillian Naming Service allows you to run tests annotated with @RunsAsClient without have to add the routes
 manually to your /etc/hosts to make its name resolvable. The arquillian cube generates a custon namespaces prefix
-that will be used to define the application's route when running your tests against an OpenShift instance, even if you specify
-a namepsace manually it will be transparent and the application's endpoint will be resolvable within your java tests.
+that will be used to define the application's route when running your tests against an OpenShift instance, even if you
+specify a namepsace manually it will be transparent and the application's endpoint will be resolvable within your java
+tests.
 
-To use it, you need to setup your tests to use the ArquillianNameService, you can either configure it inside your test or
-by setting a System properties.
+To use it, you need to setup your tests to use the ArquillianNameService, you can either configure it inside your test
+or by setting a System properties.
 
 Configuring inside a test class:
 [source, java]
@@ -116,14 +132,19 @@ Or just setting the following System Properties:
 
 === Namespaces
 
-The default behavior of the extension is to create a unique namespace per test suite. The namespace is created Before the suite is started and destroyed in the end.
-For debugging purposes, you can set the **namespace.cleanup.enabled** and **namespace.destroy.enabled**  to false and keep the namespace around.
+The default behavior of the extension is to create a unique namespace per test suite. The namespace is created Before
+the suite is started and destroyed in the end.
+For debugging purposes, you can set the **namespace.cleanup.enabled** and **namespace.destroy.enabled**  to false and
+keep the namespace around.
 
-In other cases you may find it useful to manually create and manage the environment rather than having **arquillian** do that for you.
-In this case you can use the **namespace.use.existing** option to select an existing namespace. This option goes hand in hand with **env.init.enabled** which can be
-used to prevent the extension from modifying the environment.
+In other cases you may find it useful to manually create and manage the environment rather than having **arquillian**
+do that for you.
+In this case you can use the **namespace.use.existing** option to select an existing namespace. This option goes hand
+in hand with **env.init.enabled** which can be used to prevent the extension from modifying the environment.
 
-Last but not least, you can just tell arquillian, that you are going to use the current namespace. In this case, arquillian cube will delegate to the link:https://github.com/fabric8io/kubernetes-client/[Kubernetes Client] that will use:
+Last but not least, you can just tell arquillian, that you are going to use the current namespace. In this case,
+arquillian cube will delegate to the link:https://github.com/fabric8io/kubernetes-client/[Kubernetes Client] that
+will use:
 
 - ~/.kube/config
 - /var/run/secrets/kubernetes.io/serviceaccount/namespace
@@ -132,21 +153,29 @@ Last but not least, you can just tell arquillian, that you are going to use the 
 to determine the current namespace.
 
 ### Creating the environment
-After creating or selecting an existing namespace, the next step is the environment preparation. This is the stage where all the required Kubernetes configuration will be applied.
+
+After creating or selecting an existing namespace, the next step is the environment preparation. This is the stage
+where all the required Kubernetes configuration will be applied.
 
 #### How to run kubernetes with multiple configuration files?
-1. Out of the box, the extension will use the classpath and try to find a resource named **kubernetes.json** or **kubernetes.yaml***. The name of the resource can be changed using the **env.config.resource.name**.
-  Of course it is also possible to specify an external resource by URL using the **env.config.url**.
+1. Out of the box, the extension will use the classpath and try to find a resource named **kubernetes.json** or 
+**kubernetes.yaml***. The name of the resource can be changed using the **env.config.resource.name**.
+Of course it is also possible to specify an external resource by URL using the **env.config.url**.
 
-2. While finding resource in classpath with property **env.config.resource.name**, cube will look into classpath with given name, if not found, then cube will continue to look into classpath under META-INF/fabric8/ directory.
-  Using this you can put multiple resources(openshift.json, openshift.yml) inside META-INF/fabric8, and choose only required one by specifying **env.config.resource.name** property.
+2. While finding resource in classpath with property **env.config.resource.name**, cube will look into classpath
+with given name, if not found, then cube will continue to look into classpath under META-INF/fabric8/ directory.
+Using this you can put multiple resources(openshift.json, openshift.yml) inside META-INF/fabric8, and choose only
+required one by specifying **env.config.resource.name** property.
 
-3. Either way, it is possible that the kubernetes configuration used, depends on other configurations. It is also possible that your environment configuration is split in multiple files.
-  To cover cases like this the **env.dependencies** is provided which accepts a space separated list of URLs.
+3. Either way, it is possible that the kubernetes configuration used, depends on other configurations. It is also
+possible that your environment configuration is split in multiple files.
+To cover cases like this the **env.dependencies** is provided which accepts a space separated list of URLs.
 
-4. There are cases, where instead of specifying the resources, you want to specify some shell scripts that will setup the environment. For those cases you can use the **env.setup.script.url** / **env.teardown.script.url** to pass the
- scripts for setting up and tearing down the environment. Note that these scripts are going to be called right after the namespace is created and cleaned up respectively.
- Both scripts will be executed using visible environment variables the following:
+4. There are cases, where instead of specifying the resources, you want to specify some shell scripts that will setup
+the environment. For those cases you can use the **env.setup.script.url** / **env.teardown.script.url** to pass the
+scripts for setting up and tearing down the environment. Note that these scripts are going to be called right after the
+namespace is created and cleaned up respectively.
+Both scripts will be executed using visible environment variables the following:
 
  * KUBERNETES_MASTER
  * KUBERNETES_NAMESPACE
@@ -157,27 +186,35 @@ After creating or selecting an existing namespace, the next step is the environm
 
 (You can use any custom URL provided the appropriate URL stream handler.)
 
-**Note:** Out of the box mvn urls are supported, so you can use values like: **mvn:my.groupId/artifactId/1.0.0/json/kubernetes** (work in progress)
+**Note:** Out of the box mvn urls are supported, so you can use values like: 
+**mvn:my.groupId/artifactId/1.0.0/json/kubernetes** (work in progress)
 
-**Also:** If your project is using maven and dependencies like the above are expressed in the pom, the will be used *automatically*. (work in progress)
+**Also:** If your project is using maven and dependencies like the above are expressed in the pom, the will be used 
+*automatically*. (work in progress)
 
 [IMPORTANT]
 ====
 Arquillian Cube Kubernetes needs to authenticate into Kubernetes.
 To do it, Cube reads from `~/.kube/config` user information (token, password).
 
-For example in case of OpenShift you can use `oc login --username=admin --password=admin` for creating a token for connecting as admin, or `oc config set-credentials myself --username=admin --password=admin` for statically add the username and password and will communicate with Kubernetes to update the `~/.kube/config` file with the info provided.
+For example in case of OpenShift you can use `oc login --username=admin --password=admin` for creating a token for
+connecting as admin, or `oc config set-credentials myself --username=admin --password=admin` for statically adding the
+username and password and communicate with Kubernetes to update the `~/.kube/config` file with the info provided.
 
 You can read more about Kubernetes config file at http://kubernetes.io/docs/user-guide/kubectl/kubectl_config/
 ====
 
 === Readiness and waiting
-Creating an environment does not guarantee its readiness. For example a Docker image may be required to get pulled by a remote repository and this make take even several minutes.
-Running a test against a Pod which is not Running state is pretty much pointless, so we need to wait until everything is ready.
+Creating an environment does not guarantee its readiness. For example a Docker image may be required to get pulled by a 
+remote repository and this make take even several minutes.
+Running a test against a Pod which is not Running state is pretty much pointless, so we need to wait until everything
+is ready.
 
-This extension will wait up to **wait.timeout** until everything is up and running. Everything? It will wait for all Pods and Service *(that were created during the test suite initialization)* to become ready.
-It will poll them every **wait.poll.interval** milliseconds. For services there is also the option to perform a simple "connection test"  by setting the flag **wait.for.service.connection.enabled** to true.
-In this case it will not just wait for the service to ready, but also to be usable/connectable.
+This extension will wait up to **wait.timeout** until everything is up and running. Everything? It will wait for all
+Pods and Service *(that were created during the test suite initialization)* to become ready.
+It will poll them every **wait.poll.interval** milliseconds. For services there is also the option to perform a simple 
+"connection test"  by setting the flag **wait.for.service.connection.enabled** to true.
+In this case it will not just wait for the service to be ready, but also to be usable/connectable.
 
 === Immutable infrastructure and integration testing
 
@@ -187,9 +224,11 @@ It doesn't even need to run inside Kubernetes (it can just run in your laptop an
 
 So what exactly is your test case going to test?
 
-The test cases are meant to consume and test the provided services and assert that the environment is in the expected state.
+The test cases are meant to consume and test the provided services and assert that the environment is in the
+expected state.
 
-The test case may obtain everything it needs, by accessing the Kubernetes resources that are provided by the plugin as @ArquillianResources (see resource providers below).
+The test case may obtain everything it needs, by accessing the Kubernetes resources that are provided by the plugin as 
+@ArquillianResources (see resource providers below).
 
 === Resource Providers
 
@@ -199,7 +238,8 @@ The resource providers available, can be used to inject to your test cases the f
 - Session object that contains information (e.g. the namespace) or the uuid of the test session.
 - Deployments *(by id or as a list of all deployments created during the session, optionally filtered by label)*
 - Pods *(by id or as a list of all pods created during the session, optionally filtered by label)*
-- Replication Controllers *(by id or as a list of all replication controllers created during the session, optionally filtered by label)*
+- Replication Controllers *(by id or as a list of all replication controllers created during the session, optionally
+filtered by label)*
 - Replica Sets *(by id or as a list of all replica sets created during the session, optionally filtered by label)*
 - Services *(by id or as a list of all services created during the session, optionally filtered by label)*
 
@@ -228,7 +268,10 @@ Here's a small example:
     }
 ----
 
-The test code above, demonstrates how you can inject an use inside your test the *KubernetesClient* and the *Session* object. It also demonstrates the use of **kubernetes-assertions** which is a nice little library based on [assert4j](http://assertj.org) for performing assertions on top of the Kubernetes model.
+The test code above, demonstrates how you can inject an use inside your test the *KubernetesClient* and the
+*Session* object.
+It also demonstrates the use of **kubernetes-assertions** which is a nice little library based on 
+http://assertj.org[assert4j] for performing assertions on top of the Kubernetes model.
 
 The next example is intended to how you can inject a resource by id.
 
@@ -358,8 +401,11 @@ public class HelloWorldTest {
 Arquillian Cube Kubernetes and Openshift modules, heavily rely on the Fabric8 Kubernetes/Openshift client.
 This client is also used in wide range of frameworks, so its not that long of a shot to encounter version conflicts.
 
-To eliminate such issues, arquillian as of 1.1.0 is using a shaded uberjar of the client which contains versioned package (with major and minor version).
+To eliminate such issues, arquillian as of 1.1.0 is using a shaded uberjar of the client which contains versioned
+package (with major and minor version).
 
-All enrichers provided by the arquillian modules, are configured to work both with the internal types, but also with whatever version of the client that is found in the classpath.
+All enrichers provided by the arquillian modules, are configured to work both with the internal types, but also with
+whatever version of the client that is found in the classpath.
 
-Note: If your existing tests don't have a dependency to the kubernetes-client, you will either need to add kubernetes-client, to your classpath or use the internal classes. It is recommended to do the first.
+NOTE: If your existing tests don't have a dependency to the kubernetes-client, you will either need to add
+kubernetes-client, to your classpath or use the internal classes. It is recommended to do the first.


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes typos and formatting for the Kubernetes documentation.

#### Changes proposed in this pull request:

- Fixes table formatting and nested indentation for lists and some phrasing and typos.


Fixes #858 
