### PR TITLE
fix(#986): Reuse the same OpenShiftClient instead of instantiating a new one

### DIFF
--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/adapter/OpenShiftAdapterFactory.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/adapter/OpenShiftAdapterFactory.java
@@ -23,6 +23,7 @@
 
 package org.arquillian.cube.openshift.impl.adapter;
 
+import io.fabric8.openshift.clnt.v3_1.NamespacedOpenShiftClient;
 import java.util.ServiceLoader;
 import java.util.logging.Logger;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
@@ -31,12 +32,12 @@ import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public class OpenShiftAdapterFactory {
-    public static OpenShiftAdapter getOpenShiftAdapter(CubeOpenShiftConfiguration configuration) {
+    public static OpenShiftAdapter getOpenShiftAdapter(NamespacedOpenShiftClient client, CubeOpenShiftConfiguration configuration) {
         ServiceLoader<OpenShiftAdapterProvider> adapters = ServiceLoader.load(OpenShiftAdapterProvider.class, OpenShiftAdapterFactory.class.getClassLoader());
         //noinspection LoopStatementThatDoesntLoop
         for (OpenShiftAdapterProvider pp : adapters) {
             Logger.getLogger(OpenShiftAdapterFactory.class.getName()).info(String.format("Using %s to access OpenShift API ...", pp.getClass().getSimpleName()));
-            return pp.create(configuration);
+            return pp.create(client, configuration);
         }
         throw new IllegalStateException("No OpenShiftAdapterProvider found!");
     }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/adapter/OpenShiftAdapterProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/adapter/OpenShiftAdapterProvider.java
@@ -23,11 +23,12 @@
 
 package org.arquillian.cube.openshift.impl.adapter;
 
+import io.fabric8.openshift.clnt.v3_1.NamespacedOpenShiftClient;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
 
 /**
  * @author <a href="mailto:ales.justin@jboss.org">Ales Justin</a>
  */
 public interface OpenShiftAdapterProvider {
-    OpenShiftAdapter create(CubeOpenShiftConfiguration configuration);
+    OpenShiftAdapter create(NamespacedOpenShiftClient namespacedOpenShiftClient, CubeOpenShiftConfiguration configuration);
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/GitServer.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/GitServer.java
@@ -19,14 +19,14 @@ public class GitServer {
     private static final String GIT_SERVICE = "git";
     private static final String GIT_LOCALPORT = "10001";
     private static final String GIT_REMOTEPORT = "8080";
-    private NamespacedOpenShiftClient client;
+    private io.fabric8.openshift.clnt.v3_1.OpenShiftClient client;
     private String namespace;
     private Pod server;
     private PortForwarder forwarder;
     private Config config;
     private Service service;
 
-    public GitServer(NamespacedOpenShiftClient client, Config config, String namespace) {
+    public GitServer(io.fabric8.openshift.clnt.v3_1.OpenShiftClient client, Config config, String namespace) {
         this.client = client;
         this.config = config;
         this.namespace = namespace;

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClient.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClient.java
@@ -37,8 +37,8 @@ public class OpenShiftClient {
     private GitServer gitserver;
     private boolean keepAliveGitServer;
 
-    public OpenShiftClient(Config config, String namespace, boolean keepAliveGitServer) {
-        this.kubernetes = new DefaultOpenShiftClient(config);
+    public OpenShiftClient(io.fabric8.openshift.clnt.v3_1.OpenShiftClient client, Config config, String namespace, boolean keepAliveGitServer) {
+        this.kubernetes = (NamespacedOpenShiftClient) client;
         this.namespace = namespace;
         this.keepAliveGitServer = keepAliveGitServer;
         this.gitserver = new GitServer(this.getClient(), config, namespace);

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClientCreator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClientCreator.java
@@ -1,10 +1,10 @@
 package org.arquillian.cube.openshift.impl.client;
 
-import io.fabric8.kubernetes.api.builder.v3_1.TypedVisitor;
 import io.fabric8.kubernetes.clnt.v3_1.Config;
-import io.fabric8.kubernetes.clnt.v3_1.ConfigBuilder;
+import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.impl.event.AfterStart;
+import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
@@ -14,36 +14,34 @@ import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
 public class OpenShiftClientCreator {
 
     @Inject
+    private Instance<KubernetesClient> kubernetesClientInstance;
+
+    @Inject
     @ApplicationScoped
     private InstanceProducer<OpenShiftClient> openShiftClientProducer;
 
     public void createClient(@Observes AfterStart afterStart, Configuration conf) {
+
         if (!(conf instanceof CubeOpenShiftConfiguration)) {
             return;
         }
-        CubeOpenShiftConfiguration configuration = (CubeOpenShiftConfiguration) conf;
-        System.setProperty("KUBERNETES_TRUST_CERT", "true");
-        // override defaults for master and namespace
-        final Config config = new ConfigBuilder()
-            .withMasterUrl(configuration.getMasterUrl().toString())
-            .withNamespace(configuration.getNamespace())
-            .withTrustCerts(true)
-            .accept(new TypedVisitor<ConfigBuilder>() {
-                @Override
-                public void visit(ConfigBuilder b) {
-                    b.withNoProxy(b.getNoProxy() == null ? new String[0] : b.getNoProxy());
-                }
-            }).build();
 
-        openShiftClientProducer.set(
-            createClient(config, configuration.getNamespace(), configuration.shouldKeepAliveGitServer()));
+        final CubeOpenShiftConfiguration configuration = (CubeOpenShiftConfiguration) conf;
+
+        final KubernetesClient kubernetesClient = kubernetesClientInstance.get();
+        if (kubernetesClient != null && kubernetesClient.isAdaptable(io.fabric8.openshift.clnt.v3_1.OpenShiftClient.class)) {
+            io.fabric8.openshift.clnt.v3_1.OpenShiftClient client = kubernetesClient.adapt(io.fabric8.openshift.clnt.v3_1.OpenShiftClient.class);
+            openShiftClientProducer.set(
+                createClient(client, client.getConfiguration(), client.getNamespace(), configuration.shouldKeepAliveGitServer()));
+
+        }
     }
 
     public void clean(@Observes AfterSuite event, OpenShiftClient client) throws Exception {
         client.shutdown();
     }
 
-    public OpenShiftClient createClient(Config openShiftConfig, String namespace, boolean keepAliveGitServer) {
-        return new OpenShiftClient(openShiftConfig, namespace, keepAliveGitServer);
+    public OpenShiftClient createClient(io.fabric8.openshift.clnt.v3_1.OpenShiftClient client, Config openShiftConfig, String namespace, boolean keepAliveGitServer) {
+        return new OpenShiftClient(client, openShiftConfig, namespace, keepAliveGitServer);
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/fabric8/F8OpenShiftAdapter.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/fabric8/F8OpenShiftAdapter.java
@@ -107,30 +107,6 @@ public class F8OpenShiftAdapter extends AbstractOpenShiftAdapter {
     private final NamespacedOpenShiftClient client;
     private Map<String, KubernetesList> templates = new ConcurrentHashMap<>();
 
-    static OpenShiftConfig toOpenShiftConfig(CubeOpenShiftConfiguration configuration) {
-        OpenShiftConfigBuilder builder = new OpenShiftConfigBuilder()
-            .withMasterUrl(configuration.getKubernetesMaster())
-            .withTrustCerts(configuration.isTrustCerts());
-
-        if (configuration.hasOpenshiftBasicAuth()) {
-            builder
-                .withUsername(configuration.getUsername())
-                .withPassword(configuration.getPassword());
-        }
-
-        return builder.build();
-    }
-
-    static NamespacedOpenShiftClient create(CubeOpenShiftConfiguration configuration) {
-        OpenShiftConfig config = toOpenShiftConfig(configuration);
-        return new DefaultOpenShiftClient(config);
-    }
-
-    public F8OpenShiftAdapter(CubeOpenShiftConfiguration configuration) {
-        super(configuration);
-        this.client = create(configuration);
-    }
-
     public F8OpenShiftAdapter(NamespacedOpenShiftClient client, CubeOpenShiftConfiguration configuration) {
         super(configuration);
         this.client = client;

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/fabric8/F8OpenShiftAdapterProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/fabric8/F8OpenShiftAdapterProvider.java
@@ -23,6 +23,7 @@
 
 package org.arquillian.cube.openshift.impl.fabric8;
 
+import io.fabric8.openshift.clnt.v3_1.NamespacedOpenShiftClient;
 import org.arquillian.cube.openshift.impl.adapter.OpenShiftAdapter;
 import org.arquillian.cube.openshift.impl.adapter.OpenShiftAdapterProvider;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
@@ -33,7 +34,8 @@ import org.kohsuke.MetaInfServices;
  */
 @MetaInfServices(OpenShiftAdapterProvider.class)
 public class F8OpenShiftAdapterProvider implements OpenShiftAdapterProvider {
-    public OpenShiftAdapter create(CubeOpenShiftConfiguration configuration) {
-        return new F8OpenShiftAdapter(configuration);
+    @Override
+    public OpenShiftAdapter create(NamespacedOpenShiftClient namespacedOpenShiftClient, CubeOpenShiftConfiguration configuration) {
+        return new F8OpenShiftAdapter(namespacedOpenShiftClient, configuration);
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Reuse the same OpenShiftClient instead of instantiating a new one

#### Changes proposed in this pull request:

- Uses the OpenShiftClient instance that are injected into Arquillian scope

Fixes #986 
