### PR TITLE
fix(#876): Set wait enables to true for openshift env to be ready

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -183,6 +183,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements 
                 .withNamespaceDestroyTimeout(
                     getLongProperty(NAMESPACE_DESTROY_TIMEOUT, map, DEFAULT_NAMESPACE_DESTROY_TIMEOUT))
 
+                .withWaitEnabled(getBooleanProperty(WAIT_ENABLED, map, true))
                 .withWaitTimeout(getLongProperty(WAIT_TIMEOUT, map, DEFAULT_WAIT_TIMEOUT))
                 .withWaitPollInterval(getLongProperty(WAIT_POLL_INTERVAL, map, DEFAULT_WAIT_POLL_INTERVAL))
                 .withWaitForServiceList(


### PR DESCRIPTION
As a part of https://github.com/arquillian/arquillian-cube/pull/868/files, we are setting waitEnabled to true only for DefaultKubernetes configuration which is working fine for k8s extension. Check code [here](https://github.com/arquillian/arquillian-cube/pull/868/files#diff-6532ea423d1c6b77a83466b11a4b6240R150)

We should set it to `CubeOpenShiftConfiguration`


Fixes #876 
