### PR TITLE
Allow docker configuration to be loaded from the classpath

### DIFF
--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfigurationTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfigurationTest.java
@@ -561,6 +561,27 @@ public class CubeConfigurationTest {
     }
 
     @Test
+    public void should_parse_and_load_configuration_from_container_configuration_resource() throws IOException {
+        Map<String, String> parameters = new HashMap<String, String>();
+
+        parameters.put("serverVersion", "1.13");
+        parameters.put("serverUri", "http://localhost:25123");
+        parameters.put("definitionFormat", DefinitionFormat.CUBE.name());
+        parameters.put("dockerContainersResource", "test-topologies/topology1.yaml");
+
+        CubeDockerConfiguration cubeConfiguration = CubeDockerConfiguration.fromMap(parameters, null);
+        assertThat(cubeConfiguration.getDockerServerUri(), is("http://localhost:25123"));
+        assertThat(cubeConfiguration.getDockerServerVersion(), is("1.13"));
+
+        DockerCompositions dockerContainersContent = cubeConfiguration.getDockerContainersContent();
+        CubeContainer actualTomcat = dockerContainersContent.get("tomcat");
+        assertThat(actualTomcat, is(notNullValue()));
+
+        String image = actualTomcat.getImage().toImageRef();
+        assertThat(image, is("tutum/tomcat:7.0"));
+    }
+
+    @Test
     public void should_be_able_to_extend_and_override_toplevel() throws Exception {
         String config =
             "tomcat6:\n" +

--- a/docker/docker/src/test/resources/test-topologies/topology1.yaml
+++ b/docker/docker/src/test/resources/test-topologies/topology1.yaml
@@ -1,0 +1,7 @@
+tomcat:
+  image: tutum/tomcat:7.0
+  exposedPorts: [8089/tcp]
+  await:
+    strategy: static
+    ip: localhost
+    ports: [8080, 8089]

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -29,6 +29,9 @@ Let's see valid attributes:
 |dockerContainersFiles
 |You can set a list of locations separated by comma. These locations follow the same rules as `dockerContainersFile` so it can be a file or an URI. This property can be used to append the definitions from several files.
 
+|dockerContainersResource
+|Rather than embedding YAML as a string, or specifying a path on the filesystem, you can specify a file containing the container definitions on the java classpath. This allows you to avoid dealing with complex relative paths if sharing definitions between multiple modules.
+
 |definitionFormat
 |Sets the format of content expressed in `dockerContainers` attribute or in file set in `dockerContainersFile`. It can contain two possible values _CUBE_ to indicate that content is written following <<cube-format, Arquillian Cube>> format or _COMPOSE_ (default one in case of not set) to indicate that content is written following <<docker-compose-format, Docker Compose>> format.
 


### PR DESCRIPTION
Allow users to specify the docker configuration file as a file on the
classpath, rather that on the filesystem. This means they won't have
to worry about absolute and relative paths, which can change in maven
depending on which flags are specified (forkCount for example).

It also allows configurations to be bundled into a jar and shared
between modules.

