### PR TITLE
feat(#860): Set OpenShift resources at method level

### DIFF
--- a/openshift/api/src/main/java/org/arquillian/cube/openshift/api/OpenShiftResource.java
+++ b/openshift/api/src/main/java/org/arquillian/cube/openshift/api/OpenShiftResource.java
@@ -30,17 +30,20 @@ import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
 /**
+ * Annotation to set the OpenShift resource to be executed before test execution.
+ * These resources creation were meant to be used for resources that aren't tied to a living thing.
+ * Examples of these are service accounts, credentials, routes, ...
+ *
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD})
 @Repeatable(OpenShiftResources.class)
 public @interface OpenShiftResource {
     /**
      * The value can either be
      * link (https://www.github.com/alesj/template-testing/some.json)
      * test classpath resource (classpath:some.json)
-     * deployment archive resource (archive:some.json)
      * or plain content ({"kind" : "Secret", ...})
      *
      * W/o any prefix (or http schema) it's treated as plain content.

--- a/openshift/api/src/main/java/org/arquillian/cube/openshift/api/OpenShiftResources.java
+++ b/openshift/api/src/main/java/org/arquillian/cube/openshift/api/OpenShiftResources.java
@@ -32,7 +32,7 @@ import java.lang.annotation.Target;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 @Retention(RetentionPolicy.RUNTIME)
-@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE})
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD})
 public @interface OpenShiftResources {
     OpenShiftResource[] value();
 }

--- a/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesTest.java
+++ b/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesTest.java
@@ -1,5 +1,7 @@
 package org.arquillian.cube.openshift.standalone;
 
+import io.fabric8.openshift.api.model.RouteList;
+import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
 import java.net.URL;
 import okhttp3.OkHttpClient;
@@ -10,6 +12,7 @@ import org.arquillian.cube.openshift.impl.enricher.AwaitRoute;
 import org.arquillian.cube.openshift.impl.enricher.RouteURL;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -24,6 +27,9 @@ public class HelloWorldOpenShiftResourcesTest {
     @AwaitRoute
     URL url;
 
+    @ArquillianResource
+    OpenShiftClient openShiftClient;
+
     @Test
     public void should_show_hello_world() throws IOException {
         assertThat(url).isNotNull();
@@ -35,4 +41,12 @@ public class HelloWorldOpenShiftResourcesTest {
         assertThat(response.code()).isEqualTo(200);
         assertThat(response.body().string()).isEqualTo("Hello OpenShift!\n");
     }
+
+    @Test
+    @OpenShiftResource("classpath:hello-route-2.yaml")
+    public void should_register_extra_route() {
+        final RouteList routes = openShiftClient.routes().list();
+        assertThat(routes.getItems()).hasSize(2);
+    }
+
 }

--- a/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesTest.java
+++ b/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesTest.java
@@ -1,5 +1,7 @@
 package org.arquillian.cube.openshift.standalone;
 
+import io.fabric8.kubernetes.api.model.ObjectMeta;
+import io.fabric8.openshift.api.model.Route;
 import io.fabric8.openshift.api.model.RouteList;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
@@ -46,7 +48,11 @@ public class HelloWorldOpenShiftResourcesTest {
     @OpenShiftResource("classpath:hello-route-2.yaml")
     public void should_register_extra_route() {
         final RouteList routes = openShiftClient.routes().list();
-        assertThat(routes.getItems()).hasSize(2);
+        assertThat(routes.getItems())
+            .hasSize(2)
+            .extracting(Route::getMetadata)
+            .extracting(ObjectMeta::getName)
+            .containsExactlyInAnyOrder("hello-world", "hello-world-2");
     }
 
 }

--- a/openshift/ftest-openshift-resources-standalone/src/test/resources/hello-route-2.yaml
+++ b/openshift/ftest-openshift-resources-standalone/src/test/resources/hello-route-2.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Route
+metadata:
+  name: hello-world-2
+spec:
+  port:
+    targetPort: 8080
+  to:
+    kind: Service
+    name: hello-world

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CEEnvironmentProcessor.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CEEnvironmentProcessor.java
@@ -22,6 +22,7 @@
  */
 package org.arquillian.cube.openshift.impl;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -49,7 +50,9 @@ import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.TestClass;
 import org.jboss.arquillian.test.spi.annotation.ClassScoped;
+import org.jboss.arquillian.test.spi.event.suite.After;
 import org.jboss.arquillian.test.spi.event.suite.AfterClass;
+import org.jboss.arquillian.test.spi.event.suite.Before;
 import org.jboss.arquillian.test.spi.event.suite.BeforeClass;
 
 import static org.arquillian.cube.openshift.impl.utils.TemplateUtils.addParameterValues;
@@ -93,9 +96,32 @@ public class CEEnvironmentProcessor {
         CubeOpenShiftConfiguration configuration) throws DeploymentException {
         final TestClass testClass = event.getTestClass();
         log.info(String.format("Creating environment for %s", testClass.getName()));
-        OpenShiftResourceFactory.createResources(testClass.getName(), client, null, testClass.getJavaClass(),
+        OpenShiftResourceFactory.createResources(testClass.getName(), client, testClass.getJavaClass(),
             configuration.getProperties());
         processTemplateResources(testClass, client, configuration);
+    }
+
+    public void createOpenShiftResource(@Observes(precedence = 10) Before event, OpenShiftAdapter client,
+        CubeOpenShiftConfiguration cubeOpenShiftConfiguration) {
+
+        final TestClass testClass = event.getTestClass();
+        final Method testMethod = event.getTestMethod();
+
+        log.info(String.format("Creating environment for %s method %s", testClass.getName(), testMethod));
+
+        OpenShiftResourceFactory.createResources(testClass.getJavaClass(), client, testMethod, cubeOpenShiftConfiguration.getProperties());
+
+    }
+
+    public void deleteOpenShiftResource(@Observes(precedence = -10) After event, OpenShiftAdapter client) {
+
+        final TestClass testClass = event.getTestClass();
+        final Method testMethod = event.getTestMethod();
+
+        log.info(String.format("Deleting environment for %s method %s", testClass.getName(), testMethod.getName()));
+
+        OpenShiftResourceFactory.deleteReosurces(testClass.getJavaClass(), testMethod, client);
+
     }
 
     /**
@@ -124,12 +150,7 @@ public class CEEnvironmentProcessor {
                 }
             }
         }
-        templateDetailsProducer.set(new TemplateDetails() {
-            @Override
-            public List<List<? extends OpenShiftResource>> getResources() {
-                return RESOURCES;
-            }
-        });
+        templateDetailsProducer.set(() -> RESOURCES);
     }
 
     /**

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CEEnvironmentProcessor.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CEEnvironmentProcessor.java
@@ -120,7 +120,7 @@ public class CEEnvironmentProcessor {
 
         log.info(String.format("Deleting environment for %s method %s", testClass.getName(), testMethod.getName()));
 
-        OpenShiftResourceFactory.deleteReosurces(testClass.getJavaClass(), testMethod, client);
+        OpenShiftResourceFactory.deleteResources(testClass.getJavaClass(), testMethod, client);
 
     }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/resources/OpenShiftResourceFactory.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/resources/OpenShiftResourceFactory.java
@@ -24,10 +24,13 @@
 package org.arquillian.cube.openshift.impl.resources;
 
 import java.io.ByteArrayInputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Properties;
 import java.util.logging.Logger;
@@ -61,59 +64,78 @@ public class OpenShiftResourceFactory {
     private static final ARSAFinder ARSA_FINDER = new ARSAFinder();
     private static final TEMPFinder TEMP_FINDER = new TEMPFinder();
 
-    public static void createResources(String resourcesKey, OpenShiftAdapter adapter, Archive<?> archive, Class<?> testClass, Properties properties) {
+    public static void createResources(String resourcesKey, OpenShiftAdapter adapter, Class<?> testClass, Properties properties) {
         try {
             final StringResolver resolver = Strings.createStringResolver(properties);
 
             List<OpenShiftResource> openShiftResources = new ArrayList<>();
             OSR_FINDER.findAnnotations(openShiftResources, testClass);
-            for (OpenShiftResource osr : openShiftResources) {
-                String file = resolver.resolve(osr.value());
-
-                InputStream stream;
-                if (file.startsWith(URL_PREFIX)) {
-                    stream = new URL(file).openStream();
-                } else if (file.startsWith(CLASSPATH_PREFIX)) {
-                    String resourceName = file.substring(CLASSPATH_PREFIX.length());
-                    stream = testClass.getClassLoader().getResourceAsStream(resourceName);
-                    if (stream == null) {
-                        throw new IllegalArgumentException("Could not find resource on classpath: " + resourceName);
-                    }
-                } else if (file.startsWith(ARCHIVE_PREFIX)) {
-                    String resourceName = file.substring(ARCHIVE_PREFIX.length());
-                    Node node = archive.get(resourceName);
-                    if (node == null) {
-                        throw new IllegalArgumentException("Could not find resource in Arquillian archive: " + resourceName);
-                    }
-                    stream = node.getAsset().openStream();
-                } else {
-                    stream = new ByteArrayInputStream(file.getBytes());
-                }
-
-                log.info(String.format("Creating new OpenShift resource: %s", file));
-                adapter.createResource(resourcesKey, stream);
-            }
+            createOpenShiftResources(resourcesKey, adapter, testClass, resolver, openShiftResources);
 
             List<RoleBinding> roleBindings = new ArrayList<>();
             RB_FINDER.findAnnotations(roleBindings, testClass);
-            for (RoleBinding rb : roleBindings) {
-                String roleRefName = resolver.resolve(rb.roleRefName());
-                String userName = resolver.resolve(rb.userName());
-                log.info(String.format("Adding new role binding: %s / %s", roleRefName, userName));
-                adapter.addRoleBinding(resourcesKey, roleRefName, userName);
-            }
+            createRoleBindings(resourcesKey, adapter, resolver, roleBindings);
 
             List<AddRoleToServiceAccount> arsaBindings = new ArrayList<>();
             ARSA_FINDER.findAnnotations(arsaBindings, testClass);
-            for (AddRoleToServiceAccount arsa : arsaBindings) {
-                String role = resolver.resolve(arsa.role());
-                String saPattern = String.format("system:serviceaccount:${kubernetes.namespace}:%s", arsa.serviceAccount());
-                String serviceAccount = resolver.resolve(saPattern);
-                log.info(String.format("Adding role %s to service account %s", role, serviceAccount));
-                adapter.addRoleBinding(resourcesKey, role, serviceAccount);
-            }
+            createRolesToServiceAccounts(resourcesKey, adapter, resolver, arsaBindings);
         } catch (Exception e) {
             throw new IllegalStateException(e);
+        }
+    }
+
+    public static void createResources(Class<?> testClass, OpenShiftAdapter client, Method testMethod, Properties properties) {
+        final StringResolver resolver = Strings.createStringResolver(properties);
+
+        final List<OpenShiftResource> openShiftResources = Arrays.asList(testMethod.getAnnotationsByType(OpenShiftResource.class));
+        try {
+            createOpenShiftResources(createResourceKey(testClass, testMethod), client, testClass, resolver, openShiftResources);
+        } catch (Exception e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private static void createRolesToServiceAccounts(String resourcesKey, OpenShiftAdapter adapter,
+        StringResolver resolver, List<AddRoleToServiceAccount> arsaBindings) {
+        for (AddRoleToServiceAccount arsa : arsaBindings) {
+            String role = resolver.resolve(arsa.role());
+            String saPattern = String.format("system:serviceaccount:${kubernetes.namespace}:%s", arsa.serviceAccount());
+            String serviceAccount = resolver.resolve(saPattern);
+            log.info(String.format("Adding role %s to service account %s", role, serviceAccount));
+            adapter.addRoleBinding(resourcesKey, role, serviceAccount);
+        }
+    }
+
+    private static void createRoleBindings(String resourcesKey, OpenShiftAdapter adapter, StringResolver resolver,
+        List<RoleBinding> roleBindings) {
+        for (RoleBinding rb : roleBindings) {
+            String roleRefName = resolver.resolve(rb.roleRefName());
+            String userName = resolver.resolve(rb.userName());
+            log.info(String.format("Adding new role binding: %s / %s", roleRefName, userName));
+            adapter.addRoleBinding(resourcesKey, roleRefName, userName);
+        }
+    }
+
+    private static void createOpenShiftResources(String resourcesKey, OpenShiftAdapter adapter, Class<?> testClass,
+        StringResolver resolver, List<OpenShiftResource> openShiftResources) throws IOException {
+        for (OpenShiftResource osr : openShiftResources) {
+            String file = resolver.resolve(osr.value());
+
+            InputStream stream;
+            if (file.startsWith(URL_PREFIX)) {
+                stream = new URL(file).openStream();
+            } else if (file.startsWith(CLASSPATH_PREFIX)) {
+                String resourceName = file.substring(CLASSPATH_PREFIX.length());
+                stream = testClass.getClassLoader().getResourceAsStream(resourceName);
+                if (stream == null) {
+                    throw new IllegalArgumentException("Could not find resource on classpath: " + resourceName);
+                }
+            } else {
+                stream = new ByteArrayInputStream(file.getBytes());
+            }
+
+            log.info(String.format("Creating new OpenShift resource: %s", file));
+            adapter.createResource(resourcesKey, stream);
         }
     }
 
@@ -151,6 +173,18 @@ public class OpenShiftResourceFactory {
         } catch (Exception e) {
             throw new IllegalStateException(e);
         }
+    }
+
+    public static void deleteReosurces(Class<?> testClass, Method testMethod, OpenShiftAdapter client) {
+        try {
+            client.deleteResources(createResourceKey(testClass, testMethod));
+        } catch (Exception e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static String createResourceKey(Class<?> testClass, Method testMethod) {
+        return testClass.getName() + testMethod.getName();
     }
 
     private static abstract class Finder<U extends Annotation, V extends Annotation> {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/resources/OpenShiftResourceFactory.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/resources/OpenShiftResourceFactory.java
@@ -175,7 +175,7 @@ public class OpenShiftResourceFactory {
         }
     }
 
-    public static void deleteReosurces(Class<?> testClass, Method testMethod, OpenShiftAdapter client) {
+    public static void deleteResources(Class<?> testClass, Method testMethod, OpenShiftAdapter client) {
         try {
             client.deleteResources(createResourceKey(testClass, testMethod));
         } catch (Exception e) {


### PR DESCRIPTION
#### Short description of what this resolves:

You can set OpenShift resources using `@OpenShiftResources` annotation at method level, so resources are created before the test and deleted after the test.

#### Changes proposed in this pull request:

- `@OpenShiftResources` at method level
- Observers for creating resources before and after each test method execution.


Fixes #860 
