### PR TITLE
Do not log events upon failure, we have "logs.copy" property for that

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CEEnvironmentProcessor.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CEEnvironmentProcessor.java
@@ -22,7 +22,6 @@
  */
 package org.arquillian.cube.openshift.impl;
 
-import io.fabric8.kubernetes.api.model.v3_1.Event;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -133,18 +132,6 @@ public class CEEnvironmentProcessor {
         });
     }
 
-    private void logEvents(OpenShiftClient client, CubeOpenShiftConfiguration configuration) {
-        StringBuilder b = new StringBuilder("\nLogged events from Openshift:\n\n");
-
-        for (Event event : client.getClientExt().events().inNamespace(configuration.getNamespace()).list().getItems()) {
-            b.append(String.format("[%s] [%s]: (%s) %s\n", event.getLastTimestamp(), event.getType(), event.getReason(),
-                event.getMessage()));
-        }
-        b.append("\nEnd of Openshift events\n\n");
-
-        log.info(b.toString());
-    }
-
     /**
      * Wait for the template resources to come up after the test container has
      * been started. This allows the test container and the template resources
@@ -167,7 +154,6 @@ public class CEEnvironmentProcessor {
                 delay(client, resources);
             }
         } catch (Throwable t) {
-            logEvents(openshiftClient, configuration);
             throw new DeploymentException("Error waiting for template resources to deploy: " + testClass.getName(), t);
         }
     }


### PR DESCRIPTION
This piece of code was added when we did't have the ability to copy the
logs from pods. Now we have it, so, it's up to the user enable in order
to debug issues.

See https://github.com/jboss-openshift/ce-arq/commit/e68f78ae54b7a0fad4b81a0040faa1eebf61a0b6