### PR TITLE
fix(#957): improves cube not to stop container if it's already destroyed

### DIFF
--- a/core/src/main/java/org/arquillian/cube/impl/client/ForceStopDockerContainersShutdownHook.java
+++ b/core/src/main/java/org/arquillian/cube/impl/client/ForceStopDockerContainersShutdownHook.java
@@ -10,16 +10,13 @@ public class ForceStopDockerContainersShutdownHook {
 
     public void attachShutDownHookForceStopDockerContainers(@Observes(precedence = 200) BeforeSuite event,
         final CubeRegistry cubeRegistry) {
-        Runtime.getRuntime().addShutdownHook(new Thread() {
-            @Override
-            public void run() {
-                final List<Cube<?>> cubes = cubeRegistry.getCubes();
-                for (Cube cube : cubes) {
+        Runtime.getRuntime().addShutdownHook(new Thread(() -> {
+            final List<Cube<?>> cubes = cubeRegistry.getCubes();
+            for (Cube cube : cubes) {
 
-                        cube.stop();
-                        cube.destroy();
-                }
+                    cube.stop();
+                    cube.destroy();
             }
-        });
+        }));
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/ReportMetrics.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/metadata/ReportMetrics.java
@@ -40,7 +40,7 @@ public class ReportMetrics implements CanReportMetrics {
     public ReportInSectionBuilder report() {
 
         boolean error = EnumSet.of(Cube.State.START_FAILED, Cube.State.CREATE_FAILED,
-            Cube.State.STOP_FAILED, Cube.State.DESTORY_FAILED)
+            Cube.State.STOP_FAILED, Cube.State.DESTROY_FAILED)
             .contains(dockerCube.state());
 
         final ReportBuilder reportBuilder = Reporter.createReport(DOCKER_CONTAINER_CONFIGURATION)

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/model/DockerCube.java
@@ -49,7 +49,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
 
     private static final Logger log = Logger.getLogger(DockerCube.class.getName());
     private final PortBindings portBindings;
-    private State state = State.DESTROYED;
+    private State state = State.BEFORE_CREATE;
     private String id;
     private Binding binding = null;
     private CubeContainer configuration;
@@ -98,7 +98,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
 
     @Override
     public void create() throws CubeControlException {
-        if (state != State.DESTROYED) {
+        if (state != State.BEFORE_CREATE) {
             return;
         }
         try {
@@ -145,7 +145,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
 
     @Override
     public void stop() throws CubeControlException {
-        if (state == State.STOPPED || state == State.PRE_RUNNING) {
+        if (state == State.STOPPED || state == State.PRE_RUNNING || state == State.DESTROYED) {
             return;
         }
         try {
@@ -191,7 +191,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
             state = State.DESTROYED;
             lifecycle.fire(new AfterDestroy(id));
         } catch (Exception e) {
-            state = State.DESTORY_FAILED;
+            state = State.DESTROY_FAILED;
             throw CubeControlException.failedDestroy(id, e);
         }
     }
@@ -246,7 +246,7 @@ public class DockerCube extends BaseCube<CubeContainer> {
 
     @Override
     public void changeToPreRunning() {
-        if (state != State.DESTROYED && state != State.STARTED) {
+        if (state != State.BEFORE_CREATE && state != State.STARTED) {
             return;
         }
 

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/model/DockerCubeTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/model/DockerCubeTest.java
@@ -112,4 +112,39 @@ public class DockerCubeTest extends AbstractManagerTestBase {
         assertEventFired(BeforeDestroy.class, 1);
         assertEventFired(AfterDestroy.class, 1);
     }
+
+    @Test
+    public void shouldNotFireLifecycleEventsIfTryingToStopAlreadyDestroyedCube() {
+        // given
+        cube.stop();
+        cube.destroy();
+
+        // when
+        cube.stop();
+
+        // then - event count is 1 which is for first cube.stop()
+        assertEventFired(BeforeStop.class, 1);
+        assertEventFired(AfterStop.class, 1);
+    }
+
+    @Test
+    public void shouldNotFireLifecycleEventsIfTryingToStopAlreadyStoppedCube() {
+        // given
+        cube.stop();
+
+        // when
+        cube.stop();
+
+        // then  - event count is 1 which is for first cube.stop()
+        assertEventFired(BeforeStop.class, 1);
+        assertEventFired(AfterStop.class, 1);
+    }
+
+    @Test
+    public void shouldNotFireLifecycleEventsIfTryingToStopPreRunningCube() {
+        cube.changeToPreRunning();
+        cube.stop();
+        assertEventFired(BeforeStop.class, 0);
+        assertEventFired(AfterStop.class, 0);
+    }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -165,7 +165,7 @@ public class BuildablePodCube extends BaseCube<Void> {
             this.state = State.DESTROYED;
             lifecycle.fire(new AfterDestroy(id));
         } catch (Exception e) {
-            this.state = State.DESTORY_FAILED;
+            this.state = State.DESTROY_FAILED;
             throw CubeControlException.failedDestroy(getId(), e);
         }
     }

--- a/spi/src/main/java/org/arquillian/cube/spi/Cube.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/Cube.java
@@ -47,7 +47,7 @@ public interface Cube<T> {
 
     <X extends CubeMetadata> X getMetadata(Class<X> type);
 
-    public enum State {
+    enum State {
         CREATED,
         CREATE_FAILED,
         STARTED,
@@ -55,7 +55,8 @@ public interface Cube<T> {
         STOPPED,
         STOP_FAILED,
         DESTROYED,
-        DESTORY_FAILED,
-        PRE_RUNNING
+        DESTROY_FAILED,
+        PRE_RUNNING,
+        BEFORE_CREATE,
     }
 }


### PR DESCRIPTION

#### Short description of what this resolves:


#### Changes proposed in this pull request:

- Changed default state from `DESTROYED` to `BEFORE_CREATE`
- Now checking state while stopping container


Fixes #957 
