### PR TITLE
fix(#850): @OpenShiftResource supports yaml format

### DIFF
--- a/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesTest.java
+++ b/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesTest.java
@@ -17,7 +17,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
-@OpenShiftResource("classpath:hello-route.json")
+@OpenShiftResource("classpath:hello-route.yaml")
 public class HelloWorldOpenShiftResourcesTest {
 
     @RouteURL("hello-world")

--- a/openshift/ftest-openshift-resources-standalone/src/test/resources/hello-route.yaml
+++ b/openshift/ftest-openshift-resources-standalone/src/test/resources/hello-route.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: hello-world
+spec:
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: hello-world

--- a/openshift/openshift/pom.xml
+++ b/openshift/openshift/pom.xml
@@ -152,17 +152,6 @@
     </dependency>
 
     <dependency>
-      <groupId>org.yaml</groupId>
-      <artifactId>snakeyaml</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.3</version>
-    </dependency>
-
-    <dependency>
       <groupId>io.sundr</groupId>
       <artifactId>builder-annotations</artifactId>
       <version>0.2.8</version>

--- a/openshift/openshift/pom.xml
+++ b/openshift/openshift/pom.xml
@@ -152,6 +152,11 @@
     </dependency>
 
     <dependency>
+      <groupId>org.yaml</groupId>
+      <artifactId>snakeyaml</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
       <version>2.3</version>

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/fabric8/F8OpenShiftAdapter.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/fabric8/F8OpenShiftAdapter.java
@@ -108,6 +108,7 @@ import org.arquillian.cube.openshift.impl.utils.Port;
 import org.arquillian.cube.openshift.impl.utils.RCContext;
 import org.jboss.arquillian.container.spi.client.container.DeploymentException;
 import org.jboss.dmr.ModelNode;
+import org.yaml.snakeyaml.Yaml;
 
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
@@ -473,17 +474,16 @@ public class F8OpenShiftAdapter extends AbstractOpenShiftAdapter {
             String content = IOUtils.toString(stream, StandardCharsets.UTF_8);
 
             try {
-                // TODO only works if JSON should work with YAML as well.
-                ModelNode json;
-                json = ModelNode.fromJSONString(content);
+                final ModelNode json = ModelNode.fromJSONString(content);
                 String kind = json.get("kind").asString();
 
                 content = json.toJSONString(true);
                 return createResourceFromString(kind, content);
             } catch (IllegalArgumentException e) {
-                StringTokenizer tokenizer = new StringTokenizer(content.trim(), ":\n");
-                tokenizer.nextToken();
-                String kind = tokenizer.nextToken().trim();
+                // It is in yaml format
+                final Yaml yaml = new Yaml();
+                final Map<Object,Object> conf  = yaml.loadAs(content, Map.class);
+                String kind = (String) conf.get("kind");
 
                 return createResourceFromString(kind, content);
             }


### PR DESCRIPTION
#### Short description of what this resolves:

@OpenShiftResource supports `yaml` format

#### Changes proposed in this pull request:

- Adds snakeyaml to process yaml format in case of cannot be parsed as json

Fixes #850 
