### PR TITLE
chore #899: updates kubernetes client version to 3.1.5 from 3.1.0.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
     <version.junit>4.12</version.junit>
     <version.hamcrest>1.3</version.hamcrest>
     <version.docker-java>3.0.14</version.docker-java>
-    <version.kubernetes_client>3.1.0</version.kubernetes_client>
+    <version.kubernetes_client>3.1.5</version.kubernetes_client>
     <version.snakeyaml>1.18</version.snakeyaml>
     <version.shrinkwrap_resolver>3.0.0-alpha-4</version.shrinkwrap_resolver>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>


### PR DESCRIPTION
#### Short description of what this resolves:
Upgrades to Kubernetes Client version 3.1.5 from 3.1.0 due to a potential bug, [fabric8io/kubernetes-client#918](https://github.com/fabric8io/kubernetes-client/issues/918) in the older version

Fixes #899 
