### PR TITLE
Allow parallelization of networks

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/StarOperator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/StarOperator.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.docker.impl.client.config;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Random;
 import java.util.UUID;
 
@@ -74,6 +75,25 @@ public class StarOperator {
         }
         
         cubeContainer.setDependsOn(adjustedDependsOn);
+    }
+
+    public static void adaptNetworksToParalledRun(Map<String,String> networkResolutions, CubeContainer cubeContainer) {
+        String networkMode = cubeContainer.getNetworkMode();
+        if (networkMode != null && networkResolutions.containsKey(networkMode)) {
+            cubeContainer.setNetworkMode(networkResolutions.get(networkMode));
+        }
+
+        if (cubeContainer.getNetworks() != null) {
+            ArrayList<String> networks = new ArrayList<>();
+            for (String network : cubeContainer.getNetworks()) {
+                if (networkResolutions.containsKey(network)) {
+                    networks.add(networkResolutions.get(network));
+                } else {
+                    networks.add(network);
+                }
+            }
+            cubeContainer.setNetworks(networks);
+        }
     }
 
     public static String generateNewName(String containerName, UUID uuid) {

--- a/docs/parallel.adoc
+++ b/docs/parallel.adoc
@@ -73,6 +73,30 @@ So for example the result file could look like:
 
 Since now the ports are unique and names are unique, you can run tests using same orchestration in parallel against same docker host.
 
+The same approach can work for ensuring that each test run has a unique network. As docker allows multiple networks to have the same name, it will not throw an error if two concurrent tests create networks with the same name. However, as cube networks are specified by name in the cube specification, if there are multiple networks with the same name, the cube could end up in any one of them, resulting in hard to debug test failures.
+
+Again, adding the special character `*` to the end of the network name will cause a random network name to be used. The name can then be used for a cube's networkMode or in the cube's network list, and it will be substituted correctly when the test runs.
+
+[source, yml]
+.arquillian.xml
+----
+<property name="dockerContainers">
+    networks:
+      testnetwork*:
+        driver: bridge
+    tomcat*:
+      image: tutum/tomcat:8.0
+      portBindings: [8080/tcp]
+      networkMode: testnetwork*
+    ping*:
+      image: jonmorehouse/ping-pong
+      exposedPorts: [8089/tcp]
+      networks:
+        - testnetwork*
+</property>
+----
+
+
 NOTE: You can use the same approach for _docker-compose_ files not only with _cube_ format. But then your _docker-compose_ will be tight to Arquillian Cube. The best approach if you want to use docker-compose format is using `extends`.
 
 NOTE: Star operator must also used on enrichers for example:


### PR DESCRIPTION
If you're using networks and you want to parallelize your containers,
all the containers will end up on the same set of networks, which
could interfere with your test.

Even worse, as docker allows multiple networks with the same name, if
there's a problem with cleanup on a previous run, you may end up with
containers in different networks when you want them to be in the same
network.

This patch solves these problems by allowing the star pattern for
networks. It works the same as the container star pattern, and
networkMode and networks are updated within the container configuration.
