### PR TITLE
fix(#992): adds all starter dependency in cube-bom

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -81,6 +81,11 @@
       </dependency>
       <dependency>
         <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-docker-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-docker-junit-rule</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -111,6 +116,11 @@
       </dependency>
       <dependency>
         <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-kubernetes-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-kubernetes-reporter</artifactId>
         <version>${project.version}</version>
       </dependency>
@@ -122,6 +132,11 @@
       <dependency>
         <groupId>org.arquillian.cube</groupId>
         <artifactId>arquillian-cube-openshift</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.arquillian.cube</groupId>
+        <artifactId>arquillian-cube-openshift-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/openshift/ftest-istio-openshift/pom.xml
+++ b/openshift/ftest-istio-openshift/pom.xml
@@ -12,13 +12,8 @@
   <artifactId>arquillian-cube-istio-openshift-standalone-ftest</artifactId>
   <dependencies>
     <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/openshift/ftest-oc-proxy/pom.xml
+++ b/openshift/ftest-oc-proxy/pom.xml
@@ -13,17 +13,12 @@
   <dependencies>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-requirement</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-container</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/openshift/ftest-openshift-assistant-template/pom.xml
+++ b/openshift/ftest-openshift-assistant-template/pom.xml
@@ -22,12 +22,7 @@
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>
-      <artifactId>arquillian-cube-openshift</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.jboss.arquillian.junit</groupId>
-      <artifactId>arquillian-junit-standalone</artifactId>
+      <artifactId>arquillian-cube-openshift-starter</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION

#### Changes proposed in this pull request:

- Adds arquillian-cube-*-starter to arquillian-cube-bom
- Changed ftests to use starter dependency 
- corrected dependency in openshift/ftest-oc-proxy/pom.xml


Fixes #992 
