### PR TITLE
feat(#934): introduces template dsl for openshift assistant.

### DIFF
--- a/openshift/ftest-openshift-assistant-template/pom.xml
+++ b/openshift/ftest-openshift-assistant-template/pom.xml
@@ -39,5 +39,17 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 
 </project>

--- a/openshift/ftest-openshift-assistant-template/pom.xml
+++ b/openshift/ftest-openshift-assistant-template/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>arquillian-cube-openshift-parent</artifactId>
     <groupId>org.arquillian.cube</groupId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.13.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 

--- a/openshift/ftest-openshift-assistant-template/pom.xml
+++ b/openshift/ftest-openshift-assistant-template/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>arquillian-cube-openshift-parent</artifactId>
+    <groupId>org.arquillian.cube</groupId>
+    <version>1.12.1-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-cube-openshift-assistant-template-ftest</artifactId>
+
+  <properties>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-requirement</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-standalone</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+
+</project>

--- a/openshift/ftest-openshift-assistant-template/src/test/java/org/arquillian/cube/openshift/standalone/HelloOpenShiftAssistantTemplateTest.java
+++ b/openshift/ftest-openshift-assistant-template/src/test/java/org/arquillian/cube/openshift/standalone/HelloOpenShiftAssistantTemplateTest.java
@@ -32,7 +32,7 @@ public class HelloOpenShiftAssistantTemplateTest {
     public void should_apply_template_programmatically() throws IOException {
 
         openShiftAssistant
-                .usingTemplate(String.valueOf(getClass().getClassLoader().getResource("hello-template.yaml")))
+                .usingTemplate(getClass().getClassLoader().getResource("hello-template.yaml"))
                 .parameter("RESPONSE", "Hello from Arquillian Template")
             .deploy();
 

--- a/openshift/ftest-openshift-assistant-template/src/test/java/org/arquillian/cube/openshift/standalone/HelloOpenShiftAssistantTemplateTest.java
+++ b/openshift/ftest-openshift-assistant-template/src/test/java/org/arquillian/cube/openshift/standalone/HelloOpenShiftAssistantTemplateTest.java
@@ -1,0 +1,51 @@
+package org.arquillian.cube.openshift.standalone;
+
+import okhttp3.OkHttpClient;
+import okhttp3.Request;
+import okhttp3.Response;
+import org.arquillian.cube.openshift.impl.client.OpenShiftAssistant;
+import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.jboss.arquillian.test.api.ArquillianResource;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@RunWith(ArquillianConditionalRunner.class)
+@RequiresOpenshift
+public class HelloOpenShiftAssistantTemplateTest {
+
+    @ArquillianResource
+    private OpenShiftAssistant openShiftAssistant;
+
+    @Test
+    public void should_inject_openshift_assistant() {
+        assertThat(openShiftAssistant).isNotNull();
+    }
+
+    @Test
+    public void should_apply_template_programmatically() throws IOException {
+
+        openShiftAssistant
+                .usingTemplate("https://gist.githubusercontent.com/lordofthejars/8781cacd4000a516695ad6c55b5815b3/raw/5151aeef0f5dd8823e2c581c3b7452f04a76af59/hello-template.yaml")
+                .parameter("RESPONSE", "Hello from Arquillian Template")
+            .deploy();
+
+        final Optional<URL> route = openShiftAssistant.getRoute();
+        openShiftAssistant.awaitUrl(route.get());
+
+
+        OkHttpClient okHttpClient = new OkHttpClient();
+        Request request = new Request.Builder().get().url(route.get()).build();
+        Response response = okHttpClient.newCall(request).execute();
+
+        assertThat(response).isNotNull();
+        assertThat(response.code()).isEqualTo(200);
+        assertThat(response.body().string()).isEqualTo("Hello from Arquillian Template\n");
+    }
+}

--- a/openshift/ftest-openshift-assistant-template/src/test/java/org/arquillian/cube/openshift/standalone/HelloOpenShiftAssistantTemplateTest.java
+++ b/openshift/ftest-openshift-assistant-template/src/test/java/org/arquillian/cube/openshift/standalone/HelloOpenShiftAssistantTemplateTest.java
@@ -32,13 +32,12 @@ public class HelloOpenShiftAssistantTemplateTest {
     public void should_apply_template_programmatically() throws IOException {
 
         openShiftAssistant
-                .usingTemplate("https://gist.githubusercontent.com/lordofthejars/8781cacd4000a516695ad6c55b5815b3/raw/5151aeef0f5dd8823e2c581c3b7452f04a76af59/hello-template.yaml")
+                .usingTemplate(String.valueOf(getClass().getClassLoader().getResource("hello-template.yaml")))
                 .parameter("RESPONSE", "Hello from Arquillian Template")
             .deploy();
 
         final Optional<URL> route = openShiftAssistant.getRoute();
         openShiftAssistant.awaitUrl(route.get());
-
 
         OkHttpClient okHttpClient = new OkHttpClient();
         Request request = new Request.Builder().get().url(route.get()).build();

--- a/openshift/ftest-openshift-assistant-template/src/test/resources/hello-template.yaml
+++ b/openshift/ftest-openshift-assistant-template/src/test/resources/hello-template.yaml
@@ -1,0 +1,48 @@
+apiVersion: v1
+kind: Template
+metadata:
+  name: hello
+parameters:
+- name: RESPONSE
+  value: "Hello from Arquillian"
+  required: false
+objects:
+- apiVersion: v1
+  kind: Route
+  metadata:
+    name: hello-openshift-route
+  spec:
+    port:
+      targetPort: 8080
+    to:
+      kind: Service
+      name: hello-openshift-service
+- apiVersion: v1
+  kind: Service
+  metadata:
+    name: hello-openshift-service
+  spec:
+    ports:
+    - name: hello-openshift-service
+      port: 8080
+      protocol: TCP
+      targetPort: 8080
+    selector:
+      name: hello-openshift-service
+- apiVersion: v1
+  kind: Pod
+  metadata:
+    labels:
+      name: hello-openshift-service
+    name: hello-openshift
+  spec:
+    containers:
+    - image: openshift/hello-openshift
+      imagePullPolicy: IfNotPresent
+      name: hello-openshift
+      ports:
+      - containerPort: 8080
+        protocol: TCP
+      env:
+      - name: RESPONSE
+        value: ${RESPONSE}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -169,7 +169,7 @@ public class OpenShiftAssistant extends KubernetesAssistant {
      * @return OpenShiftAssistantTemplate object.
      */
     public OpenShiftAssistantTemplate usingTemplate(URL templateURL) {
-        return new OpenShiftAssistantTemplate(templateURL, client);
+        return new OpenShiftAssistantTemplate(templateURL, getClient());
     }
 
     /**
@@ -179,6 +179,6 @@ public class OpenShiftAssistant extends KubernetesAssistant {
      * @return OpenShiftAssistantTemplate object.
      */
     public OpenShiftAssistantTemplate usingTemplate(String templateURL) throws MalformedURLException {
-        return new OpenShiftAssistantTemplate(new URL(templateURL), client);
+        return new OpenShiftAssistantTemplate(new URL(templateURL), getClient());
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -1,22 +1,16 @@
 package org.arquillian.cube.openshift.impl.client;
 
 import io.fabric8.kubernetes.api.model.v3_1.HasMetadata;
-import io.fabric8.kubernetes.api.model.v3_1.KubernetesList;
 import io.fabric8.kubernetes.api.model.v3_1.Pod;
 import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
 import io.fabric8.openshift.api.model.v3_1.DeploymentConfig;
-import io.fabric8.openshift.api.model.v3_1.DoneableTemplate;
 import io.fabric8.openshift.api.model.v3_1.Route;
-import io.fabric8.openshift.api.model.v3_1.Template;
 import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
-import io.fabric8.openshift.clnt.v3_1.ParameterValue;
-import io.fabric8.openshift.clnt.v3_1.dsl.TemplateResource;
 import org.arquillian.cube.kubernetes.impl.KubernetesAssistant;
 
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
@@ -35,10 +29,6 @@ public class OpenShiftAssistant extends KubernetesAssistant {
     private static final Logger log = Logger.getLogger(OpenShiftAssistant.class.getName());
 
     private OpenShiftAssistantDefaultResourcesLocator openShiftAssistantDefaultResourcesLocator;
-
-    private List<ParameterValue> pvs = new ArrayList<>();
-
-    private String templateURL;
 
     OpenShiftAssistant(OpenShiftClient client, String namespace) {
         super(client, namespace);
@@ -171,36 +161,14 @@ public class OpenShiftAssistant extends KubernetesAssistant {
             .get();
     }
 
-    public OpenShiftAssistant usingTemplate(String templateURL) {
-        this.templateURL = templateURL;
-        return this;
-    }
-
-    public OpenShiftAssistant parameter(String param, String value) {
-        pvs.add(new ParameterValue(param, value));
-        return this;
-    }
-
     /**
-     * Deploys application reading resources from specified TemplateURL.
+     * Gets template URL used for deploying application.
      *
-     * @throws IOException
+     * @param templateURL path to the template
+     * @return OpenShiftAssistantTemplate object.
      */
-    public void deploy() throws IOException {
-        KubernetesList list = processTemplate(templateURL, pvs);
-        createResources(list);
+    public OpenShiftAssistantTemplate usingTemplate(String templateURL) {
+        return new OpenShiftAssistantTemplate(templateURL, client);
     }
 
-    private KubernetesList processTemplate(String templateURL, List<ParameterValue> values) throws IOException {
-        OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
-        try (InputStream stream = new URL(templateURL).openStream()) {
-            TemplateResource<Template, KubernetesList, DoneableTemplate> templateHandle =
-                openShiftClient.templates().inNamespace(this.namespace).load(stream);
-            return templateHandle.process(values.toArray(new ParameterValue[values.size()]));
-        }
-    }
-
-    private KubernetesList createResources(KubernetesList list) {
-        return client.lists().inNamespace(this.namespace).create(list);
-    }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -10,6 +10,7 @@ import org.arquillian.cube.kubernetes.impl.KubernetesAssistant;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
@@ -164,11 +165,20 @@ public class OpenShiftAssistant extends KubernetesAssistant {
     /**
      * Gets template URL used for deploying application.
      *
-     * @param templateURL path to the template
+     * @param templateURL url path to the template
      * @return OpenShiftAssistantTemplate object.
      */
-    public OpenShiftAssistantTemplate usingTemplate(String templateURL) {
+    public OpenShiftAssistantTemplate usingTemplate(URL templateURL) {
         return new OpenShiftAssistantTemplate(templateURL, client);
     }
 
+    /**
+     * Gets template URL string used for deploying application.
+     *
+     * @param templateURL path to the template
+     * @return OpenShiftAssistantTemplate object.
+     */
+    public OpenShiftAssistantTemplate usingTemplate(String templateURL) throws MalformedURLException {
+        return new OpenShiftAssistantTemplate(new URL(templateURL), client);
+    }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistantTemplate.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistantTemplate.java
@@ -1,7 +1,6 @@
 package org.arquillian.cube.openshift.impl.client;
 
 import io.fabric8.kubernetes.api.model.v3_1.KubernetesList;
-import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import io.fabric8.openshift.api.model.v3_1.DoneableTemplate;
 import io.fabric8.openshift.api.model.v3_1.Template;
 import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
@@ -18,13 +17,13 @@ import java.util.stream.Collectors;
 
 public class OpenShiftAssistantTemplate {
 
-    private final KubernetesClient client;
+    private final OpenShiftClient client;
 
     private URL templateURL;
 
     private HashMap<String, String> parameterValues = new HashMap<>();
 
-    OpenShiftAssistantTemplate(URL templateURL, KubernetesClient client) {
+    OpenShiftAssistantTemplate(URL templateURL, OpenShiftClient client) {
         this.templateURL = templateURL;
         this.client = client;
     }
@@ -51,12 +50,11 @@ public class OpenShiftAssistantTemplate {
     }
 
     private KubernetesList processTemplate(URL templateURL, HashMap<String, String> parameterValues) throws IOException {
-        final OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
         List<ParameterValue> list = new ArrayList<>();
 
         try (InputStream stream = templateURL.openStream()) {
             TemplateResource<Template, KubernetesList, DoneableTemplate> templateHandle =
-                openShiftClient.templates().inNamespace(client.getNamespace()).load(stream);
+                client.templates().inNamespace(client.getNamespace()).load(stream);
 
             list.addAll(parameterValues.entrySet().stream()
                 .map(entry -> new ParameterValue(entry.getKey(), entry.getValue()))

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistantTemplate.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistantTemplate.java
@@ -1,0 +1,72 @@
+package org.arquillian.cube.openshift.impl.client;
+
+import io.fabric8.kubernetes.api.model.v3_1.KubernetesList;
+import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
+import io.fabric8.openshift.api.model.v3_1.DoneableTemplate;
+import io.fabric8.openshift.api.model.v3_1.Template;
+import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
+import io.fabric8.openshift.clnt.v3_1.ParameterValue;
+import io.fabric8.openshift.clnt.v3_1.dsl.TemplateResource;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class OpenShiftAssistantTemplate {
+
+    private final KubernetesClient client;
+
+    private String templateURL;
+
+    private HashMap<String, String> parameterValues = new HashMap<>();
+
+    OpenShiftAssistantTemplate(String templateURL, KubernetesClient client) {
+        this.templateURL = templateURL;
+        this.client = client;
+    }
+
+    /**
+     * Stores template parameters for OpenShiftAssistantTemplate.
+     *
+     * @param name  template parameter name
+     * @param value template parameter value
+     */
+    public OpenShiftAssistantTemplate parameter(String name, String value) {
+        parameterValues.put(name, value);
+        return this;
+    }
+
+    /**
+     * Deploys application reading resources from specified TemplateURL.
+     *
+     * @throws IOException
+     */
+    public void deploy() throws IOException {
+        KubernetesList list = processTemplate(templateURL, parameterValues);
+        createResources(list);
+    }
+
+    private KubernetesList processTemplate(String templateURL, HashMap<String, String> parameterValues) throws IOException {
+        final OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
+        List<ParameterValue> list = new ArrayList<>();
+
+        try (InputStream stream = new URL(templateURL).openStream()) {
+            TemplateResource<Template, KubernetesList, DoneableTemplate> templateHandle =
+                openShiftClient.templates().inNamespace(client.getNamespace()).load(stream);
+
+            list.addAll(parameterValues.entrySet().stream()
+                .map(entry -> new ParameterValue(entry.getKey(), entry.getValue()))
+                .collect(Collectors.toList()));
+
+            return templateHandle.process(list.toArray(new ParameterValue[parameterValues.size()]));
+        }
+    }
+
+    private KubernetesList createResources(KubernetesList list) {
+        return client.lists().inNamespace(client.getNamespace()).create(list);
+    }
+}

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistantTemplate.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistantTemplate.java
@@ -20,11 +20,11 @@ public class OpenShiftAssistantTemplate {
 
     private final KubernetesClient client;
 
-    private String templateURL;
+    private URL templateURL;
 
     private HashMap<String, String> parameterValues = new HashMap<>();
 
-    OpenShiftAssistantTemplate(String templateURL, KubernetesClient client) {
+    OpenShiftAssistantTemplate(URL templateURL, KubernetesClient client) {
         this.templateURL = templateURL;
         this.client = client;
     }
@@ -50,11 +50,11 @@ public class OpenShiftAssistantTemplate {
         createResources(list);
     }
 
-    private KubernetesList processTemplate(String templateURL, HashMap<String, String> parameterValues) throws IOException {
+    private KubernetesList processTemplate(URL templateURL, HashMap<String, String> parameterValues) throws IOException {
         final OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
         List<ParameterValue> list = new ArrayList<>();
 
-        try (InputStream stream = new URL(templateURL).openStream()) {
+        try (InputStream stream = templateURL.openStream()) {
             TemplateResource<Template, KubernetesList, DoneableTemplate> templateHandle =
                 openShiftClient.templates().inNamespace(client.getNamespace()).load(stream);
 

--- a/openshift/pom.xml
+++ b/openshift/pom.xml
@@ -38,6 +38,7 @@
     <module>ftest-openshift-graphene</module>
     <module>ftest-openshift-restassured</module>
     <module>openshift-restassured</module>
+    <module>ftest-openshift-assistant-template</module>
   </modules>
 
 </project>


### PR DESCRIPTION
#### Short description of what this resolves:
Creates Template DSL for OpenShiftAssistant so you can apply templates programmatically.

This DSL looks like:

`openshiftAssistant.usingTemplate("url/to/template").parameter("param1", "value1").parameter("param2", "value2").deploy()`

#### Changes proposed in this pull request:

- Template DSL for OpenShift Assistant.
- ftest to showcase template DSL for OpenShift Assistant.

Fixes #934 
