### PR TITLE
fix(#984): reads configuration to initialize K8Client in Kubernetes/Openshift Requirement.

### DIFF
--- a/kubernetes/kubernetes/pom.xml
+++ b/kubernetes/kubernetes/pom.xml
@@ -114,6 +114,10 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.config</groupId>
+      <artifactId>arquillian-config-impl-base</artifactId>
+    </dependency>
 
   </dependencies>
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientConfigBuilder.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientConfigBuilder.java
@@ -1,13 +1,13 @@
-package org.arquillian.cube.kubernetes;
+package org.arquillian.cube.kubernetes.impl;
 
 import io.fabric8.kubernetes.api.builder.v3_1.TypedVisitor;
 import io.fabric8.kubernetes.clnt.v3_1.ConfigBuilder;
 import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.kubernetes.api.Configuration;
 
-public class ClientConfigurator {
+public class ClientConfigBuilder {
 
-    public static ConfigBuilder getConfigBuilder(Configuration config) {
+    public ConfigBuilder configuration(Configuration config) {
         final ConfigBuilder configBuilder = new ConfigBuilder()
             .withNamespace(config.getNamespace())
             .withApiVersion(config.getApiVersion())

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientConfigurator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientConfigurator.java
@@ -1,0 +1,36 @@
+package org.arquillian.cube.kubernetes;
+
+import io.fabric8.kubernetes.api.builder.v3_1.TypedVisitor;
+import io.fabric8.kubernetes.clnt.v3_1.ConfigBuilder;
+import org.arquillian.cube.impl.util.Strings;
+import org.arquillian.cube.kubernetes.api.Configuration;
+
+public class ClientConfigurator {
+
+    public static ConfigBuilder getConfigBuilder(Configuration config) {
+        final ConfigBuilder configBuilder = new ConfigBuilder()
+            .withNamespace(config.getNamespace())
+            .withApiVersion(config.getApiVersion())
+            .withTrustCerts(config.isTrustCerts())
+            .accept(new TypedVisitor<ConfigBuilder>() {
+                @Override
+                public void visit(ConfigBuilder b) {
+                    b.withNoProxy(b.getNoProxy() == null ? new String[0] : b.getNoProxy());
+                }
+            });
+
+        if (Strings.isNotNullOrEmpty(config.getMasterUrl().toString())) {
+            configBuilder.withMasterUrl(config.getMasterUrl().toString());
+        }
+
+        if (Strings.isNotNullOrEmpty(config.getToken())) {
+            configBuilder.withOauthToken(config.getToken());
+        }
+
+        if (Strings.isNotNullOrEmpty(config.getUsername()) && Strings.isNotNullOrEmpty(config.getPassword())) {
+            configBuilder.withUsername(config.getUsername())
+                .withPassword(config.getPassword());
+        }
+        return configBuilder;
+    }
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientCreator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientCreator.java
@@ -15,16 +15,16 @@
  */
 package org.arquillian.cube.kubernetes.impl;
 
-import io.fabric8.kubernetes.api.builder.v3_1.TypedVisitor;
 import io.fabric8.kubernetes.clnt.v3_1.ConfigBuilder;
 import io.fabric8.kubernetes.clnt.v3_1.DefaultKubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
-import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
+
+import static org.arquillian.cube.kubernetes.ClientConfigurator.getConfigBuilder;
 
 /**
  * Creates an instances of the {@link KubernetesClient} when a {@link @Configuration} is available.
@@ -36,31 +36,7 @@ public class ClientCreator {
     private InstanceProducer<KubernetesClient> producer;
 
     public void createClient(@Observes Configuration config) {
-
-        final ConfigBuilder configBuilder = new ConfigBuilder()
-            .withNamespace(config.getNamespace())
-            .withApiVersion(config.getApiVersion())
-            .withTrustCerts(config.isTrustCerts())
-            .accept(new TypedVisitor<ConfigBuilder>() {
-                @Override
-                public void visit(ConfigBuilder b) {
-                    b.withNoProxy(b.getNoProxy() == null ? new String[0] : b.getNoProxy());
-                }
-            });
-
-        if (Strings.isNotNullOrEmpty(config.getMasterUrl().toString())) {
-            configBuilder.withMasterUrl(config.getMasterUrl().toString());
-        }
-
-        if (Strings.isNotNullOrEmpty(config.getToken())) {
-            configBuilder.withOauthToken(config.getToken());
-        }
-
-        if (Strings.isNotNullOrEmpty(config.getUsername()) && Strings.isNotNullOrEmpty(config.getPassword())) {
-            configBuilder.withUsername(config.getUsername())
-                .withPassword(config.getPassword());
-        }
-
+        final ConfigBuilder configBuilder = getConfigBuilder(config);
         producer.set(new DefaultKubernetesClient(configBuilder.build()));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientCreator.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ClientCreator.java
@@ -15,7 +15,7 @@
  */
 package org.arquillian.cube.kubernetes.impl;
 
-import io.fabric8.kubernetes.clnt.v3_1.ConfigBuilder;
+import io.fabric8.kubernetes.clnt.v3_1.Config;
 import io.fabric8.kubernetes.clnt.v3_1.DefaultKubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import org.arquillian.cube.kubernetes.api.Configuration;
@@ -23,8 +23,6 @@ import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
-
-import static org.arquillian.cube.kubernetes.ClientConfigurator.getConfigBuilder;
 
 /**
  * Creates an instances of the {@link KubernetesClient} when a {@link @Configuration} is available.
@@ -36,7 +34,8 @@ public class ClientCreator {
     private InstanceProducer<KubernetesClient> producer;
 
     public void createClient(@Observes Configuration config) {
-        final ConfigBuilder configBuilder = getConfigBuilder(config);
-        producer.set(new DefaultKubernetesClient(configBuilder.build()));
+        final Config buildConfig = new ClientConfigBuilder().configuration(config).build();
+
+        producer.set(new DefaultKubernetesClient(buildConfig));
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationFactory.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationFactory.java
@@ -27,7 +27,7 @@ import static org.arquillian.cube.kubernetes.impl.Constants.PROTOCOL_HANDLERS;
 
 public class DefaultConfigurationFactory<C extends DefaultConfiguration> implements ConfigurationFactory<C> {
 
-    protected static final String KUBERNETES_EXTENSION_NAME = "kubernetes";
+    public static final String KUBERNETES_EXTENSION_NAME = "kubernetes";
 
     protected static void configureProtocolHandlers(Map<String, String> conf) {
         Set<String> handlers = new LinkedHashSet<>();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ExtensionRegistrar.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/ExtensionRegistrar.java
@@ -1,0 +1,20 @@
+package org.arquillian.cube.kubernetes.impl;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar;
+
+public class ExtensionRegistrar {
+
+    private final ConfigurationRegistrar configurationRegistrar = new ConfigurationRegistrar();
+    private final ArquillianDescriptor arquillian = configurationRegistrar.loadConfiguration();
+    private Map<String, String> map = new HashMap<>();
+
+    public DefaultConfiguration loadExtension(List<String> extension) {
+        extension.forEach(ext -> map.putAll(arquillian.extension(ext).getExtensionProperties()));
+        return DefaultConfiguration.fromMap(map);
+    }
+
+}

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
@@ -1,22 +1,20 @@
 package org.arquillian.cube.kubernetes.impl.requirement;
 
-import io.fabric8.kubernetes.clnt.v3_1.Config;
 import io.fabric8.kubernetes.clnt.v3_1.DefaultKubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.utils.URLUtils;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.Collections;
+import java.util.List;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.arquillian.cube.kubernetes.impl.ClientConfigBuilder;
 import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
+import org.arquillian.cube.kubernetes.impl.ExtensionRegistrar;
 import org.arquillian.cube.spi.requirement.Constraint;
 import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
-import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
-import org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar;
 
-import static org.arquillian.cube.kubernetes.ClientConfigurator.getConfigBuilder;
 import static org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory.KUBERNETES_EXTENSION_NAME;
 
 //TODO: The kubernetes client currently doesn't expose a method to do a version check. An issue has been raised, but until its done we do the work here. See https://github.com/fabric8io/kubernetes-client/issues/477.
@@ -24,7 +22,12 @@ public class KubernetesRequirement implements Constraint<RequiresKubernetes> {
 
     @Override
     public void check(RequiresKubernetes context) throws UnsatisfiedRequirementException {
-        KubernetesClient client = new DefaultKubernetesClient(getConfig());
+
+        final List<String> extension = Collections.singletonList(KUBERNETES_EXTENSION_NAME);
+
+        final DefaultConfiguration config = new ExtensionRegistrar().loadExtension(extension);
+
+        KubernetesClient client = new DefaultKubernetesClient(new ClientConfigBuilder().configuration(config).build());
 
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
         Request versionRequest = new Request.Builder()
@@ -42,17 +45,5 @@ public class KubernetesRequirement implements Constraint<RequiresKubernetes> {
             throw new UnsatisfiedRequirementException(
                 "Error while checking kubernetes version: [" + e.getMessage() + "]");
         }
-    }
-
-    private Config getConfig() {
-        final ConfigurationRegistrar configurationRegistrar = new ConfigurationRegistrar();
-        final ArquillianDescriptor arquillian = configurationRegistrar.loadConfiguration();
-
-        Map<String, String> map = new HashMap<>();
-        map.putAll(arquillian.extension(KUBERNETES_EXTENSION_NAME).getExtensionProperties());
-
-        final DefaultConfiguration config = DefaultConfiguration.fromMap(map);
-
-        return getConfigBuilder(config).build();
     }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
@@ -1,21 +1,30 @@
 package org.arquillian.cube.kubernetes.impl.requirement;
 
+import io.fabric8.kubernetes.clnt.v3_1.Config;
 import io.fabric8.kubernetes.clnt.v3_1.DefaultKubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.utils.URLUtils;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
 import org.arquillian.cube.spi.requirement.Constraint;
 import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar;
+
+import static org.arquillian.cube.kubernetes.ClientConfigurator.getConfigBuilder;
+import static org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory.KUBERNETES_EXTENSION_NAME;
 
 //TODO: The kubernetes client currently doesn't expose a method to do a version check. An issue has been raised, but until its done we do the work here. See https://github.com/fabric8io/kubernetes-client/issues/477.
 public class KubernetesRequirement implements Constraint<RequiresKubernetes> {
 
     @Override
     public void check(RequiresKubernetes context) throws UnsatisfiedRequirementException {
-        KubernetesClient client = new DefaultKubernetesClient();
+        KubernetesClient client = new DefaultKubernetesClient(getConfig());
 
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
         Request versionRequest = new Request.Builder()
@@ -33,5 +42,17 @@ public class KubernetesRequirement implements Constraint<RequiresKubernetes> {
             throw new UnsatisfiedRequirementException(
                 "Error while checking kubernetes version: [" + e.getMessage() + "]");
         }
+    }
+
+    private Config getConfig() {
+        final ConfigurationRegistrar configurationRegistrar = new ConfigurationRegistrar();
+        final ArquillianDescriptor arquillian = configurationRegistrar.loadConfiguration();
+
+        Map<String, String> map = new HashMap<>();
+        map.putAll(arquillian.extension(KUBERNETES_EXTENSION_NAME).getExtensionProperties());
+
+        final DefaultConfiguration config = DefaultConfiguration.fromMap(map);
+
+        return getConfigBuilder(config).build();
     }
 }

--- a/openshift/ftest-standalone/src/test/resources/arquillian.xml
+++ b/openshift/ftest-standalone/src/test/resources/arquillian.xml
@@ -6,6 +6,15 @@
 
   <extension qualifier="openshift">
     <property name="env.config.resource.name">hello-openshift.json</property>
+
+    <!-- configuring remote cluster -->
+
+    <!--
+    <property name="namespace.use.existing">existing-namespace</property>
+    <property name="kubernetes.master">https://api.starter-us-east-2.openshift.com</property>
+    <property name="cube.auth.token">token</property>
+    <property name="cube.username">username</property>
+    <property name="cube.password">password</property>-->
   </extension>
 
 </arquillian>

--- a/openshift/ftest-standalone/src/test/resources/arquillian.xml
+++ b/openshift/ftest-standalone/src/test/resources/arquillian.xml
@@ -12,7 +12,9 @@
     <!--
     <property name="namespace.use.existing">existing-namespace</property>
     <property name="kubernetes.master">https://api.starter-us-east-2.openshift.com</property>
+
     <property name="cube.auth.token">token</property>
+    OR
     <property name="cube.username">username</property>
     <property name="cube.password">password</property>-->
   </extension>

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -32,6 +32,7 @@ import org.arquillian.cube.openshift.impl.graphene.location.OpenShiftCustomizabl
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
 import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
+import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentScenarioGenerator;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -81,7 +82,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
         if (Validate.classExists("org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender")
             && doesNotContainStandaloneExtension()) {
             builder.service(AuxiliaryArchiveAppender.class, UtilsArchiveAppender.class);
-            builder.service(DeploymentScenarioGenerator.class, ExternalDeploymentScenarioGenerator.class);
+            builder.override(DeploymentScenarioGenerator.class, AnnotationDeploymentScenarioGenerator.class, ExternalDeploymentScenarioGenerator.class);
             builder.observer(TemplateContainerStarter.class);
             builder.service(ResourceProvider.class, OpenShiftHandleResourceProvider.class);
         }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurationFactory.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurationFactory.java
@@ -27,7 +27,7 @@ import org.jboss.arquillian.core.api.annotation.Inject;
 public class CubeOpenShiftConfigurationFactory extends DefaultConfigurationFactory<CubeOpenShiftConfiguration>
     implements ConfigurationFactory<CubeOpenShiftConfiguration> {
 
-    private static final String OPENSHIFT_EXTENSION_NAME = "openshift";
+    public static final String OPENSHIFT_EXTENSION_NAME = "openshift";
 
     @Inject
     @ApplicationScoped

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
@@ -1,21 +1,31 @@
 package org.arquillian.cube.openshift.impl.requirement;
 
+import io.fabric8.kubernetes.clnt.v3_1.Config;
 import io.fabric8.kubernetes.clnt.v3_1.DefaultKubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
 import io.fabric8.kubernetes.clnt.v3_1.utils.URLUtils;
 import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.Response;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
 import org.arquillian.cube.spi.requirement.Constraint;
 import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
+import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.config.impl.extension.ConfigurationRegistrar;
+
+import static org.arquillian.cube.kubernetes.ClientConfigurator.getConfigBuilder;
+import static org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory.KUBERNETES_EXTENSION_NAME;
+import static org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfigurationFactory.OPENSHIFT_EXTENSION_NAME;
 
 public class OpenshiftRequirement implements Constraint<RequiresOpenshift> {
 
     @Override
     public void check(RequiresOpenshift context) throws UnsatisfiedRequirementException {
-        KubernetesClient client = new DefaultKubernetesClient();
+        KubernetesClient client = new DefaultKubernetesClient(getConfig());
 
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
         Request versionRequest = new Request.Builder()
@@ -34,5 +44,18 @@ public class OpenshiftRequirement implements Constraint<RequiresOpenshift> {
         } catch (IOException e) {
             throw new UnsatisfiedRequirementException("Error while checking Openshift version: [" + e.getMessage() + "]");
         }
+    }
+
+    private Config getConfig() {
+        final ConfigurationRegistrar configurationRegistrar = new ConfigurationRegistrar();
+        final ArquillianDescriptor arquillian = configurationRegistrar.loadConfiguration();
+
+        Map<String, String> map = new HashMap<>();
+        map.putAll(arquillian.extension(KUBERNETES_EXTENSION_NAME).getExtensionProperties());
+        map.putAll(arquillian.extension(OPENSHIFT_EXTENSION_NAME).getExtensionProperties());
+
+        final CubeOpenShiftConfiguration config = CubeOpenShiftConfiguration.fromMap(map);
+
+        return getConfigBuilder(config).build();
     }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   </issueManagement>
 
   <properties>
-    <version.arquillian_core>1.2.0.Final</version.arquillian_core>
+    <version.arquillian_core>1.4.0-SNAPSHOT</version.arquillian_core>
     <version.junit>4.12</version.junit>
     <version.hamcrest>1.3</version.hamcrest>
     <version.docker-java>3.0.14</version.docker-java>

--- a/pom.xml
+++ b/pom.xml
@@ -67,7 +67,7 @@
   </issueManagement>
 
   <properties>
-    <version.arquillian_core>1.4.0-SNAPSHOT</version.arquillian_core>
+    <version.arquillian_core>1.4.0.Final</version.arquillian_core>
     <version.junit>4.12</version.junit>
     <version.hamcrest>1.3</version.hamcrest>
     <version.docker-java>3.0.14</version.docker-java>


### PR DESCRIPTION
#### Short description of what this resolves:
1. Reads extension configuration to initialize K8Client with Remote Cluster in Kubernetes/Openshift Requirement.
2. Fixes IllegalArgumentException due to the addition of multiple org.jboss.shrinkwrap.api.Archive deployments with the same name: DEFAULT.

#### Changes proposed in this pull request:

- reads extension configuration from `Arquillian Descriptor` exposed from [Arquillian Core](https://github.com/arquillian/arquillian-core/pull/165) in Kubernetes and OpenShift Requirement. 
- extracts ConfigBuilder logic to ClientConfigurator class.
- Updates Arquillian Core Version.
- Overrides AnnotationDeploymentScenarioGenerator service with the registered ExternalDeploymentScenarioGenerator service.
 
Fixes  https://github.com/arquillian/arquillian-core/issues/166,  #984 
