### PR TITLE
feat(#830): support oc or kubectl command to execute as a part of your tests.

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -402,33 +402,7 @@ Let's see how can you execute `oc` or `kubectl` commands as a part of your test.
 [source, java]
 .OpenshiftAndK8sExample.java
 ----
-public class HelloWorldTest {
-
-    private CommandExecutor commandExecutor;
-
-    @Before
-    public void initCommandExecutor() {
-        commandExecutor = new CommandExecutor();
-    }
-
-    @Test
-    public void should_be_able_deploy_resources_using_oc() {
-        // when
-        final List<String> resources = commandExecutor.execCommand("oc create -f https://goo.gl/qaiGRJ");
-
-        // then
-        assertThat(resources).contains("service \"hello-world\" created", "deployment \"hello-world\" created");
-    }
-
-    @Test
-    public void should_be_able_get_namespace_using_kubectl() {
-        // when
-        final List<String> namespaces = commandExecutor.execCommand("kubectl get ns -o=name");
-
-        // then
-        assertThat(namespaces).contains("namespaces/default");
-    }
-}
+include::../openshift/ftest-oc-proxy/src/test/java/org/arquillian/cube/openshift/ftest/HelloWorldTest.java[tag=client_cli_execution]
 ----
 
 === Dealing with version conflicts

--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -397,6 +397,40 @@ public class HelloWorldTest {
 }
 ----
 
+Let's see how can you execute `oc` or `kubectl` commands as a part of your test.
+
+[source, java]
+.OpenshiftAndK8sExample.java
+----
+public class HelloWorldTest {
+
+    private CommandExecutor commandExecutor;
+
+    @Before
+    public void initCommandExecutor() {
+        commandExecutor = new CommandExecutor();
+    }
+
+    @Test
+    public void should_be_able_deploy_resources_using_oc() {
+        // when
+        final List<String> resources = commandExecutor.execCommand("oc create -f https://goo.gl/qaiGRJ");
+
+        // then
+        assertThat(resources).contains("service \"hello-world\" created", "deployment \"hello-world\" created");
+    }
+
+    @Test
+    public void should_be_able_get_namespace_using_kubectl() {
+        // when
+        final List<String> namespaces = commandExecutor.execCommand("kubectl get ns -o=name");
+
+        // then
+        assertThat(namespaces).contains("namespaces/default");
+    }
+}
+----
+
 === Dealing with version conflicts
 Arquillian Cube Kubernetes and Openshift modules, heavily rely on the Fabric8 Kubernetes/Openshift client.
 This client is also used in wide range of frameworks, so its not that long of a shot to encounter version conflicts.

--- a/kubernetes/kubernetes/pom.xml
+++ b/kubernetes/kubernetes/pom.xml
@@ -97,6 +97,10 @@
       <version>1.4.14</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.arquillian.spacelift</groupId>
+      <artifactId>arquillian-spacelift</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/utils/CommandExecutor.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/utils/CommandExecutor.java
@@ -1,0 +1,33 @@
+package org.arquillian.cube.kubernetes.impl.utils;
+
+import java.util.List;
+import org.arquillian.spacelift.Spacelift;
+import org.arquillian.spacelift.process.Command;
+import org.arquillian.spacelift.process.CommandBuilder;
+import org.arquillian.spacelift.process.ProcessResult;
+import org.arquillian.spacelift.task.os.CommandTool;
+
+public class CommandExecutor {
+
+    public List<String> execCommand(String command) {
+        if (command.isEmpty()) {
+            throw new IllegalStateException("command to run can't be empty");
+        }
+        final String[] arguments = command.split("\\s+");
+        return execCommandAsArray(arguments);
+    }
+
+    public List<String> execCommand(String... arguments) {
+        return execCommandAsArray(arguments);
+    }
+
+    private List<String> execCommandAsArray(String... arguments) {
+        Command allowExecCmd = new CommandBuilder(arguments).build();
+        ProcessResult processResult = Spacelift.task(CommandTool.class)
+            .command(allowExecCmd)
+            .execute()
+            .await();
+
+        return processResult.output();
+    }
+}

--- a/openshift/ftest-oc-proxy/pom.xml
+++ b/openshift/ftest-oc-proxy/pom.xml
@@ -1,0 +1,36 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-cube-openshift-parent</artifactId>
+    <groupId>org.arquillian.cube</groupId>
+    <version>1.9.3-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-cube-openshift-oc-proxy-ftest</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-requirement</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/openshift/ftest-oc-proxy/src/test/java/org/arquillian/cube/openshift/ftest/HelloWorldTest.java
+++ b/openshift/ftest-oc-proxy/src/test/java/org/arquillian/cube/openshift/ftest/HelloWorldTest.java
@@ -1,35 +1,23 @@
 package org.arquillian.cube.openshift.ftest;
 
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.List;
 import org.arquillian.cube.kubernetes.impl.utils.CommandExecutor;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+// tag::client_cli_execution[]
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
 public class HelloWorldTest {
 
-    private CommandExecutor commandExecutor;
-
-    @Before
-    public void initCommandExecutor() {
-        commandExecutor = new CommandExecutor();
-    }
-
-    @Test
-    public void should_be_able_deploy_resources_using_oc() {
-        // when
-        final List<String> resources = commandExecutor.execCommand("oc create -f https://goo.gl/qaiGRJ");
-
-        // then
-        assertThat(resources).contains("service \"hello-world\" created", "deployment \"hello-world\" created");
-    }
+    private static CommandExecutor commandExecutor = new CommandExecutor();
 
     @Test
     public void should_be_able_get_namespace_using_kubectl() {
@@ -40,10 +28,37 @@ public class HelloWorldTest {
         assertThat(namespaces).contains("namespaces/default");
     }
 
-    @After
-    public void deleteDeployment() {
-        final List<String> strings = commandExecutor.execCommand("oc delete -f https://goo.gl/qaiGRJ");
+    @Test
+    public void should_be_able_deploy_resources_using_oc() {
+        // given
+        String commandToExecute = "oc create -f " + getResource("openshift.json");
+
+        // when
+        final List<String> resources = commandExecutor.execCommand(commandToExecute);
+
+        // then
+        assertThat(resources).contains("service \"hello-world\" created", "deployment \"hello-world\" created");
+    }
+
+    @AfterClass
+    public static void deleteDeployment() {
+        String commandToExecute = "oc delete -f " + getResource("openshift.json");
+        final List<String> strings = commandExecutor.execCommand(commandToExecute);
 
         assertThat(strings).contains("service \"hello-world\" deleted", "deployment \"hello-world\" deleted");
     }
+
+    private static String getResource(String resourceName) {
+        final URL resource = Thread.currentThread().getContextClassLoader().getResource(resourceName);
+        if (resource == null) {
+            throw new IllegalStateException("Expected " + resourceName + " to be on the classpath");
+        }
+
+        try {
+            return resource.toURI().getPath();
+        } catch (URISyntaxException e) {
+            throw new RuntimeException(e);
+        }
+    }
 }
+// end::client_cli_execution[]

--- a/openshift/ftest-oc-proxy/src/test/java/org/arquillian/cube/openshift/ftest/HelloWorldTest.java
+++ b/openshift/ftest-oc-proxy/src/test/java/org/arquillian/cube/openshift/ftest/HelloWorldTest.java
@@ -1,0 +1,49 @@
+package org.arquillian.cube.openshift.ftest;
+
+import java.util.List;
+import org.arquillian.cube.kubernetes.impl.utils.CommandExecutor;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class HelloWorldTest {
+
+    private CommandExecutor commandExecutor;
+
+    @Before
+    public void initCommandExecutor() {
+        commandExecutor = new CommandExecutor();
+    }
+
+    @Test
+    public void should_be_able_deploy_resources_using_oc() {
+        // when
+        final List<String> resources = commandExecutor.execCommand("oc create -f https://goo.gl/qaiGRJ");
+
+        // then
+        assertThat(resources).contains("service \"hello-world\" created", "deployment \"hello-world\" created");
+    }
+
+    @Test
+    public void should_be_able_get_namespace_using_kubectl() {
+        // when
+        final List<String> namespaces = commandExecutor.execCommand("kubectl get ns -o=name");
+
+        // then
+        assertThat(namespaces).contains("namespaces/default");
+    }
+
+    @After
+    public void deleteDeployment() {
+        final List<String> strings = commandExecutor.execCommand("oc delete -f https://goo.gl/qaiGRJ");
+
+        assertThat(strings).contains("service \"hello-world\" deleted", "deployment \"hello-world\" deleted");
+    }
+}

--- a/openshift/ftest-oc-proxy/src/test/resources/arquillian.xml
+++ b/openshift/ftest-oc-proxy/src/test/resources/arquillian.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://jboss.org/schema/arquillian"
+  xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <extension qualifier="openshift">
+    <property name="namespace.use.current">true</property>
+    <property name="env.init.enabled">false</property>
+  </extension>
+</arquillian>

--- a/openshift/ftest-oc-proxy/src/test/resources/openshift.json
+++ b/openshift/ftest-oc-proxy/src/test/resources/openshift.json
@@ -1,0 +1,60 @@
+{
+  "apiVersion" : "v1",
+  "kind" : "List",
+  "items" : [ {
+    "apiVersion" : "v1",
+    "kind" : "Service",
+    "metadata" : {
+      "name" : "hello-world"
+    },
+    "spec" : {
+      "ports" : [ {
+        "port" : 8080,
+        "protocol" : "TCP",
+        "targetPort" : 8080
+      } ],
+      "selector" : {
+        "app" : "hello-world"
+      }
+    }
+  }, {
+    "apiVersion" : "extensions/v1beta1",
+    "kind" : "Deployment",
+    "metadata" : {
+      "name" : "hello-world"
+    },
+    "spec" : {
+      "replicas" : 1,
+      "selector" : {
+        "matchLabels": {
+          "app": "hello-world"
+        }
+      },
+      "template" : {
+        "metadata" : {
+          "labels" : {
+            "app" : "hello-world"
+          }
+        },
+        "spec" : {
+          "containers" : [ {
+            "image" : "openshift/hello-openshift:v3.6.0",
+            "name" : "hello-world-container",
+            "ports" : [ {
+              "name" : "http",
+              "protocol" : "TCP",
+              "containerPort" : 8080
+            } ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/",
+                "port": 8080
+              },
+              "initialDelaySeconds": 1
+            }
+          } ]
+        }
+      }
+    }
+  }]
+}

--- a/openshift/pom.xml
+++ b/openshift/pom.xml
@@ -28,6 +28,7 @@
     <module>ftest-standalone</module>
     <module>ftest-template-standalone</module>
     <module>ftest-openshift-resources-standalone</module>
+    <module>ftest-oc-proxy</module>
   </modules>
 
 </project>


### PR DESCRIPTION
#### Short description of what this resolves:
Now you can execute any `oc` or `kubectl` command as a part of your tests.

#### Changes proposed in this pull request:

-  Adds `CommandExecutor` class to execute any command using spacelift

#### Usage
Add kubernetes-client dependency on classpath
```xml
      <dependency>
        <groupId>org.arquillian.cube</groupId>
        <artifactId>arquillian-cube-kubernetes</artifactId>
        <version>${project.version}</version>
        <scope>test</scope>
      </dependency> 
```
Write a test like following
```java
    @Test
    public void should_be_able_deploy_resources_using_oc() {
       // given
        final CommandExecutor commandExecutor = new CommandExecutor();

        // when
        final List<String> resources = commandExecutor.execCommand("oc create -f https://goo.gl/qaiGRJ");

        // then
        assertThat(resources).contains("service \"hello-world\" created", "deployment \"hello-world\" created");
    }
```


Fixes #830
