### PR TITLE
chore(#924): Abstract common logic to Kubernetes Assistant and extend it to OpenShift Assistant

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
@@ -13,7 +13,6 @@ import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientException;
 import io.fabric8.kubernetes.clnt.v3_1.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
-import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
 import org.arquillian.cube.kubernetes.impl.portforward.PortForwarder;
@@ -58,16 +57,10 @@ public class KubernetesAssistant {
     private KubernetesAssistantDefaultResourceLocator kubernetesAssistantDefaultResourcesLocator;
     private Map<String, List<HasMetadata>> created = new LinkedHashMap<>();
 
-    KubernetesAssistant(KubernetesClient client, String namespace) {
+    public KubernetesAssistant(KubernetesClient client, String namespace) {
         this.client = client;
         this.namespace = namespace;
         this.kubernetesAssistantDefaultResourcesLocator = new KubernetesAssistantDefaultResourceLocator();
-    }
-
-    public KubernetesAssistant(io.fabric8.openshift.clnt.v3_1.OpenShiftClient openShiftClient, String namespace) {
-        this.client = openShiftClient;
-        this.client.adapt(OpenShiftClient.class);
-        this.namespace = namespace;
     }
 
     /**
@@ -99,7 +92,7 @@ public class KubernetesAssistant {
         if (defaultFileOptional.isPresent()) {
             deployApplication(applicationName, defaultFileOptional.get());
         } else {
-            log.warning("No default Kubernetes or OpenShift resources found at default locations.");
+            log.warning("No default Kubernetes resources found at default locations.");
         }
     }
 
@@ -246,7 +239,7 @@ public class KubernetesAssistant {
         }
     }
 
-    public List<? extends HasMetadata> deploy(String name, InputStream element) throws IOException {
+    protected List<? extends HasMetadata> deploy(String name, InputStream element) throws IOException {
         NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> declarations = client.load(element);
         List<HasMetadata> entities = declarations.createOrReplace();
 
@@ -467,7 +460,7 @@ public class KubernetesAssistant {
             });
     }
 
-    public List<Pod> getPods(String label) {
+    protected List<Pod> getPods(String label) {
         return this.client
             .pods()
             .inNamespace(this.namespace)

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
@@ -13,6 +13,7 @@ import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientException;
 import io.fabric8.kubernetes.clnt.v3_1.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
+import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
 import org.arquillian.cube.kubernetes.impl.portforward.PortForwarder;
@@ -61,6 +62,12 @@ public class KubernetesAssistant {
         this.client = kubernetesClient;
         this.namespace = namespace;
         this.kubernetesAssistantDefaultResourcesLocator = new KubernetesAssistantDefaultResourceLocator();
+    }
+
+    public KubernetesAssistant(io.fabric8.openshift.clnt.v3_1.OpenShiftClient openShiftClient, String namespace) {
+        this.client = openShiftClient;
+        this.client.adapt(OpenShiftClient.class);
+        this.namespace = namespace;
     }
 
     /**
@@ -219,7 +226,7 @@ public class KubernetesAssistant {
         }
     }
 
-    private void deploy(InputStream inputStream) throws IOException {
+    public void deploy(InputStream inputStream) throws IOException {
         final List<? extends HasMetadata> entities = deploy("application", inputStream);
 
         if (this.applicationName == null) {
@@ -233,7 +240,7 @@ public class KubernetesAssistant {
         }
     }
 
-    private List<? extends HasMetadata> deploy(String name, InputStream element) throws IOException {
+    public List<? extends HasMetadata> deploy(String name, InputStream element) throws IOException {
         NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> declarations = client.load(element);
         List<HasMetadata> entities = declarations.createOrReplace();
 
@@ -455,7 +462,7 @@ public class KubernetesAssistant {
             });
     }
 
-    private List<Pod> getPods(String label) {
+    public List<Pod> getPods(String label) {
         return this.client
             .pods()
             .inNamespace(this.namespace)

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
@@ -16,8 +16,6 @@ import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
 import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
-import org.arquillian.cube.kubernetes.impl.portforward.PortForwarder;
-
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -39,6 +37,7 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import org.arquillian.cube.kubernetes.impl.portforward.PortForwarder;
 
 import static org.arquillian.cube.kubernetes.impl.enricher.KuberntesServiceUrlResourceProvider.LOCALHOST;
 import static org.awaitility.Awaitility.await;
@@ -49,17 +48,17 @@ import static org.awaitility.Awaitility.await;
 public class KubernetesAssistant {
 
     private static final Logger log = Logger.getLogger(KubernetesAssistant.class.getName());
-    private final io.fabric8.kubernetes.clnt.v3_1.KubernetesClient client;
 
-    private final String namespace;
-    private String applicationName;
+
+    protected KubernetesClient client;
+    protected String namespace;
+    protected String applicationName;
 
     private KubernetesAssistantDefaultResourceLocator kubernetesAssistantDefaultResourcesLocator;
-
     private Map<String, List<HasMetadata>> created = new LinkedHashMap<>();
 
-    public KubernetesAssistant(io.fabric8.kubernetes.clnt.v3_1.KubernetesClient kubernetesClient, String namespace) {
-        this.client = kubernetesClient;
+    KubernetesAssistant(KubernetesClient client, String namespace) {
+        this.client = client;
         this.namespace = namespace;
         this.kubernetesAssistantDefaultResourcesLocator = new KubernetesAssistantDefaultResourceLocator();
     }
@@ -252,7 +251,6 @@ public class KubernetesAssistant {
 
         return entities;
     }
-
     /**
      * Gets the URL of the service with the given name that has been created during the current session.
      *

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
@@ -16,6 +16,8 @@ import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
 import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
 import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
 import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
+import org.arquillian.cube.kubernetes.impl.portforward.PortForwarder;
+
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -37,7 +39,6 @@ import java.util.function.Predicate;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.arquillian.cube.kubernetes.impl.portforward.PortForwarder;
 
 import static org.arquillian.cube.kubernetes.impl.enricher.KuberntesServiceUrlResourceProvider.LOCALHOST;
 import static org.awaitility.Awaitility.await;
@@ -225,6 +226,12 @@ public class KubernetesAssistant {
         }
     }
 
+    /**
+     * Deploys application reading resources from specified InputStream
+     *
+     * @param inputStream  where resources are read
+     * @throws IOException
+     */
     public void deploy(InputStream inputStream) throws IOException {
         final List<? extends HasMetadata> entities = deploy("application", inputStream);
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/KubernetesAssistantResourceProvider.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/enricher/external/KubernetesAssistantResourceProvider.java
@@ -15,7 +15,7 @@ public class KubernetesAssistantResourceProvider implements ResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
-        return KubernetesAssistant.class.isAssignableFrom(type);
+        return KubernetesAssistant.class.getName().equals(type.getName());
     }
 
     @Override

--- a/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantTest.java
+++ b/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantTest.java
@@ -20,7 +20,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class HelloWorldOpenShiftAssistantTest {
 
     @ArquillianResource
-    OpenShiftAssistant openShiftAssistant;
+    private OpenShiftAssistant openShiftAssistant;
 
     @Test
     public void should_inject_openshift_assistant() {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -2,33 +2,19 @@ package org.arquillian.cube.openshift.impl.client;
 
 import io.fabric8.kubernetes.api.model.v3_1.HasMetadata;
 import io.fabric8.kubernetes.api.model.v3_1.Pod;
-import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientException;
-import io.fabric8.kubernetes.clnt.v3_1.dsl.NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable;
 import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
 import io.fabric8.openshift.api.model.v3_1.DeploymentConfig;
 import io.fabric8.openshift.api.model.v3_1.Route;
-import io.github.lukehutch.fastclasspathscanner.FastClasspathScanner;
-import io.github.lukehutch.fastclasspathscanner.matchprocessor.FileMatchProcessor;
+import org.arquillian.cube.kubernetes.impl.KubernetesAssistant;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Comparator;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 
 import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
 import static org.awaitility.Awaitility.await;
@@ -37,7 +23,7 @@ import static org.awaitility.Awaitility.await;
  * Class that allows you to deploy undeploy and wait for resources programmatically in a test.
  *
  */
-public class OpenShiftAssistant {
+public class OpenShiftAssistant extends KubernetesAssistant {
 
     private static final Logger log = Logger.getLogger(OpenShiftAssistant.class.getName());
     private final io.fabric8.openshift.clnt.v3_1.OpenShiftClient client;
@@ -47,24 +33,11 @@ public class OpenShiftAssistant {
     private String applicationName;
     private OpenShiftAssistantDefaultResourcesLocator openShiftAssistantDefaultResourcesLocator;
 
-    private Map<String, List<HasMetadata>> created
-        = new LinkedHashMap<>();
-
     public OpenShiftAssistant(io.fabric8.openshift.clnt.v3_1.OpenShiftClient openShiftClient, String namespace) {
+        super(openShiftClient, namespace);
         this.client = openShiftClient;
         this.namespace = namespace;
         this.openShiftAssistantDefaultResourcesLocator = new OpenShiftAssistantDefaultResourcesLocator();
-    }
-
-    /**
-     * Deploys application finding resources in default location in classpath. That is:
-     * openshift.(y[a]ml|json), kubernetes.(y[a]ml|json), META-INF/fabric8/openshift.(y[a]ml|json), META-INF/fabric8/kubernetes.(y[a]ml|json)
-     * @return the name of the application defined in the DeplymentConfig.
-     * @throws IOException
-     */
-    public String deployApplication() throws IOException {
-        deployApplication((String) null);
-        return this.applicationName;
     }
 
     /**
@@ -77,6 +50,7 @@ public class OpenShiftAssistant {
      * @return the name of the application
      * @throws IOException
      */
+    @Override
     public void deployApplication(String applicationName) throws IOException {
 
         final Optional<URL> defaultFileOptional = this.openShiftAssistantDefaultResourcesLocator.locate();
@@ -89,129 +63,9 @@ public class OpenShiftAssistant {
 
     }
 
-    /**
-     * Deploys application reading resources from specified classpath location
-     * @param applicationName to configure in cluster
-     * @param classpathLocations where resources are read
-     * @throws IOException
-     */
-    public void deployApplication(String applicationName, String... classpathLocations) throws IOException {
-
-        final List<URL> classpathElements = Arrays.stream(classpathLocations)
-            .map(classpath -> Thread.currentThread().getContextClassLoader().getResource(classpath))
-            .collect(Collectors.toList());
-
-        deployApplication(applicationName, classpathElements.toArray(new URL[classpathElements.size()]));
-
-    }
-
-    /**
-     * Deploys application reading resources from specified URLs
-     * @param urls where resources are read
-     * @return the name of the application
-     * @throws IOException
-     */
-    public String deployApplication(URL... urls) throws IOException {
-        deployApplication(null, urls);
-
-        return this.applicationName;
-    }
-
-    /**
-     * Deploys application reading resources from specified URLs
-     * @param applicationName to configure in cluster
-     * @param urls where resources are read
-     * @return the name of the application
-     * @throws IOException
-     */
-    public void deployApplication(String applicationName, URL... urls) throws IOException {
-        this.applicationName = applicationName;
-
-        for (URL url : urls) {
-            try (InputStream inputStream = url.openStream()) {
-                deploy(inputStream);
-            }
-        }
-
-    }
-
-    /**
-     * Deploys application reading resources from classpath, matching the given regular expression.
-     * For example kubernetes/.*\\.json will deploy all resources ending with json placed at kubernetes classpath directory.
-     * @param applicationName to configure the cluster
-     * @param pattern to match the resources.
-     */
-    public void deployAll(String applicationName, String pattern) {
-        this.applicationName = applicationName;
-
-        final FastClasspathScanner fastClasspathScanner = new FastClasspathScanner();
-
-        fastClasspathScanner.matchFilenamePattern(pattern, (FileMatchProcessor) (relativePath, inputStream, lengthBytes) -> {
-            deploy(inputStream);
-        }).scan();
-    }
-
-    /**
-     * Deploys application reading resources from classpath, matching the given regular expression.
-     * For example kubernetes/.*\\.json will deploy all resources ending with json placed at kubernetes classpath directory.
-     * @param pattern to match the resources.
-     */
-    public String deployAll(String pattern) {
-        final FastClasspathScanner fastClasspathScanner = new FastClasspathScanner();
-
-        fastClasspathScanner.matchFilenamePattern(pattern, (FileMatchProcessor) (relativePath, inputStream, lengthBytes) -> {
-            deploy(inputStream);
-        }).scan();
-
-        return this.applicationName;
-
-    }
-
-    /**
-     * Deploys all y(a)ml and json files located at given directory.
-     * @param directory where resource files are stored
-     * @return the name of the application
-     * @throws IOException
-     */
-    public String deployAll(Path directory) throws IOException {
-        deployAll(directory);
-        return this.applicationName;
-    }
-
-    /**
-     * Deploys all y(a)ml and json files located at given directory.
-     * @param applicationName to configure in cluster
-     * @param directory where resources files are stored
-     * @throws IOException
-     */
-    public void deployAll(String applicationName, Path directory) throws IOException {
-        this.applicationName = applicationName;
-
-        if (Files.isDirectory(directory)) {
-            Files.list(directory)
-                .filter(p -> p.endsWith(".yaml") || p.endsWith(".yml") || p.endsWith(".json"))
-                .map(p -> {
-                    try {
-                        return Files.newInputStream(p);
-                    } catch (IOException e) {
-                        throw new IllegalArgumentException(e);
-                    }
-                })
-                .forEach(is -> {
-                    try {
-                        deploy(is);
-                    } catch (IOException e) {
-                        throw new IllegalArgumentException(e);
-                    }
-                });
-        } else {
-            throw new IllegalArgumentException(String.format("%s should be a directory", directory));
-        }
-    }
-
-    private void deploy(InputStream inputStream) throws IOException {
-        final List<? extends HasMetadata> entities
-            = deploy("application", inputStream);
+    @Override
+    public void deploy(InputStream inputStream) throws IOException {
+        final List<? extends HasMetadata> entities = deploy("application", inputStream);
 
         if (this.applicationName == null) {
 
@@ -222,19 +76,6 @@ public class OpenShiftAssistant {
 
             deploymentConfig.ifPresent(name -> this.applicationName = name);
         }
-    }
-
-    private List<? extends HasMetadata> deploy(String name, InputStream element) throws IOException {
-        NamespaceListVisitFromServerGetDeleteRecreateWaitApplicable<HasMetadata, Boolean> declarations = client.load(element);
-        List<HasMetadata> entities = declarations.createOrReplace();
-
-        this.created.merge(name, entities, (list1, list2) -> Stream.of(list1, list2)
-            .flatMap(Collection::stream)
-            .collect(Collectors.toList()));
-
-        log.info(String.format("%s deployed, %s object(s) created.", name, entities.size()));
-
-        return entities;
     }
 
     /**
@@ -284,84 +125,6 @@ public class OpenShiftAssistant {
     }
 
     /**
-     * Removes all resources deployed using this class.
-     */
-    public void cleanup() {
-        List<String> keys = new ArrayList<>(created.keySet());
-        keys.sort(String::compareTo);
-        for (String key : keys) {
-            created.remove(key)
-                .stream()
-                .sorted(Comparator.comparing(HasMetadata::getKind))
-                .forEach(metadata -> {
-                    log.info(String.format("Deleting %s : %s", key, metadata.getKind()));
-                    deleteWithRetries(metadata);
-                });
-        }
-    }
-
-    private void deleteWithRetries(HasMetadata metadata) {
-        int retryCounter = 0;
-        boolean deleteUnsucessful = true;
-        do {
-            retryCounter++;
-            try {
-                // returns false when successfully deleted
-                deleteUnsucessful = client.resource(metadata).withGracePeriod(0).delete();
-            } catch (KubernetesClientException e) {
-                try {
-                    TimeUnit.MILLISECONDS.sleep(500);
-                } catch (InterruptedException interrupted) {
-                    throw new RuntimeException(interrupted);
-                }
-                e.printStackTrace();
-                log.info(String.format("Error deleting resource %s %s retrying #%s ", metadata.getKind(),
-                    metadata.getMetadata().getName(), retryCounter));
-            }
-        } while (retryCounter < 3 && deleteUnsucessful);
-        if (deleteUnsucessful) {
-            throw new RuntimeException("Unable to delete " + metadata);
-        }
-    }
-
-    /**
-     * Awaits at most 5 minutes until all pods are running.
-     */
-    public void awaitApplicationReadinessOrFail() {
-        await().atMost(5, TimeUnit.MINUTES).until(() -> {
-                List<Pod> list = client.pods().inNamespace(namespace).list().getItems();
-                return list.stream()
-                    .filter(pod -> pod.getMetadata().getName().startsWith(applicationName))
-                    .filter(this::isRunning)
-                    .collect(Collectors.toList()).size() >= 1;
-            }
-        );
-    }
-
-    private boolean isRunning(Pod pod) {
-        return "running".equalsIgnoreCase(pod.getStatus().getPhase());
-    }
-
-    public String project() {
-        return namespace;
-    }
-
-    /**
-     * Awaits at most 5 minutes until all pods meets the given predicate.
-     * @param filter used to wait to detect that a pod is up and running.
-     */
-    public void awaitPodReadinessOrFail(Predicate<Pod> filter) {
-        await().atMost(5, TimeUnit.MINUTES).until(() -> {
-                List<Pod> list = client.pods().inNamespace(namespace).list().getItems();
-                return list.stream()
-                    .filter(filter)
-                    .filter(this::isRunning)
-                    .collect(Collectors.toList()).size() >= 1;
-            }
-        );
-    }
-
-    /**
      * Waits until the url responds with correct status code
      * @param routeUrl URL to check (usually a route one)
      * @param statusCodes list of status code that might return that service is up and running.
@@ -376,6 +139,7 @@ public class OpenShiftAssistant {
      * Scaling the application to given replicas
      * @param replicas to scale the application
      */
+    @Override
     public void scale(final int replicas) {
         log.info(String.format("Scaling replicas from %s to %s.", getPods("deploymentconfig").size(), replicas));
         this.client
@@ -398,15 +162,6 @@ public class OpenShiftAssistant {
                     return false;
                 }
             });
-    }
-
-    private List<Pod> getPods(String label) {
-        return this.client
-            .pods()
-            .inNamespace(this.namespace)
-            .withLabel(label, this.applicationName)
-            .list()
-            .getItems();
     }
 
     /**

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftRouteLocator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftRouteLocator.java
@@ -40,7 +40,7 @@ public class OpenShiftRouteLocator {
             .findFirst();
 
         return optionalRoute
-            .map(this::createUrlFromRoute)
+            .map(OpenShiftRouteLocator::createUrlFromRoute)
             .orElseThrow(() -> new NullPointerException("No route defined."));
     }
 
@@ -52,7 +52,7 @@ public class OpenShiftRouteLocator {
         return config;
     }
 
-    private URL createUrlFromRoute(Route route) {
+    static URL createUrlFromRoute(Route route) {
         try {
             final String protocol = route.getSpec().getTls() == null ? "http" : "https";
             final String path = route.getSpec().getPath() == null ? "" : route.getSpec().getPath();
@@ -62,7 +62,7 @@ public class OpenShiftRouteLocator {
         }
     }
 
-    private int resolvePort(String protocol) {
+    private static int resolvePort(String protocol) {
         if ("http".equals(protocol)) {
             return 80;
         } else {

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/OpenShiftAssistantResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/OpenShiftAssistantResourceProvider.java
@@ -1,11 +1,12 @@
 package org.arquillian.cube.openshift.impl.enricher.external;
 
-import java.lang.annotation.Annotation;
 import org.arquillian.cube.openshift.impl.client.OpenShiftAssistant;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
+
+import java.lang.annotation.Annotation;
 
 public class OpenShiftAssistantResourceProvider implements ResourceProvider {
 
@@ -22,7 +23,7 @@ public class OpenShiftAssistantResourceProvider implements ResourceProvider {
         OpenShiftAssistant openShiftAssistant = this.openShiftAssistantInstance.get();
 
         if (openShiftAssistant == null) {
-            throw new IllegalStateException("Unable to inject DockerClient into test.");
+            throw new IllegalStateException("Unable to inject OpenShift Assistant into test.");
         }
 
         return openShiftAssistant;

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/OpenShiftAssistantResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/OpenShiftAssistantResourceProvider.java
@@ -1,12 +1,11 @@
 package org.arquillian.cube.openshift.impl.enricher.external;
 
+import java.lang.annotation.Annotation;
 import org.arquillian.cube.openshift.impl.client.OpenShiftAssistant;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.arquillian.test.spi.enricher.resource.ResourceProvider;
-
-import java.lang.annotation.Annotation;
 
 public class OpenShiftAssistantResourceProvider implements ResourceProvider {
 
@@ -15,7 +14,7 @@ public class OpenShiftAssistantResourceProvider implements ResourceProvider {
 
     @Override
     public boolean canProvide(Class<?> type) {
-        return OpenShiftAssistant.class.isAssignableFrom(type);
+        return OpenShiftAssistant.class.getName().equals(type.getName());
     }
 
     @Override
@@ -23,7 +22,7 @@ public class OpenShiftAssistantResourceProvider implements ResourceProvider {
         OpenShiftAssistant openShiftAssistant = this.openShiftAssistantInstance.get();
 
         if (openShiftAssistant == null) {
-            throw new IllegalStateException("Unable to inject OpenShift Assistant into test.");
+            throw new IllegalStateException("Unable to inject OpenshiftAssistant into test.");
         }
 
         return openShiftAssistant;


### PR DESCRIPTION
#### Short description of what this resolves:

Abstract the common logic from the Kubernetes and OpenShift Assistants to Kubernetes Assistant and extend the same to OpenShift Assistant.

#### Changes proposed in this pull request:

- Removes duplicate code logic from OpenShift Assistant.
- Fixes `canProvide` method for provider classes.

Fixes #924 

  
  