### PR TITLE
Cube CI is using oc cluster up to run all ftests from k8s & openshift

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,7 +60,7 @@ install:
 before_script: ./mvnw install -q -U -DskipTests=true
 
 script:
-  - ./mvnw clean test -pl openshift/ftest
+  - ./mvnw clean install
   - 'if [ $FORCE_DOC_GEN == 0 ] || [ $GENERATE_DOC == 0 ]; then
       docker run -v $TRAVIS_BUILD_DIR:/docs/ --name adoc-to-html rochdev/alpine-asciidoctor:mini asciidoctor /docs/README.adoc -a generated-doc=true -a asciidoctor-source=/docs/docs -o /docs/gh-pages/index.html;
     fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,11 @@ cache:
   directories:
     - $HOME/.m2
 
+matrix:
+ - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.0" COMMIT_ID="c4dd4cf"
+ - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.1" COMMIT_ID="008f2d5"
+ - env: OC_CLUSTER_UP=true OC_VERSION="v3.8.0-alpha.0" COMMIT_ID="e6b20e1"
+
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "#doc" | wc -l) -gt 0 ] && FORCE_DOC_GEN=0 || FORCE_DOC_GEN=1'
@@ -29,6 +34,23 @@ before_install:
       GH_REF=$(git remote get-url origin | awk "{sub(/https:\/\//,\"https://${GH_TOKEN}@\")}; 1" | awk "{sub(/\.git/, \"\")} 1");
       docker pull rochdev/alpine-asciidoctor:mini;
     fi'
+
+install:
+  - |
+      if [ ${OC_CLUSTER_UP} ]; then
+        tmp=`mktemp`
+        echo 'DOCKER_OPTS="$DOCKER_OPTS --insecure-registry 172.30.0.0/16"' > ${tmp}
+        sudo mv ${tmp} /etc/default/docker
+        sudo mount --make-shared /
+        sudo service docker restart
+        curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
+            chmod +x kubectl && sudo mv kubectl /usr/local/bin/
+        client_tools="openshift-origin-client-tools-${OC_VERSION}-${COMMIT_ID}-linux-64bit" && curl -LO https://github.com/openshift/origin/releases/download/${OC_VERSION}/${client_tools}.tar.gz && \
+          tar -xvzf ${client_tools}.tar.gz && sudo mv $PWD/${client_tools}/oc /usr/local/bin/ && rm -rf ${client_tools}.tar.gz
+        oc cluster up --version=${OC_VERSION}
+        sleep 10
+        oc login -u system:admin
+      fi
 
 before_script: ./mvnw install -q -U -DskipTests=true
 
@@ -55,3 +77,8 @@ after_failure:
   - 'if [ $FORCE_DOC_GEN == 0 ] || [ $GENERATE_DOC == 0 ]; then
       docker logs adoc-to-html;
     fi'
+  - |
+      if [ ${OC_CLUSTER_UP} ]; then
+        oc project default
+        oc get event -w
+      fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,10 +15,10 @@ cache:
   directories:
     - $HOME/.m2
 
-matrix:
- - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.0" COMMIT_ID="c4dd4cf"
- - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.1" COMMIT_ID="008f2d5"
- - env: OC_CLUSTER_UP=true OC_VERSION="v3.8.0-alpha.0" COMMIT_ID="e6b20e1"
+env:
+ - OC_CLUSTER_UP=true OC_VERSION="v3.6.0" COMMIT_ID="c4dd4cf"
+ - OC_CLUSTER_UP=true OC_VERSION="v3.6.1" COMMIT_ID="008f2d5"
+ - OC_CLUSTER_UP=true OC_VERSION="v3.8.0-alpha.0" COMMIT_ID="e6b20e1"
 
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,11 @@
 sudo: required
+
+matrix:
+  include:
+    - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.0" COMMIT_ID="c4dd4cf"
+    - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.1" COMMIT_ID="008f2d5"
+    - env: OC_CLUSTER_UP=true OC_VERSION="v3.7.0-rc.0" COMMIT_ID="e92d5c5"
+
 services:
   - docker
 addons:
@@ -14,11 +21,6 @@ jdk:
 cache:
   directories:
     - $HOME/.m2
-
-env:
- - OC_CLUSTER_UP=true OC_VERSION="v3.6.0" COMMIT_ID="c4dd4cf"
- - OC_CLUSTER_UP=true OC_VERSION="v3.6.1" COMMIT_ID="008f2d5"
- - OC_CLUSTER_UP=true OC_VERSION="v3.8.0-alpha.0" COMMIT_ID="e6b20e1"
 
 before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,8 @@ install:
         sudo mv ${tmp} /etc/default/docker
         sudo mount --make-shared /
         sudo service docker restart
+        docker pull openshift/wildfly-101-centos7
+        docker pull aslakknutsen/openshift-arquillian-gitserver
         curl -LO https://storage.googleapis.com/kubernetes-release/release/$(curl -s https://storage.googleapis.com/kubernetes-release/release/stable.txt)/bin/linux/amd64/kubectl && \
             chmod +x kubectl && sudo mv kubectl /usr/local/bin/
         client_tools="openshift-origin-client-tools-${OC_VERSION}-${COMMIT_ID}-linux-64bit" && curl -LO https://github.com/openshift/origin/releases/download/${OC_VERSION}/${client_tools}.tar.gz && \
@@ -58,7 +60,7 @@ install:
 before_script: ./mvnw install -q -U -DskipTests=true
 
 script:
-  - ./mvnw clean install
+  - ./mvnw clean test -pl openshift/ftest
   - 'if [ $FORCE_DOC_GEN == 0 ] || [ $GENERATE_DOC == 0 ]; then
       docker run -v $TRAVIS_BUILD_DIR:/docs/ --name adoc-to-html rochdev/alpine-asciidoctor:mini asciidoctor /docs/README.adoc -a generated-doc=true -a asciidoctor-source=/docs/docs -o /docs/gh-pages/index.html;
     fi'

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ sudo: required
 
 matrix:
   include:
+    #https://github.com/openshift/origin/issues/17210
+    #- env: OC_CLUSTER_UP=true OC_VERSION="v3.7.0-rc.0" COMMIT_ID="e92d5c5"
     - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.0" COMMIT_ID="c4dd4cf"
     - env: OC_CLUSTER_UP=true OC_VERSION="v3.6.1" COMMIT_ID="008f2d5"
-    - env: OC_CLUSTER_UP=true OC_VERSION="v3.7.0-rc.0" COMMIT_ID="e92d5c5"
 
 services:
   - docker

--- a/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftTestCase.java
+++ b/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftTestCase.java
@@ -9,7 +9,6 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 

--- a/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftTestCase.java
+++ b/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftTestCase.java
@@ -9,11 +9,13 @@ import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
+@Ignore
 public class HelloPodDeploymentOpenShiftTestCase {
 
     @ArquillianResource

--- a/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftTestCase.java
+++ b/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftTestCase.java
@@ -15,7 +15,6 @@ import org.junit.runner.RunWith;
 
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
-@Ignore
 public class HelloPodDeploymentOpenShiftTestCase {
 
     @ArquillianResource


### PR DESCRIPTION
#### Short description of what this resolves:
Running `oc cluster up` on travis.

#### Changes proposed in this pull request:
 - Starting cluster using `oc cluster up` to start openshift cluster.
- Using matrix to run tests on different cluster


Fixes #882
