### PR TITLE
Adds check for route readiness for openshift-graphene integration.

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -9,10 +9,9 @@ import io.fabric8.openshift.api.model.v3_1.DeploymentConfig;
 import io.fabric8.openshift.api.model.v3_1.Route;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
-import java.io.FileInputStream;
+
 import java.io.IOException;
 import java.io.InputStream;
-import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Files;
@@ -31,6 +30,7 @@ import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
+import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
 import static org.awaitility.Awaitility.await;
 
 /**
@@ -369,35 +369,7 @@ public class OpenShiftAssistant {
      *                    If not set, then only 200 status code is used.
      */
     public void awaitUrl(URL routeUrl, int... statusCodes) {
-        await().atMost(5, TimeUnit.MINUTES).until(() -> tryConnect(routeUrl, statusCodes));
-    }
-
-    private boolean tryConnect(URL routeUrl, int[] statusCodes) {
-        if (statusCodes.length == 0) {
-            statusCodes = new int[] { 200 };
-        }
-
-        HttpURLConnection urlConnection = null;
-        try {
-            urlConnection = (HttpURLConnection) routeUrl.openConnection();
-            urlConnection.setConnectTimeout(1000);
-            urlConnection.setReadTimeout(1000);
-            urlConnection.connect();
-            int connectionResponseCode = urlConnection.getResponseCode();
-            for (int expectedStatusCode : statusCodes) {
-                if (expectedStatusCode == connectionResponseCode) {
-                    return true;
-                }
-            }
-        } catch (Exception e) {
-            // retry
-        } finally {
-            if (urlConnection != null) {
-                urlConnection.disconnect();
-            }
-        }
-
-        return false;
+        awaitRoute(routeUrl, statusCodes);
     }
 
     /**

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/graphene/location/OpenshiftCustomizableURLResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/graphene/location/OpenshiftCustomizableURLResourceProvider.java
@@ -1,9 +1,9 @@
 package org.arquillian.cube.openshift.impl.graphene.location;
 
 import io.fabric8.openshift.api.model.v3_1.Route;
-import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
@@ -14,6 +14,8 @@ import java.lang.annotation.Annotation;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
+
+import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
 
 public class OpenshiftCustomizableURLResourceProvider implements ResourceProvider {
 
@@ -34,7 +36,9 @@ public class OpenshiftCustomizableURLResourceProvider implements ResourceProvide
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
         try {
-            return resolveUrl();
+            final URL routeUrl = resolveUrl();
+            awaitRoute(routeUrl);
+            return routeUrl;
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(e);
         }


### PR DESCRIPTION
#### Short description of what this resolves:

Adds `Await Route` validation check to ensure readiness of the route before execution of the Graphene Integration Tests which might otherwise fail due to not ready state of the route. 

#### Changes proposed in this pull request:

- Abstracts Await Route Logic to ResourceUtil class. 
- Refactors awaitRoute for RouteUrlEnrichers and OpenshiftAssistant classes.
- Adds await route for openshift graphene integration.


Fixes #911 
