### PR TITLE
chore(#977): updates logger message to include FMP warning.

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -163,8 +163,8 @@ public class SessionManager implements SessionCreatedListener {
                         resources.addAll(resourceInstaller.install(configUrl));
                     }
                 } else {
-                    log.warn(
-                        "Did not find any kubernetes configuration. If you are using fabric8-maven-plugin, ensure `mvn package fabric8:build` is run first.");
+                    log.warn("Did not find any kubernetes/openshift configuration files. If you are using fabric8-maven-plugin, "
+                        + "ensure mvn package fabric8:resource fabric8:build is run first to generate resources.");
                 }
 
                 List<HasMetadata> resourcesToWait = new ArrayList<>(resources);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -1,39 +1,5 @@
 package org.arquillian.cube.kubernetes.impl;
 
-import static org.arquillian.cube.impl.util.SystemEnvironmentVariables.propertyToEnvironmentVariableName;
-import static org.arquillian.cube.kubernetes.impl.utils.ProcessUtil.runCommand;
-
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.atomic.AtomicReference;
-
-import org.arquillian.cube.impl.util.Strings;
-import org.arquillian.cube.kubernetes.api.AnnotationProvider;
-import org.arquillian.cube.kubernetes.api.Configuration;
-import org.arquillian.cube.kubernetes.api.DependencyResolver;
-import org.arquillian.cube.kubernetes.api.FeedbackProvider;
-import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
-import org.arquillian.cube.kubernetes.api.Logger;
-import org.arquillian.cube.kubernetes.api.NamespaceService;
-import org.arquillian.cube.kubernetes.api.ResourceInstaller;
-import org.arquillian.cube.kubernetes.api.Session;
-import org.arquillian.cube.kubernetes.api.SessionCreatedListener;
-import org.jboss.arquillian.core.spi.Validate;
-import org.xnio.IoUtils;
-
 import io.fabric8.kubernetes.api.model.v3_1.Container;
 import io.fabric8.kubernetes.api.model.v3_1.Endpoints;
 import io.fabric8.kubernetes.api.model.v3_1.Event;
@@ -53,6 +19,38 @@ import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientTimeoutException;
 import io.fabric8.kubernetes.clnt.v3_1.Watch;
 import io.fabric8.kubernetes.clnt.v3_1.Watcher;
 import io.fabric8.kubernetes.clnt.v3_1.dsl.LogWatch;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import org.arquillian.cube.impl.util.Strings;
+import org.arquillian.cube.kubernetes.api.AnnotationProvider;
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.DependencyResolver;
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
+import org.arquillian.cube.kubernetes.api.Logger;
+import org.arquillian.cube.kubernetes.api.NamespaceService;
+import org.arquillian.cube.kubernetes.api.ResourceInstaller;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.arquillian.cube.kubernetes.api.SessionCreatedListener;
+import org.jboss.arquillian.core.spi.Validate;
+import org.xnio.IoUtils;
+
+import static org.arquillian.cube.impl.util.SystemEnvironmentVariables.propertyToEnvironmentVariableName;
+import static org.arquillian.cube.kubernetes.impl.utils.ProcessUtil.runCommand;
 
 public class SessionManager implements SessionCreatedListener {
 
@@ -165,7 +163,8 @@ public class SessionManager implements SessionCreatedListener {
                         resources.addAll(resourceInstaller.install(configUrl));
                     }
                 } else {
-                    log.warn("Did not find any kubernetes configuration.");
+                    log.warn(
+                        "Did not find any kubernetes configuration. If you are using fabric8-maven-plugin, ensure `mvn package fabric8:build` is run first.");
                 }
 
                 List<HasMetadata> resourcesToWait = new ArrayList<>(resources);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -163,8 +163,8 @@ public class SessionManager implements SessionCreatedListener {
                         resources.addAll(resourceInstaller.install(configUrl));
                     }
                 } else {
-                    log.warn("Did not find any kubernetes/openshift configuration files. If you are using fabric8-maven-plugin, "
-                        + "ensure mvn package fabric8:resource fabric8:build is run first to generate resources.");
+                    log.warn("Did not find any kubernetes/openshift configuration files before starting the test execution. If you are using fabric8-maven-plugin, "
+                        + "ensure `mvn package fabric8:resource fabric8:build` is run first to generate the resources.");
                 }
 
                 List<HasMetadata> resourcesToWait = new ArrayList<>(resources);


### PR DESCRIPTION
#### Short description of what this resolves:
Logs warning to run fabric8-maven-plugin first, if FMP used and no Kubernetes resource found.

#### Changes proposed in this pull request:

- Updates logger message.

Fixes #977 
