### PR TITLE
fix(#919): Adds readyness probe for k8s logs ftest

### DIFF
--- a/kubernetes/ftest-kubernetes-logs/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes-logs/src/test/resources/kubernetes.json
@@ -14,7 +14,14 @@
                         "image": "busybox",
                         "name": "only-container",
                         "command": ["/bin/sh"],
-                        "args": ["-c", "while true; do echo only-one; sleep 1; done"]
+                        "args": ["-c", "while true; do  sleep 1; file=\"/tmp/healthy\"; if [[ ! -f $file ]]; then touch $file; fi; echo only-one; done"],
+                        "readinessProbe": {
+                            "exec": {
+                                "command": ["cat", "/tmp/healthy"]
+                            },
+                            "initialDelaySeconds": 2,
+                            "periodSeconds": 2
+                        }
                     }
                 ]
             }
@@ -32,13 +39,27 @@
                         "image": "busybox",
                         "name": "first-container",
                         "command": ["/bin/sh"],
-                        "args": ["-c", "while true; do echo first; sleep 1; done"]
+                        "args": ["-c", "while true; do  sleep 1; file=\"/tmp/healthy\"; if [[ ! -f $file ]]; then touch $file; fi; echo first; done"],
+                        "readinessProbe": {
+                              "exec": {
+                                "command": ["cat", "/tmp/healthy"]
+                              },
+                              "initialDelaySeconds": 2,
+                              "periodSeconds": 2
+                        }
                     },
                     {
                         "image": "busybox",
                         "name": "second-container",
                         "command": ["/bin/sh"],
-                        "args": ["-c", "while true; do echo second; sleep 1; done"]
+                        "args": ["-c", "while true; do  sleep 1; file=\"/tmp/healthy\"; if [[ ! -f $file ]]; then touch $file; fi; echo second; done"],
+                        "readinessProbe": {
+                            "exec": {
+                              "command": ["cat", "/tmp/healthy"]
+                            },
+                            "initialDelaySeconds": 2,
+                            "periodSeconds": 2
+                        }
                     }
                 ]
             }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -274,8 +274,9 @@ public class SessionManager implements SessionCreatedListener {
     }
 
     private void setupConsoleListener() {
-        if (!configuration.isLogCopyEnabled())
+        if (!configuration.isLogCopyEnabled()) {
             return;
+        }
 
         logPath = configuration.getLogPath();
         if (Strings.isNullOrEmpty(logPath))
@@ -350,8 +351,9 @@ public class SessionManager implements SessionCreatedListener {
     }
 
     private void setupEventListener() {
-        if (!configuration.isLogCopyEnabled())
+        if (!configuration.isLogCopyEnabled()) {
             return;
+        }
 
 
         final Watcher<Event> watcher = new Watcher<Event>() {


### PR DESCRIPTION

#### Short description of what this resolves:
Fixes intermittent failing ftest-kubernetes-logs

#### Changes proposed in this pull request:

- Adds readynessprode for pod container



Fixes #919 
