### PR TITLE
Add support for default docker configuration

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -18,6 +18,8 @@ import java.io.File;
 import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.nio.file.FileSystems;
+import java.nio.file.Files;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
@@ -58,6 +60,7 @@ public class CubeDockerConfigurationResolver {
      */
     public Map<String, String> resolve(Map<String, String> config) {
         config = resolveSystemEnvironmentVariables(config);
+        config = resolveSystemDefaultSetup(config);
         config = resolveDockerInsideDocker(config);
         config = resolveDownloadDockerMachine(config);
         config = resolveAutoStartDockerMachine(config);
@@ -193,6 +196,17 @@ public class CubeDockerConfigurationResolver {
 
         if (!config.containsKey(CubeDockerConfiguration.TLS_VERIFY) && isDockerTlsVerifySet()) {
             config.put(CubeDockerConfiguration.TLS_VERIFY, Boolean.TRUE.toString());
+        }
+
+        return config;
+    }
+    
+    private Map<String, String> resolveSystemDefaultSetup(Map<String, String> config) {
+        if (!config.containsKey(CubeDockerConfiguration.DOCKER_URI)) {
+            URI uri = URI.create(operatingSystem.getDefaultFamily().getServerUri());
+            if (Files.exists(FileSystems.getDefault().getPath(uri.getPath()))){
+                config.put(CubeDockerConfiguration.DOCKER_URI, operatingSystem.getDefaultFamily().getServerUri());
+            }
         }
 
         return config;

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -6,8 +6,8 @@ import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.GitHubUtil;
 import org.arquillian.cube.docker.impl.util.HomeResolverUtil;
 import org.arquillian.cube.docker.impl.util.Machine;
-import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.impl.util.SystemEnvironmentVariables;
@@ -42,10 +42,10 @@ public class CubeDockerConfigurationResolver {
     private final Top top;
     private final DockerMachine dockerMachine;
     private final Boot2Docker boot2Docker;
-    private final OperatingSystem operatingSystem;
+    private final OperatingSystemInterface operatingSystem;
 
     public CubeDockerConfigurationResolver(Top top, DockerMachine dockerMachine, Boot2Docker boot2Docker,
-                                           OperatingSystem operatingSystem) {
+                                           OperatingSystemInterface operatingSystem) {
         this.top = top;
         this.dockerMachine = dockerMachine;
         this.boot2Docker = boot2Docker;

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -232,10 +232,6 @@ public class CubeDockerConfigurationResolver {
         }
 
         config.put(CubeDockerConfiguration.DOCKER_URI, dockerServerUri);
-        if (!config.containsKey(CubeDockerConfiguration.CERT_PATH)) {
-            config.put(CubeDockerConfiguration.CERT_PATH,
-                HomeResolverUtil.resolveHomeDirectoryChar(getDefaultTlsDirectory(config)));
-        }
 
         resolveDockerServerIp(config, dockerServerUri);
 
@@ -246,6 +242,11 @@ public class CubeDockerConfigurationResolver {
 
         URI serverUri = URI.create(config.get(CubeDockerConfiguration.DOCKER_URI));
         String scheme = serverUri.getScheme();
+
+        if (!config.containsKey(CubeDockerConfiguration.CERT_PATH)) {
+            config.put(CubeDockerConfiguration.CERT_PATH,
+                HomeResolverUtil.resolveHomeDirectoryChar(getDefaultTlsDirectory(config)));
+        }
 
         if (scheme.equals(HTTP_SCHEME)) {
             config.remove(CubeDockerConfiguration.TLS_VERIFY);
@@ -268,6 +269,10 @@ public class CubeDockerConfigurationResolver {
             } catch (URISyntaxException e) {
                 throw new IllegalArgumentException(e);
             }
+        }
+
+        if (scheme.equals("unix") || scheme.equals("npipe")){
+            config.put(CubeDockerConfiguration.TLS_VERIFY, Boolean.toString(false));
         }
 
         if (!config.containsKey(CubeDockerConfiguration.TLS_VERIFY)) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -214,7 +214,7 @@ public class CubeDockerConfigurationResolver {
             URI uri = URI.create(defaultUri);
             if (Files.exists(FileSystems.getDefault().getPath(uri.getPath()))){
 
-                DockerClient client = defaultDocker.GetDefaultDockerClient(defaultUri);
+                DockerClient client = defaultDocker.getDefaultDockerClient(defaultUri);
                 InfoCmd cmd = client.infoCmd();
                 try {
                     Info info = cmd.exec();

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -6,6 +6,7 @@ import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.GitHubUtil;
 import org.arquillian.cube.docker.impl.util.HomeResolverUtil;
 import org.arquillian.cube.docker.impl.util.Machine;
+import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.impl.util.Strings;
@@ -39,14 +40,14 @@ public class CubeDockerConfigurationResolver {
     private final Top top;
     private final DockerMachine dockerMachine;
     private final Boot2Docker boot2Docker;
-    private final OperatingSystemFamily operatingSystemFamily;
+    private final OperatingSystem operatingSystem;
 
     public CubeDockerConfigurationResolver(Top top, DockerMachine dockerMachine, Boot2Docker boot2Docker,
-                                           OperatingSystemFamily operatingSystemFamily) {
+                                           OperatingSystem operatingSystem) {
         this.top = top;
         this.dockerMachine = dockerMachine;
         this.boot2Docker = boot2Docker;
-        this.operatingSystemFamily = operatingSystemFamily;
+        this.operatingSystem = operatingSystem;
     }
 
     /**
@@ -258,7 +259,7 @@ public class CubeDockerConfigurationResolver {
         if (!config.containsKey(CubeDockerConfiguration.TLS_VERIFY)) {
             config.put(CubeDockerConfiguration.TLS_VERIFY, Boolean.toString(true));
 
-            if (operatingSystemFamily == OperatingSystemFamily.LINUX) {
+            if (operatingSystem.getFamily() == OperatingSystemFamily.LINUX) {
 
                 String dockerServerIp = config.get(CubeDockerConfiguration.DOCKER_SERVER_IP);
 
@@ -350,7 +351,7 @@ public class CubeDockerConfigurationResolver {
                 String serverUri = OperatingSystemFamily.MACHINE.getServerUri();
                 cubeConfiguration.put(CubeDockerConfiguration.DOCKER_URI, serverUri);
             } else {
-                String serverUri = operatingSystemFamily.getServerUri();
+                String serverUri = operatingSystem.getFamily().getServerUri();
                 cubeConfiguration.put(CubeDockerConfiguration.DOCKER_URI, serverUri);
             }
         }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
@@ -8,6 +8,7 @@ import org.arquillian.cube.docker.impl.client.config.StarOperator;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystem;
+import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.spi.CubeConfiguration;
@@ -54,14 +55,14 @@ public class CubeDockerConfigurator {
 
     @Inject
     @ApplicationScoped
-    private InstanceProducer<OperatingSystem> operatingSystemInstanceProducer;
+    private InstanceProducer<OperatingSystemInterface> operatingSystemInstanceProducer;
 
 
     public void configure(@Observes CubeConfiguration event, ArquillianDescriptor arquillianDescriptor) {
         configure(arquillianDescriptor);
     }
 
-    OperatingSystem getCurrentOperatingSystem() {
+    OperatingSystemInterface getCurrentOperatingSystem() {
         return new OperatingSystemResolver().currentOperatingSystem();
     }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
@@ -6,6 +6,7 @@ import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
 import org.arquillian.cube.docker.impl.client.config.Network;
 import org.arquillian.cube.docker.impl.client.config.StarOperator;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
+import org.arquillian.cube.docker.impl.util.DefaultDocker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
@@ -76,6 +77,7 @@ public class CubeDockerConfigurator {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(topInstance.get(),
             dockerMachineInstance.get(),
             boot2DockerInstance.get(),
+            new DefaultDocker(),
             operatingSystemInstanceProducer.get());
         resolver.resolve(config);
         CubeDockerConfiguration cubeConfiguration = CubeDockerConfiguration.fromMap(config, injectorInstance.get());

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
@@ -1,23 +1,13 @@
 package org.arquillian.cube.docker.impl.client;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-import java.util.Random;
-import java.util.UUID;
-import java.util.logging.Logger;
 import org.arquillian.cube.HostIpContext;
 import org.arquillian.cube.docker.impl.client.config.CubeContainer;
 import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
-import org.arquillian.cube.docker.impl.client.config.Link;
 import org.arquillian.cube.docker.impl.client.config.Network;
-import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.arquillian.cube.docker.impl.client.config.StarOperator;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystem;
-import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.spi.CubeConfiguration;
@@ -28,6 +18,13 @@ import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.logging.Logger;
 
 public class CubeDockerConfigurator {
 
@@ -59,12 +56,21 @@ public class CubeDockerConfigurator {
     @ApplicationScoped
     private InstanceProducer<OperatingSystem> operatingSystemInstanceProducer;
 
+
     public void configure(@Observes CubeConfiguration event, ArquillianDescriptor arquillianDescriptor) {
         configure(arquillianDescriptor);
     }
 
+    OperatingSystem getCurrentOperatingSystem() {
+        return new OperatingSystemResolver().currentOperatingSystem();
+    }
+
     private void configure(ArquillianDescriptor arquillianDescriptor) {
-        operatingSystemInstanceProducer.set(new OperatingSystemResolver().currentOperatingSystem());
+
+        if (!Optional.ofNullable(operatingSystemInstanceProducer.get()).isPresent()) {
+            operatingSystemInstanceProducer.set(getCurrentOperatingSystem());
+        }
+
         Map<String, String> config = arquillianDescriptor.extension(EXTENSION_NAME).getExtensionProperties();
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(topInstance.get(),
             dockerMachineInstance.get(),

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurator.java
@@ -16,6 +16,7 @@ import org.arquillian.cube.docker.impl.client.config.PortBinding;
 import org.arquillian.cube.docker.impl.client.config.StarOperator;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
+import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
@@ -56,19 +57,19 @@ public class CubeDockerConfigurator {
 
     @Inject
     @ApplicationScoped
-    private InstanceProducer<OperatingSystemFamily> operatingSystemFamilyInstanceProducer;
+    private InstanceProducer<OperatingSystem> operatingSystemInstanceProducer;
 
     public void configure(@Observes CubeConfiguration event, ArquillianDescriptor arquillianDescriptor) {
         configure(arquillianDescriptor);
     }
 
     private void configure(ArquillianDescriptor arquillianDescriptor) {
-        operatingSystemFamilyInstanceProducer.set(new OperatingSystemResolver().currentOperatingSystem().getFamily());
+        operatingSystemInstanceProducer.set(new OperatingSystemResolver().currentOperatingSystem());
         Map<String, String> config = arquillianDescriptor.extension(EXTENSION_NAME).getExtensionProperties();
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(topInstance.get(),
             dockerMachineInstance.get(),
             boot2DockerInstance.get(),
-            operatingSystemFamilyInstanceProducer.get());
+            operatingSystemInstanceProducer.get());
         resolver.resolve(config);
         CubeDockerConfiguration cubeConfiguration = CubeDockerConfiguration.fromMap(config, injectorInstance.get());
         cubeConfiguration = resolveDynamicNames(cubeConfiguration);

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerMachineDistro.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerMachineDistro.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.docker.impl.model;
 
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.OperatingSystemFamilyInterface;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 
 public enum DockerMachineDistro {
@@ -19,7 +20,7 @@ public enum DockerMachineDistro {
     }
 
     public static String resolveDistro() {
-        OperatingSystemFamily currentOSFamily = new OperatingSystemResolver().currentOperatingSystem().getFamily();
+        OperatingSystemFamilyInterface currentOSFamily = new OperatingSystemResolver().currentOperatingSystem().getFamily();
         for (DockerMachineDistro distro : values()) {
             for (OperatingSystemFamily osFamily : distro.osFamily) {
                 if (osFamily == currentOSFamily) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerRequirement.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerRequirement.java
@@ -12,6 +12,7 @@ import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfigurationResolver;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
+import org.arquillian.cube.docker.impl.util.DefaultDocker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
@@ -29,6 +30,7 @@ public class DockerRequirement implements Constraint<RequiresDocker> {
         this.resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(commandLineExecutor),
             new Boot2Docker(commandLineExecutor),
+            new DefaultDocker(),
             new OperatingSystemResolver().currentOperatingSystem()
         );
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerRequirement.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/requirement/DockerRequirement.java
@@ -29,7 +29,7 @@ public class DockerRequirement implements Constraint<RequiresDocker> {
         this.resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(commandLineExecutor),
             new Boot2Docker(commandLineExecutor),
-            new OperatingSystemResolver().currentOperatingSystem().getFamily()
+            new OperatingSystemResolver().currentOperatingSystem()
         );
     }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/DefaultDocker.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/DefaultDocker.java
@@ -6,7 +6,7 @@ import com.github.dockerjava.core.DockerClientBuilder;
 
 public class DefaultDocker {
 
-    public DockerClient GetDefaultDockerClient(String defaultPath) {
+    public DockerClient getDefaultDockerClient(String defaultPath) {
         final DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig
             .createDefaultConfigBuilder();
         configBuilder.withDockerHost(defaultPath);

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/DefaultDocker.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/DefaultDocker.java
@@ -1,0 +1,15 @@
+package org.arquillian.cube.docker.impl.util;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DefaultDockerClientConfig;
+import com.github.dockerjava.core.DockerClientBuilder;
+
+public class DefaultDocker {
+
+    public DockerClient GetDefaultDockerClient(String defaultPath) {
+        final DefaultDockerClientConfig.Builder configBuilder = DefaultDockerClientConfig
+            .createDefaultConfigBuilder();
+        configBuilder.withDockerHost(defaultPath);
+        return DockerClientBuilder.getInstance(configBuilder.build()).build();
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystem.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystem.java
@@ -36,10 +36,16 @@ public enum OperatingSystem {
 
     final private String label;
     final private OperatingSystemFamily family;
+    final private OperatingSystemFamily default_family;
 
     private OperatingSystem(String label, OperatingSystemFamily family) {
         this.label = label;
         this.family = family;
+        if (label.startsWith("Windows")) {
+            this.default_family = OperatingSystemFamily.WINDOWS_NPIPE;
+        } else {
+            this.default_family = OperatingSystemFamily.UNIX;
+        }
     }
 
     static public OperatingSystem resolve(String osName) {
@@ -55,6 +61,10 @@ public enum OperatingSystem {
 
     public OperatingSystemFamily getFamily() {
         return family;
+    }
+
+    public OperatingSystemFamily getDefaultFamily() {
+        return default_family;
     }
 
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystem.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystem.java
@@ -7,7 +7,7 @@ import static org.arquillian.cube.docker.impl.util.OperatingSystemFamily.UNIX;
 import static org.arquillian.cube.docker.impl.util.OperatingSystemFamily.UNKNOWN;
 import static org.arquillian.cube.docker.impl.util.OperatingSystemFamily.WINDOWS;
 
-public enum OperatingSystem {
+public enum OperatingSystem implements OperatingSystemInterface {
     LINUX_OS("Linux", LINUX),
     MAC_OSX("Mac OS X", MAC),
     MAC_OS("Mac OS", MAC),

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemFamily.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemFamily.java
@@ -3,6 +3,7 @@ package org.arquillian.cube.docker.impl.util;
 public enum OperatingSystemFamily {
     LINUX("unix:///var/run/docker.sock", false),
     WINDOWS("https://" + AbstractCliInternetAddressResolver.DOCKERHOST_TAG + ":2376", true),
+    WINDOWS_NPIPE("npipe:////./pipe/docker_engine", false),
     UNIX("unix:///var/run/docker.sock", false),
     DIND("unix:///var/run/docker.sock", false),
     DEC_OS("unix:///var/run/docker.sock", false),

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemFamily.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemFamily.java
@@ -1,6 +1,6 @@
 package org.arquillian.cube.docker.impl.util;
 
-public enum OperatingSystemFamily {
+public enum OperatingSystemFamily implements OperatingSystemFamilyInterface {
     LINUX("unix:///var/run/docker.sock", false),
     WINDOWS("https://" + AbstractCliInternetAddressResolver.DOCKERHOST_TAG + ":2376", true),
     WINDOWS_NPIPE("npipe:////./pipe/docker_engine", false),

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemFamilyInterface.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemFamilyInterface.java
@@ -1,0 +1,7 @@
+package org.arquillian.cube.docker.impl.util;
+
+public interface OperatingSystemFamilyInterface {
+    String getServerUri();
+
+    boolean isBoot2Docker();
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemInterface.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemInterface.java
@@ -1,0 +1,9 @@
+package org.arquillian.cube.docker.impl.util;
+
+public interface OperatingSystemInterface {
+    String getLabel();
+
+    OperatingSystemFamilyInterface getFamily();
+
+    OperatingSystemFamilyInterface getDefaultFamily();
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystemResolver.java
@@ -4,7 +4,7 @@ public class OperatingSystemResolver {
 
     private String osNameProperty = System.getProperty("os.name");
 
-    public OperatingSystem currentOperatingSystem() {
+    public OperatingSystemInterface currentOperatingSystem() {
         return OperatingSystem.resolve(osNameProperty);
     }
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -61,6 +61,20 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         return new PathStringEndsWithMatcher(suffix);
     }
 
+    private void bindNonExistingDockerSocketOS() {
+        OperatingSystem os;
+
+        // invert OS selection to ensure we point to a non-existing
+        // socket
+        if (System.getProperty("os.name").startsWith("Windows")) {
+            os = OperatingSystem.MAC_OS;
+        } else {
+            os = OperatingSystem.WINDOWS_8;
+        }
+
+        bind(ApplicationScoped.class, OperatingSystem.class, os);
+    }
+
     @Override
     protected void addExtensions(List<Class<?>> extensions) {
         extensions.add(CubeDockerConfigurator.class);
@@ -186,7 +200,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(commandLineExecutor.execCommand("docker-machine"))
             .thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
 
-        bind(ApplicationScoped.class, OperatingSystem.class, OperatingSystem.MAC_OS);
+        bindNonExistingDockerSocketOS();
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.99.100:2376"));
@@ -215,6 +229,9 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         when(commandLineExecutor.execCommand("docker-machine"))
             .thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
 
+
+        bindNonExistingDockerSocketOS();
+
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.1:2376"));
     }
@@ -233,6 +250,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
 
         when(commandLineExecutor.execCommand("boot2docker", "ip")).thenReturn("192.168.0.1");
         when(commandLineExecutor.execCommand("docker-machine")).thenThrow(new IllegalArgumentException());
+
+        bindNonExistingDockerSocketOS();
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.0.1:2376"));

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -6,6 +6,8 @@ import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.OperatingSystemFamilyInterface;
+import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.arquillian.cube.spi.CubeConfiguration;
@@ -13,6 +15,7 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.StringEndsWith;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
+import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.test.AbstractManagerTestBase;
 import org.junit.Assume;
@@ -47,6 +50,10 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     @Mock
     ExtensionDef extensionDef;
     @Mock
+    OperatingSystemInterface operatingSystem;
+    @Mock
+    OperatingSystemFamilyInterface operatingSystemFamily;
+    @Mock
     Top top;
 
     private static Matcher<String> defaultDockerMachineCertPath() {
@@ -62,17 +69,11 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     }
 
     private void bindNonExistingDockerSocketOS() {
-        OperatingSystem os;
+        when(operatingSystem.getDefaultFamily()).thenReturn(operatingSystemFamily);
+        when(operatingSystem.getFamily()).thenReturn(OperatingSystemFamily.MAC);
+        when(operatingSystemFamily.getServerUri()).thenReturn("non/existing/path");
 
-        // invert OS selection to ensure we point to a non-existing
-        // socket
-        if (System.getProperty("os.name").startsWith("Windows")) {
-            os = OperatingSystem.MAC_OS;
-        } else {
-            os = OperatingSystem.WINDOWS_8;
-        }
-
-        bind(ApplicationScoped.class, OperatingSystem.class, os);
+        bind(ApplicationScoped.class, OperatingSystemInterface.class, operatingSystem);
     }
 
     @Override

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -1,16 +1,10 @@
 package org.arquillian.cube.docker.impl.client;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
 import org.apache.commons.lang.SystemUtils;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
+import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
@@ -28,16 +22,20 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import static org.hamcrest.CoreMatchers.containsString;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.CoreMatchers.not;
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.*;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CubeConfiguratorTest extends AbstractManagerTestBase {
@@ -75,6 +73,7 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         bind(ApplicationScoped.class, DockerMachine.class, new DockerMachine(commandLineExecutor));
         bind(ApplicationScoped.class, ArquillianDescriptor.class, arquillianDescriptor);
         bind(ApplicationScoped.class, Top.class, top);
+
         when(top.isSpinning()).thenReturn(false);
     }
 
@@ -186,6 +185,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         // Docker Machine is installed
         when(commandLineExecutor.execCommand("docker-machine"))
             .thenReturn("Usage: docker-machine [OPTIONS] COMMAND [arg...]");
+
+        bind(ApplicationScoped.class, OperatingSystem.class, OperatingSystem.MAC_OS);
 
         fire(new CubeConfiguration());
         assertThat(config, hasEntry(CubeDockerConfiguration.DOCKER_URI, "tcp://192.168.99.100:2376"));

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
@@ -1,26 +1,95 @@
 package org.arquillian.cube.docker.impl.client;
 
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
+import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystem;
+import org.arquillian.cube.docker.impl.util.OperatingSystemFamilyInterface;
+import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
 
+import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
 import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.when;
 
+@RunWith(MockitoJUnitRunner.class)
 public class CubeDockerConfigurationResolverTest {
+
+    @Mock
+    private static OperatingSystemInterface operatingSystemInterface;
+
+    @Mock
+    private static OperatingSystemFamilyInterface defaultOperatingSystemFamilyInterface;
+
+    @Mock
+    private static CommandLineExecutor boot2dockerCommandLineExecutor;
+
+    @Test
+    public void shouldDetectsValidDockerDefault() throws Exception {
+
+        CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
+            new DockerMachine(null),
+            new Boot2Docker(null),
+            operatingSystemInterface);
+        URL sockURL = this.getClass().getClassLoader().getResource("docker.sock");
+
+        String sockUri = "unix://" + sockURL.getPath();
+        when(defaultOperatingSystemFamilyInterface.getServerUri()).thenReturn(sockUri);
+        when(operatingSystemInterface.getDefaultFamily()).thenReturn(defaultOperatingSystemFamilyInterface);
+        when(operatingSystemInterface.getFamily()).thenReturn(OperatingSystem.MAC_OSX.getFamily());
+
+        Map<String, String> config = new HashMap<>();
+
+        Map<String, String> resolvedConfig = resolver.resolve(config);
+
+        assertThat(Boolean.valueOf(resolvedConfig.get(CubeDockerConfiguration.TLS_VERIFY)), is(false));
+        assertThat(resolvedConfig.get(CubeDockerConfiguration.CERT_PATH), is(nullValue()));
+        assertThat(resolvedConfig.get(CubeDockerConfiguration.DOCKER_URI), is(sockUri));
+    }
+
+    @Test
+    public void shouldSkipsInvalidDockerDefault() throws Exception {
+
+        CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
+            new DockerMachine(null),
+            new Boot2Docker(boot2dockerCommandLineExecutor),
+            operatingSystemInterface);
+        when(boot2dockerCommandLineExecutor.execCommand(Matchers.<String>anyVararg())).thenReturn("127.0.0.1");
+
+        String sockUri = "unix:///a/path-that/does/not/exist";
+        when(defaultOperatingSystemFamilyInterface.getServerUri()).thenReturn(sockUri);
+        when(operatingSystemInterface.getDefaultFamily()).thenReturn(defaultOperatingSystemFamilyInterface);
+        when(operatingSystemInterface.getFamily()).thenReturn(OperatingSystem.MAC_OSX.getFamily());
+
+        Map<String, String> config = new HashMap<>();
+
+        Map<String, String> resolvedConfig = resolver.resolve(config);
+
+        assertThat(Boolean.valueOf(resolvedConfig.get(CubeDockerConfiguration.TLS_VERIFY)), is(true));
+        assertThat(resolvedConfig.get(CubeDockerConfiguration.DOCKER_URI), is("tcp://127.0.0.1:2376"));
+    }
 
     @Test
     public void shouldNotSetTlsVerifyForTcpSchemeOnOSX() {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(null),
             new Boot2Docker(null),
-            OperatingSystem.MAC_OSX);
+            operatingSystemInterface);
+
+        String sockUri = "unix:///a/path-that/does/not/exist";
+        when(defaultOperatingSystemFamilyInterface.getServerUri()).thenReturn(sockUri);
+        when(operatingSystemInterface.getDefaultFamily()).thenReturn(defaultOperatingSystemFamilyInterface);
+        when(operatingSystemInterface.getFamily()).thenReturn(OperatingSystem.MAC_OSX.getFamily());
 
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://localhost:2376");
@@ -36,7 +105,12 @@ public class CubeDockerConfigurationResolverTest {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(null),
             new Boot2Docker(null),
-            OperatingSystem.LINUX_OS);
+            operatingSystemInterface);
+
+        String sockUri = "unix:///a/path-that/does/not/exist";
+        when(defaultOperatingSystemFamilyInterface.getServerUri()).thenReturn(sockUri);
+        when(operatingSystemInterface.getDefaultFamily()).thenReturn(defaultOperatingSystemFamilyInterface);
+        when(operatingSystemInterface.getFamily()).thenReturn(OperatingSystem.LINUX_OS.getFamily());
 
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://localhost:2376");

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
@@ -55,7 +55,7 @@ public class CubeDockerConfigurationResolverTest {
     private static Info info;
 
     public DefaultDocker mockDefaultDocker() {
-        when(defaultDocker.GetDefaultDockerClient(anyString())).thenReturn(dockerClient);
+        when(defaultDocker.getDefaultDockerClient(anyString())).thenReturn(dockerClient);
         when(dockerClient.infoCmd()).thenReturn(infoCmd);
         when(infoCmd.exec()).thenReturn(info);
         return defaultDocker;

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.docker.impl.client;
 
-import java.util.HashMap;
-import java.util.Map;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
-import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.Top;
 import org.junit.Test;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
@@ -19,7 +20,7 @@ public class CubeDockerConfigurationResolverTest {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(null),
             new Boot2Docker(null),
-            OperatingSystemFamily.MAC);
+            OperatingSystem.MAC_OSX);
 
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://localhost:2376");
@@ -35,7 +36,7 @@ public class CubeDockerConfigurationResolverTest {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(null),
             new Boot2Docker(null),
-            OperatingSystemFamily.LINUX);
+            OperatingSystem.LINUX_OS);
 
         Map<String, String> config = new HashMap<>();
         config.put(CubeDockerConfiguration.DOCKER_URI, "tcp://localhost:2376");

--- a/docker/docker/src/test/resources/docker.sock
+++ b/docker/docker/src/test/resources/docker.sock
@@ -1,0 +1,1 @@
+.placeHolder

--- a/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/DockerClientInitializer.java
+++ b/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/DockerClientInitializer.java
@@ -5,6 +5,7 @@ import org.arquillian.cube.docker.impl.client.CubeDockerConfigurationResolver;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
+import org.arquillian.cube.docker.impl.util.DefaultDocker;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
@@ -27,6 +28,7 @@ public class DockerClientInitializer {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(new CommandLineExecutor()),
             new Boot2Docker(new CommandLineExecutor()),
+            new DefaultDocker(),
             new OperatingSystemResolver().currentOperatingSystem());
 
         final Map<String, String> config = resolver.resolve(new HashMap<>());

--- a/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/DockerClientInitializer.java
+++ b/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/DockerClientInitializer.java
@@ -27,7 +27,7 @@ public class DockerClientInitializer {
         CubeDockerConfigurationResolver resolver = new CubeDockerConfigurationResolver(new Top(),
             new DockerMachine(new CommandLineExecutor()),
             new Boot2Docker(new CommandLineExecutor()),
-            new OperatingSystemResolver().currentOperatingSystem().getFamily());
+            new OperatingSystemResolver().currentOperatingSystem());
 
         final Map<String, String> config = resolver.resolve(new HashMap<>());
 

--- a/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/utils/NumberConversionTest.java
+++ b/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/utils/NumberConversionTest.java
@@ -1,6 +1,9 @@
 package org.arquillian.cube.docker.impl.client.utils;
 
+import org.junit.Before;
 import org.junit.Test;
+
+import java.util.Locale;
 
 import static org.arquillian.cube.docker.impl.client.utils.NumberConversion.convertToLong;
 import static org.arquillian.cube.docker.impl.client.utils.NumberConversion.humanReadableByteCount;
@@ -8,6 +11,11 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertThat;
 
 public class NumberConversionTest {
+
+    @Before
+    public void set_locale(){
+        Locale.setDefault(Locale.ENGLISH);
+    }
 
     private static final Long TEN_MEGABYTES = 9999800L;
 


### PR DESCRIPTION
As discussed in #883, here is an implementation to consider the default docker configuration before running `docker-machine` or `boot2docker`

Fixes #883
