### PR TITLE
fix(836): description to use TCP to connect to Docker Server in the documentation.

### DIFF
--- a/docs/preliminaries.adoc
+++ b/docs/preliminaries.adoc
@@ -7,9 +7,34 @@ To use *Arquillian Cube* you need a _Docker_ daemon running on a computer (it ca
 By default the _Docker_ server uses UNIX sockets for communicating with the _Docker_ client. *Arquillian Cube* will attempt to detect the operating system it is running on and either set _docker-java_ to use UNIX socket on _Linux_ or to <<Boot2Docker>> on _Windows_/_Mac_ as the default URI.
 
 If you want to use TCP/IP to connect to the Docker server, you'll need to make sure that your _Docker_ server is listening on TCP port.
-To allow _Docker_ server to use TCP add the following line to +/etc/default/docker+:
+To allow _Docker_ server to use TCP set the _Docker daemon options_, the exact process for which varies by the way you
+launch the Docker daemon and/or the underlying OS:
 
-+DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"+
+* systemd (Ubuntu, Debian, RHEL 7, CentOS 7, Fedora, Archlinux) — edit docker.service and change the ExecStart value
+
++
+To change the value of an option, ExecStart in this case, do the following:
+
+ $ sudo systemctl edit docker
+
++
+This will create the necessary directory structure under `/etc/systemd/system/docker.service.d` and open an editor
+(using the default editor configured for the user) to the override file. Add the section below into the editor:
+
+ [Service]
+ ExecStart=
+ ExecStart=/usr/bin/dockerd -H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock
+
++
+It was necessary to clear out ExecStart using `ExecStart=` before setting it to the override value. This is only
+required for some options and most options in the configuration file would not need to be cleared like this. Using
+systemctl edit also ensures that the override settings are loaded.
+
+* Ubuntu 12.04 — set DOCKER_OPTS in `/etc/default/docker`
+
+ DOCKER_OPTS="-H tcp://127.0.0.1:2375 -H unix:///var/run/docker.sock"
+
+* OS/X — select Preferences -> Daemon -> Advanced
 
 After restarting the _Docker_ daemon you need to make sure that _Docker_ is up and listening on TCP.
 


### PR DESCRIPTION
#### Short description of what this resolves:
The problem is that in Linux distros running systemd, adding -H tcp://127.0.0.1:2375 to /etc/default/docker does not have the effect it used to.

#### Changes proposed in this pull request:

- Updates the description to use TCP to connect to Docker Server in the documentation.

Fixes #836 
