### PR TITLE
Improve could not resolve route message

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.openshift.impl.enricher;
 
 import io.fabric8.openshift.api.model.v3_1.Route;
+import io.fabric8.openshift.api.model.v3_1.RouteList;
 import org.arquillian.cube.impl.util.ReflectionUtil;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
@@ -16,6 +17,10 @@ import java.lang.reflect.Method;
 import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URL;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
 
@@ -95,7 +100,8 @@ public class RouteURLEnricher implements TestEnricher {
         final OpenShiftClient client = clientInstance.get();
         final Route route = client.getClient().routes().inNamespace(config.getNamespace()).withName(routeName).get();
         if (route == null) {
-            throw new IllegalArgumentException("Could not resolve route: " + routeName);
+            List<Route> availableRoutes = client.getClient().routes().inNamespace(config.getNamespace()).list().getItems();
+            throw new IllegalArgumentException("Could not resolve route: " + routeName + ". Available routes: " + availableRoutes.stream().map(r -> r.getMetadata().getName()).collect(Collectors.toList()));
         }
 
         final String protocol = route.getSpec().getTls() == null ? "http" : "https";


### PR DESCRIPTION
Add a hint about the available routes when you specify a invalid route name, like the example below:

```
    @RouteURL("kie-app")
    private URL routeURL;
```

With this change a message similar to this will be printed within the stacktrace:

> Caused by: java.lang.IllegalArgumentException: Could not resolve route: kie-app. Available routes: [kie-app-kieserver, secure-kie-app-kieserver]


It could be helpful when you are unsure about the route name, and instead to configure the arquillian to do not remove the test project to check the route names,
it is easier to have it on the stacktrace.


  