### PR TITLE
fix(#951): sets plugin to skip publishing ftest artifacts to maven central.

### DIFF
--- a/kubernetes/ftest-kubernetes-assistant/pom.xml
+++ b/kubernetes/ftest-kubernetes-assistant/pom.xml
@@ -36,5 +36,16 @@
     </dependency>
   </dependencies>
 
-
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
 </project>

--- a/openshift/ftest-oc-proxy/pom.xml
+++ b/openshift/ftest-oc-proxy/pom.xml
@@ -31,4 +31,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/openshift/ftest-openshift-assistant/pom.xml
+++ b/openshift/ftest-openshift-assistant/pom.xml
@@ -38,4 +38,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/openshift/ftest-openshift-resources-standalone/pom.xml
+++ b/openshift/ftest-openshift-resources-standalone/pom.xml
@@ -48,4 +48,18 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/openshift/ftest-openshift-restassured/pom.xml
+++ b/openshift/ftest-openshift-restassured/pom.xml
@@ -36,4 +36,17 @@
     </dependency>
   </dependencies>
 
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/openshift/ftest-standalone/pom.xml
+++ b/openshift/ftest-standalone/pom.xml
@@ -37,4 +37,18 @@
       <version>${version.kubernetes_client}</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/openshift/ftest-template-standalone/pom.xml
+++ b/openshift/ftest-template-standalone/pom.xml
@@ -42,4 +42,18 @@
       <version>2.6.3</version>
     </dependency>
   </dependencies>
+
+  <build>
+    <plugins>
+      <!-- This artifact shouldn't be deployed to maven repository -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
 </project>

--- a/requirement-spi/pom.xml
+++ b/requirement-spi/pom.xml
@@ -5,7 +5,7 @@
   <parent>
     <artifactId>arquillian-cube-parent</artifactId>
     <groupId>org.arquillian.cube</groupId>
-    <version>1.12.1-SNAPSHOT</version>
+    <version>1.13.1-SNAPSHOT</version>
   </parent>
   <modelVersion>4.0.0</modelVersion>
 


### PR DESCRIPTION
#### Short description of what this resolves:
Should skip releasing ftests jars to maven central.

#### Changes proposed in this pull request:

- Set `maven-deploy-plugin` in pom.xml for ftest modules.

Fixes #951 
