### PR TITLE
fix(#939): improves shutdown hook to stop and remove container

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/client/ForceStopDockerContainersShutdownHook.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/ForceStopDockerContainersShutdownHook.java
@@ -8,20 +8,16 @@ import org.jboss.arquillian.test.spi.event.suite.BeforeSuite;
 
 public class ForceStopDockerContainersShutdownHook {
 
-    public void attachShutDownHookForceStopDcokerContainers(@Observes(precedence = 200) BeforeSuite event,
+    public void attachShutDownHookForceStopDockerContainers(@Observes(precedence = 200) BeforeSuite event,
         final CubeRegistry cubeRegistry) {
         Runtime.getRuntime().addShutdownHook(new Thread() {
             @Override
             public void run() {
                 final List<Cube<?>> cubes = cubeRegistry.getCubes();
                 for (Cube cube : cubes) {
-                    // If container is started, and we are exiting we need to stop it.
-                    // Notice that in case of STARTORCONNECT and STARTORCONNECTANDLEAVE the state is PRE_RUNNING
-                    // so they are not going to be stopped
-                    if (Cube.State.STARTED.equals(cube.state())) {
+
                         cube.stop();
                         cube.destroy();
-                    }
                 }
             }
         });


### PR DESCRIPTION

#### Short description of what this resolves:


#### Changes proposed in this pull request:

- We are not checking state in shutdown hook as it's already checked in `stop` and `destroy` 


Fixes #939 
