### PR TITLE
fix(test): requires openshift for graphene integration

### DIFF
--- a/openshift/ftest-openshift-graphene/src/test/java/org/arquillian/cube/openshift/ftest/TodoBrowserTest.java
+++ b/openshift/ftest-openshift-graphene/src/test/java/org/arquillian/cube/openshift/ftest/TodoBrowserTest.java
@@ -1,13 +1,15 @@
 package org.arquillian.cube.openshift.ftest;
 
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.drone.api.annotation.Drone;
 import org.jboss.arquillian.graphene.page.InitialPage;
-import org.jboss.arquillian.junit.Arquillian;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.openqa.selenium.WebDriver;
 
-@RunWith(Arquillian.class)
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
 public class TodoBrowserTest {
 
     @Drone


### PR DESCRIPTION
As this test assumes OpenShift to be available we should require it explicitly 