### PR TITLE
 feat#894: Creates RestAssured integration with OpenShift routes.

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -648,9 +648,7 @@ treated as is. For example:
 [source, xml]
 .arquillian.xml
 ----
-<extension qualifier="restassured">
-    <property name="baseUri">http://hello-world</property> <!1>
-</extension>
+include::../openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml[tag=restassured_configuration]
 ----
 
 As shown in the above snippet example (1), this integration will try to find an OpenShift route with name hello-world
@@ -681,22 +679,7 @@ to write your Arquillian Cube test as :
 [source, java]
 .PingPongTest.java
 ----
-@RunWith(ArquillianConditionalRunner.class)
-@RequiresOpenshift
-public class PingPongTest {
-
-    @ArquillianResource
-    RequestSpecBuilder requestSpecBuilder;
-
-    @Test
-    public void test_default_endpoint() {
-        given(requestSpecBuilder.build())
-            .when().get()
-            .then()
-            .statusCode(200)
-            .body(containsString("Hello OpenShift!"));
-    }
-}
+include::../openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/PingPongTest.java[tag=openshift_restassured_example]
 ----
 
 Notice that no _ip_ nor _port_ configuration are required since everything is managed and configured by Cube.

--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -634,6 +634,76 @@ https://github.com/arquillian/arquillian-cube/tree/master/openshift/ftest-opensh
 
 Also, you can learn more about Graphene at http://arquillian.org/guides/functional_testing_using_graphene/ .
 
+=== OpenShift Integration with Rest-Assured
+
+Integration with Rest-Assured allows for auto-resolution of the base URI of the application deployed within the
+OpenShift cluster by using `OpenShift Route` definition for configuring Rest-Assured.
+
+==== Configuration
+
+You can configure a specific base URI using the `baseUri` property from restassured configuration. In this case, the
+hostname is going to be resolved as OpenShift route name, and if there is no route with that name, then the base URI is
+treated as is. For example:
+
+[source, xml]
+.arquillian.xml
+----
+<extension qualifier="restassured">
+    <property name="baseUri">http://hello-world</property> <!1>
+</extension>
+----
+
+As shown in the above snippet example (1), this integration will try to find an OpenShift route with name hello-world
+and inject its IP. If there is no route with that name, then the base URI field is considered to be the final base URI.
+
+If however, no specific base URI is configured, a default route from the definition is used for rest-assured
+configuration.
+
+==== Dependency
+
+To use Arquillian Cube OpenShift RestAssured integration you only need to add as dependency.
+
+[source, xml]
+.pom.xml
+----
+<dependency>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-openshift-restassured</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+==== Example
+
+After setting the dependencies for OpenShift and OpenShift-RestAssured and configuring the extensions, you are all set
+to write your Arquillian Cube test as :
+
+[source, java]
+.PingPongTest.java
+----
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class PingPongTest {
+
+    @ArquillianResource
+    RequestSpecBuilder requestSpecBuilder;
+
+    @Test
+    public void test_default_endpoint() {
+        given(requestSpecBuilder.build())
+            .when().get()
+            .then()
+            .statusCode(200)
+            .body(containsString("Hello OpenShift!"));
+    }
+}
+----
+
+Notice that no _ip_ nor _port_ configuration are required since everything is managed and configured by Cube.
+
+You can see the full example using OpenShift and Rest-Assured at
+https://github.com/arquillian/arquillian-cube/tree/master/openshift/ftest-openshift-restassured .
+
 === Arquillian Kubernetes and OpenShift Recipes
 
 To help you get started with ease, listed below are specially curated examples for Kubernetes and OpenShift Extensions.

--- a/openshift/ftest-openshift-graphene/src/test/java/org/arquillian/cube/openshift/ftest/TodoBrowserTest.java
+++ b/openshift/ftest-openshift-graphene/src/test/java/org/arquillian/cube/openshift/ftest/TodoBrowserTest.java
@@ -16,7 +16,7 @@ public class TodoBrowserTest {
     WebDriver webDriver;
 
     @Test
-    public void shouldShowHelloWorld(@InitialPage HomePage homePage) {
+    public void shouldShowWelcomePageMessage(@InitialPage HomePage homePage) {
         homePage.assertOnWelcomePage();
     }
 }

--- a/openshift/ftest-openshift-restassured/pom.xml
+++ b/openshift/ftest-openshift-restassured/pom.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-cube-openshift-parent</artifactId>
+    <groupId>org.arquillian.cube</groupId>
+    <version>1.11.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-cube-openshift-ftest-restassured</artifactId>
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-requirement</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift-restassured</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/HelloOpenShiftRestAssuredTest.java
+++ b/openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/HelloOpenShiftRestAssuredTest.java
@@ -13,7 +13,7 @@ import static org.hamcrest.CoreMatchers.containsString;
 // tag::openshift_restassured_example[]
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
-public class PingPongTest {
+public class HelloOpenShiftRestAssuredTest {
 
     @ArquillianResource
     RequestSpecBuilder requestSpecBuilder;

--- a/openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/PingPongTest.java
+++ b/openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/PingPongTest.java
@@ -1,0 +1,28 @@
+package org.arquillian.openshift.restassured;
+
+import io.restassured.builder.RequestSpecBuilder;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import static io.restassured.RestAssured.given;
+import static org.hamcrest.CoreMatchers.containsString;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class PingPongTest {
+
+    @ArquillianResource
+    RequestSpecBuilder requestSpecBuilder;
+
+    @Test
+    public void testGreetingEndpoint() {
+        given(requestSpecBuilder.build())
+            .when().get()
+            .then()
+            .statusCode(200)
+            .body(containsString("Hello OpenShift!"));
+    }
+}

--- a/openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/PingPongTest.java
+++ b/openshift/ftest-openshift-restassured/src/test/java/org/arquillian/openshift/restassured/PingPongTest.java
@@ -10,6 +10,7 @@ import org.junit.runner.RunWith;
 import static io.restassured.RestAssured.given;
 import static org.hamcrest.CoreMatchers.containsString;
 
+// tag::openshift_restassured_example[]
 @RunWith(ArquillianConditionalRunner.class)
 @RequiresOpenshift
 public class PingPongTest {
@@ -26,3 +27,4 @@ public class PingPongTest {
             .body(containsString("Hello OpenShift!"));
     }
 }
+// end::openshift_restassured_example[]

--- a/openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml
+++ b/openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml
@@ -6,8 +6,9 @@
   <extension qualifier="openshift">
   </extension>
 
+  <!-- tag::restassured_configuration[] -->
   <extension qualifier="restassured">
-    <property name="baseUri">http://hello-world</property>
+    <property name="baseUri">http://hello-world</property>   <!--1-->
   </extension>
-
+  <!-- end::restassured_configuration[] -->
 </arquillian>

--- a/openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml
+++ b/openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml
@@ -8,7 +8,7 @@
 
   <!-- tag::restassured_configuration[] -->
   <extension qualifier="restassured">
-    <property name="baseUri">http://hello-world</property>   <!--1-->
+    <property name="baseUri">http://hello-openshift</property>   <!--1-->
   </extension>
   <!-- end::restassured_configuration[] -->
 </arquillian>

--- a/openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml
+++ b/openshift/ftest-openshift-restassured/src/test/resources/arquillian.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<arquillian xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xmlns="http://jboss.org/schema/arquillian"
+  xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
+
+  <extension qualifier="openshift">
+  </extension>
+
+  <extension qualifier="restassured">
+    <property name="baseUri">http://hello-world</property>
+  </extension>
+
+</arquillian>

--- a/openshift/ftest-openshift-restassured/src/test/resources/openshift.json
+++ b/openshift/ftest-openshift-restassured/src/test/resources/openshift.json
@@ -1,0 +1,75 @@
+{
+  "apiVersion" : "v1",
+  "kind" : "List",
+  "items" : [ {
+    "apiVersion" : "v1",
+    "kind" : "Service",
+    "metadata" : {
+      "name" : "hello-world"
+    },
+    "spec" : {
+      "ports" : [ {
+        "port" : 8080,
+        "protocol" : "TCP",
+        "targetPort" : 8080
+      } ],
+      "selector" : {
+        "app" : "hello-world"
+      }
+    }
+  }, {
+    "apiVersion" : "extensions/v1beta1",
+    "kind" : "Deployment",
+    "metadata" : {
+      "name" : "hello-world"
+    },
+    "spec" : {
+      "replicas" : 1,
+      "selector" : {
+        "matchLabels": {
+          "app": "hello-world"
+        }
+      },
+      "template" : {
+        "metadata" : {
+          "labels" : {
+            "app" : "hello-world"
+          }
+        },
+        "spec" : {
+          "containers" : [ {
+            "image" : "openshift/hello-openshift:v3.6.0",
+            "name" : "hello-world-container",
+            "ports" : [ {
+              "name" : "http",
+              "protocol" : "TCP",
+              "containerPort" : 8080
+            } ],
+            "readinessProbe": {
+              "httpGet": {
+                "path": "/",
+                "port": 8080
+              },
+              "initialDelaySeconds": 1
+            }
+          } ]
+        }
+      }
+    }
+  }, {
+      "apiVersion": "v1",
+      "kind": "Route",
+      "metadata": {
+        "name": "hello-world"
+      },
+      "spec": {
+        "port": {
+          "targetPort": 8080
+        },
+        "to": {
+          "kind": "Service",
+          "name": "hello-world"
+        }
+      }
+    }]
+}

--- a/openshift/ftest-openshift-restassured/src/test/resources/openshift.json
+++ b/openshift/ftest-openshift-restassured/src/test/resources/openshift.json
@@ -5,7 +5,7 @@
     "apiVersion" : "v1",
     "kind" : "Service",
     "metadata" : {
-      "name" : "hello-world"
+      "name" : "hello-openshift"
     },
     "spec" : {
       "ports" : [ {
@@ -14,32 +14,32 @@
         "targetPort" : 8080
       } ],
       "selector" : {
-        "app" : "hello-world"
+        "app" : "hello-openshift"
       }
     }
   }, {
     "apiVersion" : "extensions/v1beta1",
     "kind" : "Deployment",
     "metadata" : {
-      "name" : "hello-world"
+      "name" : "hello-openshift"
     },
     "spec" : {
       "replicas" : 1,
       "selector" : {
         "matchLabels": {
-          "app": "hello-world"
+          "app": "hello-openshift"
         }
       },
       "template" : {
         "metadata" : {
           "labels" : {
-            "app" : "hello-world"
+            "app" : "hello-openshift"
           }
         },
         "spec" : {
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
-            "name" : "hello-world-container",
+            "name" : "hello-openshift-container",
             "ports" : [ {
               "name" : "http",
               "protocol" : "TCP",
@@ -60,7 +60,7 @@
       "apiVersion": "v1",
       "kind": "Route",
       "metadata": {
-        "name": "hello-world"
+        "name": "hello-openshift"
       },
       "spec": {
         "port": {
@@ -68,7 +68,7 @@
         },
         "to": {
           "kind": "Service",
-          "name": "hello-world"
+          "name": "hello-openshift"
         }
       }
     }]

--- a/openshift/openshift-restassured/pom.xml
+++ b/openshift/openshift-restassured/pom.xml
@@ -45,7 +45,6 @@
     <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-openshift-api</artifactId>
-      <version>${project.version}</version>
     </dependency>
     <dependency>
       <groupId>org.jboss.arquillian.container</groupId>

--- a/openshift/openshift-restassured/pom.xml
+++ b/openshift/openshift-restassured/pom.xml
@@ -1,0 +1,67 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-openshift-parent</artifactId>
+    <version>1.11.1-SNAPSHOT</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <name>Arquillian Cube OpenShift RestAssured Integration</name>
+  <artifactId>arquillian-cube-openshift-restassured</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.test</groupId>
+      <artifactId>arquillian-test-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.config</groupId>
+      <artifactId>arquillian-config-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.core</groupId>
+      <artifactId>arquillian-core-spi</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift-api</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-test-impl-base
+      </artifactId> <!-- required to inherit logic of OperatesOnDeploymentAwareProvider -->
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.rest-assured</groupId>
+      <artifactId>rest-assured</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/AuthenticationSchemeFactory.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/AuthenticationSchemeFactory.java
@@ -7,10 +7,6 @@ import java.util.Arrays;
 
 public class AuthenticationSchemeFactory {
 
-    private AuthenticationSchemeFactory() {
-        super();
-    }
-
     public static AuthenticationScheme create(String attribute) {
         String[] parameters = attribute.split(":");
 

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/AuthenticationSchemeFactory.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/AuthenticationSchemeFactory.java
@@ -1,0 +1,78 @@
+package org.arquillian.cube.openshift.restassured;
+
+import io.restassured.RestAssured;
+import io.restassured.authentication.AuthenticationScheme;
+
+import java.util.Arrays;
+
+public class AuthenticationSchemeFactory {
+
+    private AuthenticationSchemeFactory() {
+        super();
+    }
+
+    public static AuthenticationScheme create(String attribute) {
+        String[] parameters = attribute.split(":");
+
+        if (parameters.length < 2) {
+            throw new IllegalArgumentException(
+                String.format("Authentication scheme %s doesn't follow the standard format <protocol>:(<value>[:])+"));
+        }
+
+        switch (parameters[0]) {
+            case "basic": {
+                validateEntry(parameters, 3);
+                return RestAssured.basic(parameters[1], parameters[2]);
+            }
+            case "form": {
+                validateEntry(parameters, 3);
+                return RestAssured.form(parameters[1], parameters[2]);
+            }
+            case "preemptive": {
+                validateEntry(parameters, 3);
+                return RestAssured.preemptive().basic(parameters[1], parameters[2]);
+            }
+            case "certificate": {
+                validateEntryBigger(parameters, 3);
+                final String[] url = Arrays.copyOfRange(parameters, 2, parameters.length - 1);
+                return RestAssured.certificate(join(url), parameters[parameters.length - 1]);
+            }
+            case "digest": {
+                validateEntry(parameters, 3);
+                return RestAssured.digest(parameters[1], parameters[2]);
+            }
+            case "oauth": {
+                validateEntry(parameters, 5);
+                return RestAssured.oauth(parameters[1], parameters[2], parameters[3], parameters[4]);
+            }
+            case "oauth2": {
+                validateEntry(parameters, 2);
+                return RestAssured.oauth2(parameters[1]);
+            }
+            default:
+                throw new IllegalArgumentException(String.format("Unrecognized protocol %s", parameters[0]));
+        }
+    }
+
+    private static String join(String[] elements) {
+        StringBuilder builder = new StringBuilder();
+        for (String s : elements) {
+            builder.append(s);
+        }
+        return builder.toString();
+    }
+
+    private static void validateEntryBigger(String[] parameters, int numberOfValid) {
+        if (parameters.length < numberOfValid) {
+            throw new IllegalArgumentException(
+                String.format("Invalid number of parameters for %s command.", Arrays.toString(parameters)));
+        }
+    }
+
+    private static void validateEntry(String[] parameters, int numberOfValid) {
+        if (parameters.length != numberOfValid) {
+            throw new IllegalArgumentException(
+                String.format("Invalid number of parameters for %s command.", Arrays.toString(parameters)));
+        }
+    }
+}

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RequestSpecBuilderResourceProvider.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RequestSpecBuilderResourceProvider.java
@@ -1,0 +1,115 @@
+package org.arquillian.cube.openshift.restassured;
+
+import io.fabric8.openshift.api.model.v3_1.Route;
+import io.restassured.builder.RequestSpecBuilder;
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Optional;
+
+public class RequestSpecBuilderResourceProvider implements ResourceProvider {
+
+    @Inject
+    private Instance<OpenShiftClient> clientInstance;
+
+    @Inject
+    private Instance<Configuration> configurationInstance;
+
+    @Inject
+    private Instance<RestAssuredConfiguration> restAssuredConfigurationInstance;
+
+    @Inject
+    private Instance<RequestSpecBuilder> requestSpecBuilderInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return RequestSpecBuilder.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        try {
+            final RestAssuredConfiguration restAssuredConfiguration = this.restAssuredConfigurationInstance.get();
+            final String baseUri = restAssuredConfiguration.getBaseUri();
+
+            return (baseUri != null && !baseUri.isEmpty()) ?
+                configureRequestSpecBuilder(getRoute(new URL(baseUri))) : configureRequestSpecBuilder(getRoute());
+
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private RequestSpecBuilder configureRequestSpecBuilder(URL route) {
+        final RequestSpecBuilder requestSpecBuilder = requestSpecBuilderInstance.get();
+        if (requestSpecBuilder == null) {
+            throw new IllegalStateException("RequestSpecBuilder was not found.");
+        }
+
+        requestSpecBuilder.setBaseUri(route.getProtocol() + "://" + route.getHost());
+        requestSpecBuilder.setPort(route.getPort());
+        requestSpecBuilder.setBasePath(route.getPath());
+
+        return requestSpecBuilder;
+    }
+
+    private URL getRoute(URL routeUrl) {
+        final CubeOpenShiftConfiguration config = getCubeOpenShiftConfiguration();
+        final OpenShiftClient client = clientInstance.get();
+
+        final String routeName = routeUrl.getHost();
+        Route route = client.getClient().routes().inNamespace(config.getNamespace()).withName(routeName).get();
+        if (route == null) {
+            return routeUrl;
+        }
+        return createUrlFromRoute(route);
+    }
+
+    private URL getRoute() {
+        final CubeOpenShiftConfiguration config = getCubeOpenShiftConfiguration();
+        final OpenShiftClient client = clientInstance.get();
+
+        Optional<Route> optionalRoute = client.getClient().routes().inNamespace(config.getNamespace())
+            .list().getItems()
+            .stream()
+            .findFirst();
+
+        return optionalRoute
+            .map(this::createUrlFromRoute)
+            .orElseThrow(() -> new NullPointerException("No route defined."));
+    }
+
+    private CubeOpenShiftConfiguration getCubeOpenShiftConfiguration() {
+        final CubeOpenShiftConfiguration config = (CubeOpenShiftConfiguration) configurationInstance.get();
+        if (config == null) {
+            throw new NullPointerException("CubeOpenShiftConfiguration is null.");
+        }
+        return config;
+    }
+
+    private URL createUrlFromRoute(Route route) {
+        try {
+            final String protocol = route.getSpec().getTls() == null ? "http" : "https";
+            final String path = route.getSpec().getPath() == null ? "" : route.getSpec().getPath();
+            return new URL(protocol, route.getSpec().getHost(), resolvePort(protocol), path);
+        } catch (MalformedURLException e) {
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private int resolvePort(String protocol) {
+        if ("http".equals(protocol)) {
+            return 80;
+        } else {
+            return 443;
+        }
+    }
+}

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RequestSpecBuilderResourceProvider.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RequestSpecBuilderResourceProvider.java
@@ -1,9 +1,8 @@
 package org.arquillian.cube.openshift.restassured;
 
-import io.fabric8.openshift.api.model.v3_1.Route;
 import io.restassured.builder.RequestSpecBuilder;
 import org.arquillian.cube.kubernetes.api.Configuration;
-import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.arquillian.cube.openshift.impl.client.OpenShiftRouteLocator;
 import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -13,7 +12,8 @@ import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 import java.lang.annotation.Annotation;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Optional;
+
+import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
 
 public class RequestSpecBuilderResourceProvider implements ResourceProvider {
 
@@ -37,12 +37,16 @@ public class RequestSpecBuilderResourceProvider implements ResourceProvider {
     @Override
     public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
         try {
+            final OpenShiftRouteLocator openShiftRouteLocator = new OpenShiftRouteLocator(clientInstance, configurationInstance);
+
             final RestAssuredConfiguration restAssuredConfiguration = this.restAssuredConfigurationInstance.get();
             final String baseUri = restAssuredConfiguration.getBaseUri();
 
-            return (baseUri != null && !baseUri.isEmpty()) ?
-                configureRequestSpecBuilder(getRoute(new URL(baseUri))) : configureRequestSpecBuilder(getRoute());
-
+            if (baseUri != null && !baseUri.isEmpty()) {
+                return configureRequestSpecBuilder(openShiftRouteLocator.getRoute(new URL(baseUri)));
+            } else {
+                return configureRequestSpecBuilder(openShiftRouteLocator.getRoute());
+            }
         } catch (MalformedURLException e) {
             throw new IllegalArgumentException(e);
         }
@@ -58,58 +62,7 @@ public class RequestSpecBuilderResourceProvider implements ResourceProvider {
         requestSpecBuilder.setPort(route.getPort());
         requestSpecBuilder.setBasePath(route.getPath());
 
+        awaitRoute(route);
         return requestSpecBuilder;
-    }
-
-    private URL getRoute(URL routeUrl) {
-        final CubeOpenShiftConfiguration config = getCubeOpenShiftConfiguration();
-        final OpenShiftClient client = clientInstance.get();
-
-        final String routeName = routeUrl.getHost();
-        Route route = client.getClient().routes().inNamespace(config.getNamespace()).withName(routeName).get();
-        if (route == null) {
-            return routeUrl;
-        }
-        return createUrlFromRoute(route);
-    }
-
-    private URL getRoute() {
-        final CubeOpenShiftConfiguration config = getCubeOpenShiftConfiguration();
-        final OpenShiftClient client = clientInstance.get();
-
-        Optional<Route> optionalRoute = client.getClient().routes().inNamespace(config.getNamespace())
-            .list().getItems()
-            .stream()
-            .findFirst();
-
-        return optionalRoute
-            .map(this::createUrlFromRoute)
-            .orElseThrow(() -> new NullPointerException("No route defined."));
-    }
-
-    private CubeOpenShiftConfiguration getCubeOpenShiftConfiguration() {
-        final CubeOpenShiftConfiguration config = (CubeOpenShiftConfiguration) configurationInstance.get();
-        if (config == null) {
-            throw new NullPointerException("CubeOpenShiftConfiguration is null.");
-        }
-        return config;
-    }
-
-    private URL createUrlFromRoute(Route route) {
-        try {
-            final String protocol = route.getSpec().getTls() == null ? "http" : "https";
-            final String path = route.getSpec().getPath() == null ? "" : route.getSpec().getPath();
-            return new URL(protocol, route.getSpec().getHost(), resolvePort(protocol), path);
-        } catch (MalformedURLException e) {
-            throw new IllegalStateException(e);
-        }
-    }
-
-    private int resolvePort(String protocol) {
-        if ("http".equals(protocol)) {
-            return 80;
-        } else {
-            return 443;
-        }
     }
 }

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredConfiguration.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredConfiguration.java
@@ -1,0 +1,119 @@
+package org.arquillian.cube.openshift.restassured;
+
+import io.restassured.authentication.AuthenticationScheme;
+
+import java.util.Map;
+
+public class RestAssuredConfiguration {
+
+    private static final String RELAXED_HTTPS_VALIDATION_ALL_PROTOCOLS = "";
+
+    private String baseUri;
+    private String schema = "http";
+    private int port = -1;
+    private String basePath;
+    private String rootPath;
+    private AuthenticationScheme authenticationScheme;
+    private String useRelaxedHttpsValidation;
+    private String[] exclusionContainers = new String[0];
+
+    public static RestAssuredConfiguration fromMap(final Map<String, String> conf) {
+        RestAssuredConfiguration restAssuredConfiguration = new RestAssuredConfiguration();
+
+        if (conf.containsKey("baseUri")) {
+            restAssuredConfiguration.baseUri = conf.get("baseUri");
+        }
+
+        if (conf.containsKey("port")) {
+            restAssuredConfiguration.port = Integer.parseInt(conf.get("port"));
+        }
+
+        if (conf.containsKey("basePath")) {
+            restAssuredConfiguration.basePath = conf.get("basePath");
+        }
+
+        if (conf.containsKey("rootPath")) {
+            restAssuredConfiguration.rootPath = conf.get("rootPath");
+        }
+
+        if (conf.containsKey("authenticationScheme")) {
+            restAssuredConfiguration.authenticationScheme =
+                AuthenticationSchemeFactory.create(conf.get("authenticationScheme"));
+        }
+
+        if (conf.containsKey("schema")) {
+            restAssuredConfiguration.schema = conf.get("schema");
+        }
+
+        if (conf.containsKey("exclusionContainers")) {
+            restAssuredConfiguration.exclusionContainers = conf.get("exclusionContainers").split(",");
+            for (int i = 0; i < restAssuredConfiguration.exclusionContainers.length; i++) {
+                restAssuredConfiguration.exclusionContainers[i] = restAssuredConfiguration.exclusionContainers[i].trim();
+            }
+        }
+
+        if (conf.containsKey("useRelaxedHttpsValidation")) {
+            final String useRelaxedHttpsValidation = conf.get("useRelaxedHttpsValidation");
+
+            if (useRelaxedHttpsValidation == null || useRelaxedHttpsValidation.isEmpty()) {
+                restAssuredConfiguration.useRelaxedHttpsValidation = RELAXED_HTTPS_VALIDATION_ALL_PROTOCOLS;
+            } else {
+                restAssuredConfiguration.useRelaxedHttpsValidation = useRelaxedHttpsValidation;
+            }
+        }
+
+        return restAssuredConfiguration;
+    }
+
+    public String getUseRelaxedHttpsValidation() {
+        return useRelaxedHttpsValidation;
+    }
+
+    public boolean isUseRelaxedHttpsValidationSet() {
+        return this.useRelaxedHttpsValidation != null;
+    }
+
+    public boolean isUseRelaxedHttpsValidationInAllProtocols() {
+        return RELAXED_HTTPS_VALIDATION_ALL_PROTOCOLS.equals(this.useRelaxedHttpsValidation);
+    }
+
+    public boolean isAuthenticationSchemeSet() {
+        return this.authenticationScheme != null;
+    }
+
+    public AuthenticationScheme getAuthenticationScheme() {
+        return authenticationScheme;
+    }
+
+    public boolean isPortSet() {
+        return port > -1;
+    }
+
+    public int getPort() {
+        return port;
+    }
+
+    public boolean isBasePathSet() {
+        return basePath != null && !basePath.isEmpty();
+    }
+
+    public String getBasePath() {
+        return basePath;
+    }
+
+    public boolean isBaseUriSet() {
+        return baseUri != null && !baseUri.isEmpty();
+    }
+
+    public String getBaseUri() {
+        return baseUri;
+    }
+
+    public String[] getExclusionContainers() {
+        return exclusionContainers;
+    }
+
+    public String getSchema() {
+        return schema;
+    }
+}

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredConfigurator.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredConfigurator.java
@@ -12,7 +12,8 @@ public class RestAssuredConfigurator {
     @ApplicationScoped
     InstanceProducer<RestAssuredConfiguration> restAssuredConfigurationInstanceProducer;
 
-    // Need to be executed after CubeOpenShiftConfiguration
+    // Need to be executed after CubeOpenShiftConfiguration, to take into account OpenShift Configuration parameters
+    // required for rest assured base URI configuration.
     public void configure(@Observes(precedence = -200) ArquillianDescriptor arquillianDescriptor) {
         restAssuredConfigurationInstanceProducer.set(
             RestAssuredConfiguration.fromMap(arquillianDescriptor

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredConfigurator.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredConfigurator.java
@@ -1,0 +1,22 @@
+package org.arquillian.cube.openshift.restassured;
+
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+public class RestAssuredConfigurator {
+
+    @Inject
+    @ApplicationScoped
+    InstanceProducer<RestAssuredConfiguration> restAssuredConfigurationInstanceProducer;
+
+    // Need to be executed after CubeOpenShiftConfiguration
+    public void configure(@Observes(precedence = -200) ArquillianDescriptor arquillianDescriptor) {
+        restAssuredConfigurationInstanceProducer.set(
+            RestAssuredConfiguration.fromMap(arquillianDescriptor
+                .extension("restassured")
+                .getExtensionProperties()));
+    }
+}

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredCustomizer.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredCustomizer.java
@@ -24,13 +24,6 @@ public class RestAssuredCustomizer {
     @ApplicationScoped
     InstanceProducer<RequestSpecBuilder> requestSpecBuilderInstanceProducer;
 
-    /**
-     * Method executed before starting a test.
-     * It is important to do it in this event because in case of incontainer tests or containerless,
-     * this is when the mapped container is started and you might need to inspect the automatic port binding.
-     * <p>
-     * Precedence is set to -100 to execute this after all sarting events.
-     */
     public void configure(@Observes RestAssuredConfiguration restAssuredConfiguration) {
 
         final CubeOpenShiftConfiguration openShiftConfiguration = (CubeOpenShiftConfiguration) configurationInstance.get();

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredCustomizer.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredCustomizer.java
@@ -1,0 +1,82 @@
+package org.arquillian.cube.openshift.restassured;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.api.annotation.Observes;
+import org.jboss.arquillian.core.api.event.ManagerStopping;
+
+
+/**
+ * Class that gets restassured configuration and configures the RestAssured instance accordantly
+ */
+public class RestAssuredCustomizer {
+
+    @Inject
+    private Instance<Configuration> configurationInstance;
+
+    @Inject
+    @ApplicationScoped
+    InstanceProducer<RequestSpecBuilder> requestSpecBuilderInstanceProducer;
+
+    /**
+     * Method executed before starting a test.
+     * It is important to do it in this event because in case of incontainer tests or containerless,
+     * this is when the mapped container is started and you might need to inspect the automatic port binding.
+     * <p>
+     * Precedence is set to -100 to execute this after all sarting events.
+     */
+    public void configure(@Observes RestAssuredConfiguration restAssuredConfiguration) {
+
+        final CubeOpenShiftConfiguration openShiftConfiguration = (CubeOpenShiftConfiguration) configurationInstance.get();
+
+        final RequestSpecBuilder requestSpecBuilder = new RequestSpecBuilder();
+
+        configureRequestSpecBuilder(restAssuredConfiguration, openShiftConfiguration, requestSpecBuilder);
+
+        requestSpecBuilderInstanceProducer.set(requestSpecBuilder);
+    }
+
+    void configureRequestSpecBuilder(@Observes RestAssuredConfiguration restAssuredConfiguration, CubeOpenShiftConfiguration openShiftConfiguration, RequestSpecBuilder requestSpecBuilder) {
+        if (restAssuredConfiguration.isBaseUriSet()) {
+            requestSpecBuilder.setBaseUri(restAssuredConfiguration.getBaseUri());
+        } else {
+            requestSpecBuilder.setBaseUri(
+                restAssuredConfiguration.getSchema() + "://" + openShiftConfiguration.getMasterUrl());
+        }
+
+        if (restAssuredConfiguration.isPortSet()) {
+            requestSpecBuilder.setPort(restAssuredConfiguration.getPort());
+        } else {
+            requestSpecBuilder.setPort(openShiftConfiguration.getOpenshiftRouterHttpPort());
+        }
+
+        if (restAssuredConfiguration.isBasePathSet()) {
+            requestSpecBuilder.setBasePath(restAssuredConfiguration.getBasePath());
+        }
+
+        if (restAssuredConfiguration.isAuthenticationSchemeSet()) {
+            requestSpecBuilder.setAuth(restAssuredConfiguration.getAuthenticationScheme());
+        }
+
+        if (restAssuredConfiguration.isUseRelaxedHttpsValidationSet()) {
+            if (restAssuredConfiguration.isUseRelaxedHttpsValidationInAllProtocols()) {
+                requestSpecBuilder.setRelaxedHTTPSValidation();
+            } else {
+                requestSpecBuilder.setRelaxedHTTPSValidation(restAssuredConfiguration.getUseRelaxedHttpsValidation());
+            }
+        }
+    }
+
+    /**
+     * Resets RestAssured configuration values to default.
+     */
+    public void resetRestAssuredConfiguration(@Observes ManagerStopping event) {
+        RestAssured.reset();
+    }
+}

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredCustomizer.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredCustomizer.java
@@ -13,7 +13,7 @@ import org.jboss.arquillian.core.api.event.ManagerStopping;
 
 
 /**
- * Class that gets restassured configuration and configures the RestAssured instance accordantly
+ * Class that gets restassured configuration and configures the RestAssured instance accordingly.
  */
 public class RestAssuredCustomizer {
 

--- a/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredExtension.java
+++ b/openshift/openshift-restassured/src/main/java/org/arquillian/cube/openshift/restassured/RestAssuredExtension.java
@@ -1,0 +1,14 @@
+package org.arquillian.cube.openshift.restassured;
+
+import org.jboss.arquillian.core.spi.LoadableExtension;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+public class RestAssuredExtension implements LoadableExtension {
+
+    @Override
+    public void register(ExtensionBuilder builder) {
+        builder.observer(RestAssuredConfigurator.class)
+            .observer(RestAssuredCustomizer.class)
+            .service(ResourceProvider.class, RequestSpecBuilderResourceProvider.class);
+    }
+}

--- a/openshift/openshift-restassured/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
+++ b/openshift/openshift-restassured/src/main/resources/META-INF/services/org.jboss.arquillian.core.spi.LoadableExtension
@@ -1,0 +1,1 @@
+org.arquillian.cube.openshift.restassured.RestAssuredExtension

--- a/openshift/openshift-restassured/src/test/java/org/arquillian/cube/openshift/restassured/AuthenticateSchemeFactoryTest.java
+++ b/openshift/openshift-restassured/src/test/java/org/arquillian/cube/openshift/restassured/AuthenticateSchemeFactoryTest.java
@@ -1,0 +1,85 @@
+package org.arquillian.cube.openshift.restassured;
+
+import io.restassured.authentication.AuthenticationScheme;
+import io.restassured.authentication.BasicAuthScheme;
+import io.restassured.authentication.CertAuthScheme;
+import io.restassured.authentication.FormAuthScheme;
+import io.restassured.authentication.OAuthScheme;
+import io.restassured.authentication.PreemptiveBasicAuthScheme;
+import io.restassured.authentication.PreemptiveOAuth2HeaderScheme;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class AuthenticateSchemeFactoryTest {
+
+    @Test
+    public void should_create_basic_auth() {
+        final AuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.create("basic:username:password");
+        assertThat(authenticationScheme).isInstanceOf(BasicAuthScheme.class);
+        BasicAuthScheme basicAuthScheme = (BasicAuthScheme) authenticationScheme;
+        assertThat(basicAuthScheme.getUserName()).isEqualTo("username");
+        assertThat(basicAuthScheme.getPassword()).isEqualTo("password");
+    }
+
+    @Test
+    public void should_create_form_auth() {
+        final AuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.create("form:username:password");
+        assertThat(authenticationScheme).isInstanceOf(FormAuthScheme.class);
+        FormAuthScheme authScheme = (FormAuthScheme) authenticationScheme;
+        assertThat(authScheme.getUserName()).isEqualTo("username");
+        assertThat(authScheme.getPassword()).isEqualTo("password");
+    }
+
+    @Test
+    public void should_create_preemptive_auth() {
+        final AuthenticationScheme authenticationScheme =
+            AuthenticationSchemeFactory.create("preemptive:username:password");
+        assertThat(authenticationScheme).isInstanceOf(PreemptiveBasicAuthScheme.class);
+        PreemptiveBasicAuthScheme authScheme = (PreemptiveBasicAuthScheme) authenticationScheme;
+        assertThat(authScheme.getUserName()).isEqualTo("username");
+        assertThat(authScheme.getPassword()).isEqualTo("password");
+    }
+
+    @Test
+    public void should_create_certificate_auth() {
+        final AuthenticationScheme authenticationScheme =
+            AuthenticationSchemeFactory.create("certificate:file:///url:password");
+        assertThat(authenticationScheme).isInstanceOf(CertAuthScheme.class);
+        CertAuthScheme authScheme = (CertAuthScheme) authenticationScheme;
+
+        assertThat(authScheme.getTrustStorePassword()).isEqualTo("password");
+        assertThat(authScheme.getPathToTrustStore()).isEqualTo("///url");
+    }
+
+    @Test
+    public void should_create_digest_auth() {
+        final AuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.create("digest:username:password");
+        assertThat(authenticationScheme).isInstanceOf(BasicAuthScheme.class);
+        BasicAuthScheme authScheme = (BasicAuthScheme) authenticationScheme;
+        assertThat(authScheme.getUserName()).isEqualTo("username");
+        assertThat(authScheme.getPassword()).isEqualTo("password");
+    }
+
+    @Test
+    public void should_create_oauth_auth() {
+        final AuthenticationScheme authenticationScheme =
+            AuthenticationSchemeFactory.create("oauth:consumerKey:consumerSecret:accessToken:secretToken");
+        assertThat(authenticationScheme).isInstanceOf(OAuthScheme.class);
+        OAuthScheme authScheme = (OAuthScheme) authenticationScheme;
+
+        assertThat(authScheme.getAccessToken()).isEqualTo("accessToken");
+        assertThat(authScheme.getConsumerKey()).isEqualTo("consumerKey");
+        assertThat(authScheme.getConsumerSecret()).isEqualTo("consumerSecret");
+        assertThat(authScheme.getSecretToken()).isEqualTo("secretToken");
+    }
+
+    @Test
+    public void should_create_oauth_auth2() {
+        final AuthenticationScheme authenticationScheme = AuthenticationSchemeFactory.create("oauth2:accessToken");
+        assertThat(authenticationScheme).isInstanceOf(PreemptiveOAuth2HeaderScheme.class);
+        PreemptiveOAuth2HeaderScheme authScheme = (PreemptiveOAuth2HeaderScheme) authenticationScheme;
+
+        assertThat(authScheme.getAccessToken()).isEqualTo("accessToken");
+    }
+}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -16,7 +16,7 @@ import org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigReso
 import org.arquillian.cube.openshift.impl.enricher.internal.OpenshiftClientResourceProvider;
 import org.arquillian.cube.openshift.impl.ext.*;
 import org.arquillian.cube.openshift.impl.feedback.OpenshiftFeedbackProvider;
-import org.arquillian.cube.openshift.impl.graphene.location.OpenshiftCustomizableURLResourceProvider;
+import org.arquillian.cube.openshift.impl.graphene.location.OpenShiftCustomizableURLResourceProvider;
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
 import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
@@ -76,7 +76,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
 
         if (isGrapheneInStandaloneMode()) {
             builder.override(ResourceProvider.class, CustomizableURLResourceProvider.class,
-                OpenshiftCustomizableURLResourceProvider.class);
+                OpenShiftCustomizableURLResourceProvider.class);
         }
     }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftRouteLocator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftRouteLocator.java
@@ -1,60 +1,24 @@
-package org.arquillian.cube.openshift.impl.graphene.location;
+package org.arquillian.cube.openshift.impl.client;
 
 import io.fabric8.openshift.api.model.v3_1.Route;
 import org.arquillian.cube.kubernetes.api.Configuration;
-import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
-import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
 import org.jboss.arquillian.core.api.Instance;
-import org.jboss.arquillian.core.api.annotation.Inject;
-import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
-import org.jboss.arquillian.test.api.ArquillianResource;
-import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
 
-import java.lang.annotation.Annotation;
 import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.Optional;
 
-import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
+public class OpenShiftRouteLocator {
 
-public class OpenshiftCustomizableURLResourceProvider implements ResourceProvider {
-
-    @Inject
-    private Instance<GrapheneConfiguration> grapheneConfiguration;
-
-    @Inject
     private Instance<OpenShiftClient> clientInstance;
-
-    @Inject
     private Instance<Configuration> configurationInstance;
 
-    @Override
-    public boolean canProvide(Class<?> type) {
-        return URL.class.isAssignableFrom(type);
+    public OpenShiftRouteLocator(Instance<OpenShiftClient> clientInstance, Instance<Configuration> configurationInstance) {
+        this.clientInstance = clientInstance;
+        this.configurationInstance = configurationInstance;
     }
 
-    @Override
-    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
-        try {
-            final URL routeUrl = resolveUrl();
-            awaitRoute(routeUrl);
-            return routeUrl;
-        } catch (MalformedURLException e) {
-            throw new IllegalArgumentException(e);
-        }
-    }
-
-    private URL resolveUrl() throws MalformedURLException {
-        final GrapheneConfiguration grapheneConfiguration = this.grapheneConfiguration.get();
-
-        final String configuredUrl = grapheneConfiguration.getUrl();
-        if (configuredUrl != null && !configuredUrl.isEmpty()) {
-            return getRoute(new URL(configuredUrl));
-        }
-        return getRoute();
-    }
-
-    private URL getRoute(URL routeUrl) {
+    public URL getRoute(URL routeUrl) {
         final CubeOpenShiftConfiguration config = getCubeOpenShiftConfiguration();
         final OpenShiftClient client = clientInstance.get();
 
@@ -66,7 +30,7 @@ public class OpenshiftCustomizableURLResourceProvider implements ResourceProvide
         return createUrlFromRoute(route);
     }
 
-    private URL getRoute() {
+    public URL getRoute() {
         final CubeOpenShiftConfiguration config = getCubeOpenShiftConfiguration();
         final OpenShiftClient client = clientInstance.get();
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/graphene/location/OpenShiftCustomizableURLResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/graphene/location/OpenShiftCustomizableURLResourceProvider.java
@@ -1,0 +1,55 @@
+package org.arquillian.cube.openshift.impl.graphene.location;
+
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.openshift.impl.client.OpenShiftRouteLocator;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.graphene.spi.configuration.GrapheneConfiguration;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
+import java.net.MalformedURLException;
+import java.net.URL;
+
+import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
+
+public class OpenShiftCustomizableURLResourceProvider implements ResourceProvider {
+
+    @Inject
+    private Instance<GrapheneConfiguration> grapheneConfiguration;
+
+    @Inject
+    private Instance<OpenShiftClient> clientInstance;
+
+    @Inject
+    private Instance<Configuration> configurationInstance;
+
+    @Override
+    public boolean canProvide(Class<?> type) {
+        return URL.class.isAssignableFrom(type);
+    }
+
+    @Override
+    public Object lookup(ArquillianResource resource, Annotation... qualifiers) {
+        try {
+            final URL routeUrl = resolveUrl();
+            awaitRoute(routeUrl);
+            return routeUrl;
+        } catch (MalformedURLException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+
+    private URL resolveUrl() throws MalformedURLException {
+        final GrapheneConfiguration grapheneConfiguration = this.grapheneConfiguration.get();
+        final OpenShiftRouteLocator openShiftRouteLocator = new OpenShiftRouteLocator(clientInstance, configurationInstance);
+
+        final String configuredUrl = grapheneConfiguration.getUrl();
+        if (configuredUrl != null && !configuredUrl.isEmpty()) {
+            return openShiftRouteLocator.getRoute(new URL(configuredUrl));
+        }
+        return openShiftRouteLocator.getRoute();
+    }
+}

--- a/openshift/pom.xml
+++ b/openshift/pom.xml
@@ -36,6 +36,8 @@
     <module>ftest-oc-proxy</module>
     <module>ftest-openshift-assistant</module>
     <module>ftest-openshift-graphene</module>
+    <module>ftest-openshift-restassured</module>
+    <module>openshift-restassured</module>
   </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
       </dependency>
       <dependency>
         <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-openshift-restassured</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-openshift-httpclient</artifactId>
         <version>${project.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,11 @@
       </dependency>
       <dependency>
         <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-openshift-api</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-openshift-restassured</artifactId>
         <version>${project.version}</version>
       </dependency>


### PR DESCRIPTION
#### Short description of what this resolves:

Creates Rest-Assured Integration with OpenShift to auto-resolve the base URI for the application deployed on OpenShift.

#### Changes proposed in this pull request:

- Implements OpenShift RestAssured extension.
- Adds sample ftest for the same.
- Abstracts common openshift route logic. 

Fixes #894 
