### PR TITLE
fix(#983): skip checking existence of namespace if namespace.use.current set.

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -108,6 +108,8 @@ public interface Configuration {
 
     boolean isNamespaceDestroyConfirmationEnabled();
 
+    boolean isNamespaceUseCurrentEnabled();
+
     long getNamespaceDestroyTimeout();
 
     boolean isWaitEnabled();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -49,6 +49,7 @@ public class DefaultConfiguration implements Configuration {
     private final boolean namespaceCleanupEnabled;
     private final long namespaceCleanupTimeout;
     private final boolean namespaceCleanupConfirmationEnabled;
+    private final boolean namespaceUseCurrentEnabled;
 
     private final boolean namespaceDestroyEnabled;
     private final boolean namespaceDestroyConfirmationEnabled;
@@ -73,7 +74,7 @@ public class DefaultConfiguration implements Configuration {
     private String token;
 
     public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables,  URL environmentSetupScriptUrl,
-        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies,
+        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceUseCurrentEnabled,
         boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
         boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled,
         boolean namespaceDestroyConfirmationEnabled, long namespaceDestroyTimeout, boolean waitEnabled, long waitTimeout,
@@ -95,6 +96,7 @@ public class DefaultConfiguration implements Configuration {
         this.namespaceDestroyEnabled = namespaceDestroyEnabled;
         this.namespaceDestroyConfirmationEnabled = namespaceDestroyConfirmationEnabled;
         this.namespaceDestroyTimeout = namespaceDestroyTimeout;
+        this.namespaceUseCurrentEnabled = namespaceUseCurrentEnabled;
         this.waitEnabled = waitEnabled;
         this.waitTimeout = waitTimeout;
         this.waitPollInterval = waitPollInterval;
@@ -149,6 +151,7 @@ public class DefaultConfiguration implements Configuration {
                     getBooleanProperty(NAMESPACE_CLEANUP_CONFIRM_ENABLED, map, false))
                 .withNamespaceCleanupTimeout(
                     getLongProperty(NAMESPACE_CLEANUP_TIMEOUT, map, DEFAULT_NAMESPACE_CLEANUP_TIMEOUT))
+                .withNamespaceUseCurrentEnabled(getBooleanProperty(NAMESPACE_USE_CURRENT, map, false))
 
                 .withNamespaceDestroyEnabled(getBooleanProperty(NAMESPACE_DESTROY_ENABLED, map, shouldDestroyNamespace))
                 .withNamespaceDestroyConfirmationEnabled(
@@ -360,6 +363,11 @@ public class DefaultConfiguration implements Configuration {
     @Override
     public boolean isNamespaceDestroyConfirmationEnabled() {
         return namespaceDestroyConfirmationEnabled;
+    }
+
+    @Override
+    public boolean isNamespaceUseCurrentEnabled() {
+        return namespaceUseCurrentEnabled;
     }
 
     @Override

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
@@ -149,6 +149,9 @@ public class DefaultNamespaceService implements NamespaceService {
 
         @Override
         public Boolean exists(String namespace) {
+            if (configuration.isNamespaceUseCurrentEnabled()) {
+                return true;
+            }
             return client.namespaces().withName(namespace).get() != null;
         }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -76,7 +76,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
     private OpenShiftClient client;
 
     public CubeOpenShiftConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables, URL environmentSetupScriptUrl,
-                                      URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies,
+                                      URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceUseCurrentEnabled,
                                       boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
                                       boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled, long namespaceDestroyTimeout,
                                       boolean namespaceDestroyConfirmationEnabled, boolean waitEnabled, long waitTimeout, long waitPollInterval,
@@ -87,7 +87,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
                                       String token, int routerSniPort, String templateURL, String templateLabels, String templateParameters, boolean templateProcess,
                                       String username, String password, String apiVersion, boolean trustCerts, long startupTimeout, long httpClientTimeout) {
         super(sessionId, masterUrl, namespace, scriptEnvironmentVariables, environmentSetupScriptUrl, environmentTeardownScriptUrl,
-            environmentConfigUrl, environmentDependencies, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
+            environmentConfigUrl, environmentDependencies, namespaceUseCurrentEnabled, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
             namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled,
             namespaceDestroyConfirmationEnabled, namespaceDestroyTimeout, waitEnabled, waitTimeout, waitPollInterval,
             waitForServiceList, ansiLoggerEnabled, environmentInitEnabled, logCopyEnabled, logPath, kubernetesDomain, dockerRegistry, token, username, password, apiVersion, trustCerts);


### PR DESCRIPTION
#### Short description of what this resolves:

If the current namespace is set, then querying `client.getNameSpace()` causes user developer authentication issue.

```
io.fabric8.kubernetes.clnt.v3_1.KubernetesClientException: Failure executing: GET at: https://api.starter-us-east-2.openshift.com/api/v1/namespaces/myproject. Message: Forbidden! User developer/192-168-42-73:8443 doesn't have permission. User "dipakpawar231" cannot get namespaces in the namespace "myproject": User "dipakpawar231" cannot get namespaces in project "myproject".
```
#### Changes proposed in this pull request:

- skip checking existence of namespace if property `namespace.use.current` is set.

Fixes #983 
