### PR TITLE
feat(#928): simplifies dependencies for Standalone Mode

### DIFF
--- a/arquillian-cube-docker-starter/pom.xml
+++ b/arquillian-cube-docker-starter/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-parent</artifactId>
+    <version>1.12.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-cube-docker-starter</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Arquillian Cube Docker Starter</name>
+  <description>Optimized dependencyManagement for the Arquillian Cube Docker Project</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-docker</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-standalone</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/arquillian-cube-docker-starter/pom.xml
+++ b/arquillian-cube-docker-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.arquillian.cube</groupId>
     <artifactId>arquillian-cube-parent</artifactId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.13.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/arquillian-cube-kubernetes-starter/pom.xml
+++ b/arquillian-cube-kubernetes-starter/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-parent</artifactId>
+    <version>1.12.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-cube-kubernetes-starter</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Arquillian Cube Kubernetes Starter</name>
+  <description>Optimized dependencyManagement for the Arquillian Cube Kubernetes Project</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-kubernetes</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-standalone</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/arquillian-cube-kubernetes-starter/pom.xml
+++ b/arquillian-cube-kubernetes-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.arquillian.cube</groupId>
     <artifactId>arquillian-cube-parent</artifactId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.13.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/arquillian-cube-openshift-starter/pom.xml
+++ b/arquillian-cube-openshift-starter/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <groupId>org.arquillian.cube</groupId>
     <artifactId>arquillian-cube-parent</artifactId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.13.1-SNAPSHOT</version>
   </parent>
 
   <modelVersion>4.0.0</modelVersion>

--- a/arquillian-cube-openshift-starter/pom.xml
+++ b/arquillian-cube-openshift-starter/pom.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-parent</artifactId>
+    <version>1.12.1-SNAPSHOT</version>
+  </parent>
+
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>arquillian-cube-openshift-starter</artifactId>
+  <packaging>jar</packaging>
+
+  <name>Arquillian Cube OpenShift Starter</name>
+  <description>Optimized dependencyManagement for the Arquillian Cube OpenShift Project</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.arquillian.cube</groupId>
+      <artifactId>arquillian-cube-openshift</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-standalone</artifactId>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/docker/ftest-docker-compose-v2-git-context/pom.xml
+++ b/docker/ftest-docker-compose-v2-git-context/pom.xml
@@ -13,18 +13,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-docker-containerobject-dsl/pom.xml
+++ b/docker/ftest-docker-containerobject-dsl/pom.xml
@@ -10,13 +10,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-docker-containerobject/pom.xml
+++ b/docker/ftest-docker-containerobject/pom.xml
@@ -10,13 +10,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-docker-machine-network/pom.xml
+++ b/docker/ftest-docker-machine-network/pom.xml
@@ -16,13 +16,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-drone-custom/pom.xml
+++ b/docker/ftest-drone-custom/pom.xml
@@ -32,18 +32,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-drone-reporter/pom.xml
+++ b/docker/ftest-drone-reporter/pom.xml
@@ -32,13 +32,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-drone/pom.xml
+++ b/docker/ftest-drone/pom.xml
@@ -32,18 +32,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-graphene/pom.xml
+++ b/docker/ftest-graphene/pom.xml
@@ -32,11 +32,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
       <version>${version.graphene}</version>
@@ -56,7 +51,7 @@
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-junit-rules/pom.xml
+++ b/docker/ftest-junit-rules/pom.xml
@@ -35,14 +35,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-      <version>${version.arquillian_core}</version>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-junit-rules/pom.xml
+++ b/docker/ftest-junit-rules/pom.xml
@@ -7,6 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
+  <name>Arquillian Cube Docker Functional Test JUnit Rules</name>
   <artifactId>arquillian-cube-docker-junit-rules</artifactId>
 
   <properties>

--- a/docker/ftest-reporter/pom.xml
+++ b/docker/ftest-reporter/pom.xml
@@ -13,18 +13,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-restassured/pom.xml
+++ b/docker/ftest-restassured/pom.xml
@@ -13,18 +13,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-standalone-autostart/pom.xml
+++ b/docker/ftest-standalone-autostart/pom.xml
@@ -12,18 +12,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/docker/ftest-standalone-star-operator-docker-compose/pom.xml
+++ b/docker/ftest-standalone-star-operator-docker-compose/pom.xml
@@ -12,13 +12,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-standalone-star-operator/pom.xml
+++ b/docker/ftest-standalone-star-operator/pom.xml
@@ -12,13 +12,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docker/ftest-standalone/pom.xml
+++ b/docker/ftest-standalone/pom.xml
@@ -33,13 +33,8 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-docker</artifactId>
+      <artifactId>arquillian-cube-docker-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/docs/bom.adoc
+++ b/docs/bom.adoc
@@ -107,6 +107,17 @@ Then include the individual modules as you see fit, by simply depending on the u
 </dependency>
 ----
 
+==== Arquillian Cube Docker Starter (Single Unified Dependency for Cube Docker in Standalone Mode)
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-docker-starter</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
 ==== Arquillian Cube Docker Junit Rule
 
 [source, xml]
@@ -173,6 +184,17 @@ Then include the individual modules as you see fit, by simply depending on the u
 </dependency>
 ----
 
+==== Arquillian Cube Kubernetes Starter (Single Unified Dependency for Cube Kubernetes in Standalone Mode)
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-kubernetes-starter</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
 ==== Arquillian Cube Kubernetes Reporter
 
 [source, xml]
@@ -202,6 +224,17 @@ Then include the individual modules as you see fit, by simply depending on the u
 <dependency>
     <groupId>org.arquillian.cube</groupId>
     <artifactId>arquillian-cube-openshift</artifactId>
+    <scope>test</scope>
+</dependency>
+----
+
+==== Arquillian Cube Openshift Starter (Single Unified Dependency for Cube OpenShift in Standalone Mode)
+
+[source, xml]
+----
+<dependency>
+    <groupId>org.arquillian.cube</groupId>
+    <artifactId>arquillian-cube-openshift-starter</artifactId>
     <scope>test</scope>
 </dependency>
 ----

--- a/docs/bom.adoc
+++ b/docs/bom.adoc
@@ -109,13 +109,9 @@ Then include the individual modules as you see fit, by simply depending on the u
 
 ==== Arquillian Cube Docker Starter (Single Unified Dependency for Cube Docker in Standalone Mode)
 
-[source, xml]
+[source, xml, indent=0]
 ----
-<dependency>
-    <groupId>org.arquillian.cube</groupId>
-    <artifactId>arquillian-cube-docker-starter</artifactId>
-    <scope>test</scope>
-</dependency>
+include::../pom.xml[tag=docker_starter_dependency]
 ----
 
 ==== Arquillian Cube Docker Junit Rule
@@ -186,13 +182,9 @@ Then include the individual modules as you see fit, by simply depending on the u
 
 ==== Arquillian Cube Kubernetes Starter (Single Unified Dependency for Cube Kubernetes in Standalone Mode)
 
-[source, xml]
+[source, xml, indent=0]
 ----
-<dependency>
-    <groupId>org.arquillian.cube</groupId>
-    <artifactId>arquillian-cube-kubernetes-starter</artifactId>
-    <scope>test</scope>
-</dependency>
+include::../pom.xml[tag=kubernetes_starter_dependency]
 ----
 
 ==== Arquillian Cube Kubernetes Reporter
@@ -230,11 +222,7 @@ Then include the individual modules as you see fit, by simply depending on the u
 
 ==== Arquillian Cube Openshift Starter (Single Unified Dependency for Cube OpenShift in Standalone Mode)
 
-[source, xml]
+[source, xml, indent=0]
 ----
-<dependency>
-    <groupId>org.arquillian.cube</groupId>
-    <artifactId>arquillian-cube-openshift-starter</artifactId>
-    <scope>test</scope>
-</dependency>
+include::../pom.xml[tag=openshift_starter_dependency]
 ----

--- a/kubernetes/ftest-kubernetes-assistant/pom.xml
+++ b/kubernetes/ftest-kubernetes-assistant/pom.xml
@@ -12,7 +12,9 @@
     <maven.compiler.source>1.8</maven.compiler.source>
   </properties>
 
+  <name>Arquillian Cube Kubernetes Assistant Standalone Functional Test</name>
   <artifactId>arquillian-cube-kubernetes-assistant-standalone-ftest</artifactId>
+
   <dependencies>
     <dependency>
       <groupId>org.arquillian.cube</groupId>

--- a/kubernetes/ftest-kubernetes-assistant/pom.xml
+++ b/kubernetes/ftest-kubernetes-assistant/pom.xml
@@ -23,17 +23,12 @@
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-kubernetes</artifactId>
+      <artifactId>arquillian-cube-kubernetes-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kubernetes/ftest-kubernetes-logs/pom.xml
+++ b/kubernetes/ftest-kubernetes-logs/pom.xml
@@ -11,18 +11,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-kubernetes</artifactId>
+      <artifactId>arquillian-cube-kubernetes-starter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/kubernetes/ftest-kubernetes-reporter/pom.xml
+++ b/kubernetes/ftest-kubernetes-reporter/pom.xml
@@ -13,18 +13,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-kubernetes</artifactId>
+      <artifactId>arquillian-cube-kubernetes-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/kubernetes/ftest-kubernetes/pom.xml
+++ b/kubernetes/ftest-kubernetes/pom.xml
@@ -11,18 +11,13 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-kubernetes</artifactId>
+      <artifactId>arquillian-cube-kubernetes-starter</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/openshift/ftest-oc-proxy/pom.xml
+++ b/openshift/ftest-oc-proxy/pom.xml
@@ -7,6 +7,7 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
+  <name>Arquillian Cube OpenShift OC Proxy Functional Test</name>
   <artifactId>arquillian-cube-openshift-oc-proxy-ftest</artifactId>
 
   <dependencies>

--- a/openshift/ftest-openshift-assistant/pom.xml
+++ b/openshift/ftest-openshift-assistant/pom.xml
@@ -18,8 +18,7 @@
   <dependencies>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
-      <version>${project.version}</version>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -30,11 +29,6 @@
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/openshift/ftest-openshift-graphene/pom.xml
+++ b/openshift/ftest-openshift-graphene/pom.xml
@@ -30,11 +30,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.jboss.arquillian.graphene</groupId>
       <artifactId>graphene-webdriver</artifactId>
       <version>${version.graphene}</version>
@@ -48,25 +43,25 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.jboss.arquillian.extension</groupId>
+      <artifactId>arquillian-drone-webdriver-depchain</artifactId>
+      <version>${version.arquillian.drone}</version>
+      <type>pom</type>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.assertj</groupId>
       <artifactId>assertj-core</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.extension</groupId>
-      <artifactId>arquillian-drone-webdriver-depchain</artifactId>
-      <version>${version.arquillian.drone}</version>
-      <type>pom</type>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/openshift/ftest-openshift-resources-standalone/pom.xml
+++ b/openshift/ftest-openshift-resources-standalone/pom.xml
@@ -18,8 +18,7 @@
   <dependencies>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
-      <version>${project.version}</version>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -41,11 +40,6 @@
       <groupId>io.fabric8</groupId>
       <artifactId>kubernetes-client</artifactId>
       <version>2.6.3</version>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
     </dependency>
   </dependencies>
 

--- a/openshift/ftest-openshift-restassured/pom.xml
+++ b/openshift/ftest-openshift-restassured/pom.xml
@@ -18,12 +18,7 @@
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/openshift/ftest-openshift-restassured/pom.xml
+++ b/openshift/ftest-openshift-restassured/pom.xml
@@ -7,7 +7,9 @@
   </parent>
   <modelVersion>4.0.0</modelVersion>
 
+  <name>Arquillian Cube OpenShift RestAssured Functional Test</name>
   <artifactId>arquillian-cube-openshift-ftest-restassured</artifactId>
+
   <dependencies>
     <dependency>
       <groupId>org.arquillian.cube</groupId>

--- a/openshift/ftest-standalone/pom.xml
+++ b/openshift/ftest-standalone/pom.xml
@@ -12,13 +12,8 @@
   <artifactId>arquillian-cube-openshift-standalone-ftest</artifactId>
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/openshift/ftest-template-standalone/pom.xml
+++ b/openshift/ftest-template-standalone/pom.xml
@@ -12,13 +12,8 @@
   <artifactId>arquillian-cube-openshift-template-standalone-ftest</artifactId>
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,9 @@
     <module>requirement</module>
     <module>bom</module>
     <module>requirement-spi</module>
+    <module>arquillian-cube-docker-starter</module>
+    <module>arquillian-cube-kubernetes-starter</module>
+    <module>arquillian-cube-openshift-starter</module>
   </modules>
 
   <developers>

--- a/pom.xml
+++ b/pom.xml
@@ -200,6 +200,7 @@
         <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-openshift-starter</artifactId>
         <version>${project.version}</version>
+        <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.arquillian.cube</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -197,6 +197,24 @@
       </dependency>
 
       <dependency>
+        <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-openshift-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-kubernetes-starter</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-docker-starter</artifactId>
+        <version>${project.version}</version>
+        <scope>test</scope>
+      </dependency>
+
+      <dependency>
         <groupId>org.eclipse.jgit</groupId>
         <artifactId>org.eclipse.jgit</artifactId>
         <version>${version.jgit}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -196,24 +196,32 @@
         <version>${project.version}</version>
       </dependency>
 
+      <!-- tag::openshift_starter_dependency[] -->
       <dependency>
         <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-openshift-starter</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
+      <!-- end::openshift_starter_dependency[] -->
+
+      <!-- tag::kubernetes_starter_dependency[] -->
       <dependency>
         <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-kubernetes-starter</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
+      <!-- end::kubernetes_starter_dependency[] -->
+
+      <!-- tag::docker_starter_dependency[] -->
       <dependency>
         <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-docker-starter</artifactId>
         <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
+      <!-- end::docker_starter_dependency[] -->
 
       <dependency>
         <groupId>org.eclipse.jgit</groupId>


### PR DESCRIPTION
#### Short description of what this resolves:
Packages set of commonly used dependencies together in a jar module to be used as a single entity for improving user adoption.

#### Changes proposed in this pull request:

- [x] Adds missing names to existing modules.
- [x] Adds `starter` modules for OpenShift, Kubernetes, and Docker Extensions.
- [x] Update functional tests to contain simplified dependencies.

Fixes #928 
