### PR TITLE
Docker image compatible with minishift to work all ftest from cube-k8s

### DIFF
--- a/kubernetes/ftest-kubernetes-reporter/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes-reporter/src/test/resources/kubernetes.json
@@ -36,7 +36,7 @@
         },
         "spec" : {
           "containers" : [ {
-            "image" : "dockercloud/hello-world",
+            "image" : "openshift/hello-openshift:v3.6.0",
             "name" : "hello-world-container",
             "ports" : [ {
               "name" : "http",

--- a/kubernetes/ftest-kubernetes/src/test/java/HelloWorldTest.java
+++ b/kubernetes/ftest-kubernetes/src/test/java/HelloWorldTest.java
@@ -49,7 +49,7 @@ public class HelloWorldTest {
             Response response = okHttpClient.newCall(request).execute();
             assertNotNull(response);
             assertEquals(200, response.code());
-            assertTrue(response.body().string().contains("Hello world!"));
+            assertTrue(response.body().string().contains("Hello OpenShift!\n"));
         }
     }
 }

--- a/kubernetes/ftest-kubernetes/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes/src/test/resources/kubernetes.json
@@ -11,7 +11,7 @@
       "ports" : [ {
         "port" : 80,
         "protocol" : "TCP",
-        "targetPort" : 80
+        "targetPort" : 8080
       } ],
       "selector" : {
         "app" : "hello-world"
@@ -38,17 +38,17 @@
         },
         "spec" : {
           "containers" : [ {
-            "image" : "dockercloud/hello-world",
+            "image" : "openshift/hello-openshift:v3.6.0",
             "name" : "hello-world-container",
             "ports" : [ {
               "name" : "http",
               "protocol" : "TCP",
-              "containerPort" : 80
+              "containerPort" : 8080
             } ],
             "readinessProbe": {
               "httpGet": {
                 "path": "/",
-                "port": 80
+                "port": 8080
               },
               "initialDelaySeconds": 1
             }

--- a/openshift/ftest-standalone/pom.xml
+++ b/openshift/ftest-standalone/pom.xml
@@ -31,5 +31,10 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>openshift-client</artifactId>
+      <version>${version.kubernetes_client}</version>
+    </dependency>
   </dependencies>
 </project>

--- a/openshift/ftest-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldTest.java
+++ b/openshift/ftest-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldTest.java
@@ -1,7 +1,7 @@
 package org.arquillian.cube.openshift.standalone;
 
 import io.fabric8.kubernetes.api.model.v3_1.Service;
-import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
+import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
 import java.net.URL;
 import okhttp3.OkHttpClient;


### PR DESCRIPTION
#### Changes proposed in this pull request:

- Changed `dockercloud/hello-world` to `openshift/hello-openshift:v3.6.0`
- Uses k8-client version in ftest as per documentation



Fixes #880 
