### PR TITLE
chore(#981): enables printing k8s/openshift configuration parameters to console.

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
@@ -380,60 +380,60 @@ public class CubeDockerConfiguration {
     }
 
     @Override public String toString() {
-        String SEP = System.getProperty("line.separator");
+        String lineSeparator = System.lineSeparator();
         StringBuilder content = new StringBuilder();
 
-        content.append("CubeDockerConfiguration: ").append(SEP);
+        content.append("CubeDockerConfiguration: ").append(lineSeparator);
         if (dockerServerVersion != null) {
-            content.append("  ").append(DOCKER_VERSION).append(" = ").append(dockerServerVersion).append(SEP);
+            content.append("  ").append(DOCKER_VERSION).append(" = ").append(dockerServerVersion).append(lineSeparator);
         }
         if (dockerServerUri != null) {
-            content.append("  ").append(DOCKER_URI).append(" = ").append(dockerServerUri).append(SEP);
+            content.append("  ").append(DOCKER_URI).append(" = ").append(dockerServerUri).append(lineSeparator);
         }
         if (dockerRegistry != null) {
-            content.append("  ").append(DOCKER_REGISTRY).append(" = ").append(dockerRegistry).append(SEP);
+            content.append("  ").append(DOCKER_REGISTRY).append(" = ").append(dockerRegistry).append(lineSeparator);
         }
         if (boot2DockerPath != null) {
-            content.append("  ").append(BOOT2DOCKER_PATH).append(" = ").append(boot2DockerPath).append(SEP);
+            content.append("  ").append(BOOT2DOCKER_PATH).append(" = ").append(boot2DockerPath).append(lineSeparator);
         }
         if (dockerMachinePath != null) {
-            content.append("  ").append(DOCKER_MACHINE_PATH).append(" = ").append(dockerMachinePath).append(SEP);
+            content.append("  ").append(DOCKER_MACHINE_PATH).append(" = ").append(dockerMachinePath).append(lineSeparator);
         }
         if (machineName != null) {
-            content.append("  ").append(DOCKER_MACHINE_NAME).append(" = ").append(machineName).append(SEP);
+            content.append("  ").append(DOCKER_MACHINE_NAME).append(" = ").append(machineName).append(lineSeparator);
         }
         if (username != null) {
-            content.append("  ").append(USERNAME).append(" = ").append(username).append(SEP);
+            content.append("  ").append(USERNAME).append(" = ").append(username).append(lineSeparator);
         }
         if (password != null) {
-            content.append("  ").append(PASSWORD).append(" = ").append(password).append(SEP);
+            content.append("  ").append(PASSWORD).append(" = ").append(password).append(lineSeparator);
         }
         if (email != null) {
-            content.append("  ").append(EMAIL).append(" = ").append(email).append(SEP);
+            content.append("  ").append(EMAIL).append(" = ").append(email).append(lineSeparator);
         }
         if (certPath != null) {
-            content.append("  ").append(CERT_PATH).append(" = ").append(certPath).append(SEP);
+            content.append("  ").append(CERT_PATH).append(" = ").append(certPath).append(lineSeparator);
         }
 
-        content.append("  ").append(TLS_VERIFY).append(" = ").append(tlsVerify).append(SEP);
+        content.append("  ").append(TLS_VERIFY).append(" = ").append(tlsVerify).append(lineSeparator);
 
         if (dockerServerIp != null) {
-            content.append("  ").append(DOCKER_SERVER_IP).append(" = ").append(dockerServerIp).append(SEP);
+            content.append("  ").append(DOCKER_SERVER_IP).append(" = ").append(dockerServerIp).append(lineSeparator);
         }
         if (definitionFormat != null) {
-            content.append("  ").append(DEFINITION_FORMAT).append(" = ").append(definitionFormat).append(SEP);
+            content.append("  ").append(DEFINITION_FORMAT).append(" = ").append(definitionFormat).append(lineSeparator);
         }
         if (autoStartContainers != null) {
-            content.append("  ").append(AUTO_START_CONTAINERS).append(" = ").append(autoStartContainers).append(SEP);
+            content.append("  ").append(AUTO_START_CONTAINERS).append(" = ").append(autoStartContainers).append(lineSeparator);
         }
 
-        content.append("  ").append(CLEAN).append(" = ").append(clean).append(SEP);
+        content.append("  ").append(CLEAN).append(" = ").append(clean).append(lineSeparator);
 
-        content.append("  ").append(REMOVE_VOLUMES).append(" = ").append(removeVolumes).append(SEP);
+        content.append("  ").append(REMOVE_VOLUMES).append(" = ").append(removeVolumes).append(lineSeparator);
 
         if (dockerContainersContent != null) {
             String output = ConfigUtil.dump(dockerContainersContent);
-            content.append("  ").append(DOCKER_CONTAINERS).append(" = ").append(output).append(SEP);
+            content.append("  ").append(DOCKER_CONTAINERS).append(" = ").append(output).append(lineSeparator);
         }
 
         return content.toString();

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -451,81 +451,81 @@ public class DefaultConfiguration implements Configuration {
     @Override
     public String toString() {
 
-        String SEP = System.getProperty("line.separator");
+        String lineSeparator = System.lineSeparator();
         StringBuilder content = new StringBuilder();
 
-        content.append("CubeKubernetesConfiguration: ").append(SEP);
+        content.append("CubeKubernetesConfiguration: ").append(lineSeparator);
         if (namespace != null) {
-            content.append("  ").append(NAMESPACE).append(" = ").append(namespace).append(SEP);
+            content.append("  ").append(NAMESPACE).append(" = ").append(namespace).append(lineSeparator);
         }
         if (masterUrl != null) {
-            content.append("  ").append(MASTER_URL).append(" = ").append(masterUrl).append(SEP);
+            content.append("  ").append(MASTER_URL).append(" = ").append(masterUrl).append(lineSeparator);
         }
         if (scriptEnvironmentVariables != null) {
-            content.append("  ").append(ENVIRONMENT_SCRIPT_ENV).append(" = ").append(scriptEnvironmentVariables).append(SEP);
+            content.append("  ").append(ENVIRONMENT_SCRIPT_ENV).append(" = ").append(scriptEnvironmentVariables).append(lineSeparator);
         }
         if (environmentSetupScriptUrl != null) {
-            content.append("  ").append(ENVIRONMENT_SETUP_SCRIPT_URL).append(" = ").append(environmentSetupScriptUrl).append(SEP);
+            content.append("  ").append(ENVIRONMENT_SETUP_SCRIPT_URL).append(" = ").append(environmentSetupScriptUrl).append(lineSeparator);
         }
 
         if (environmentTeardownScriptUrl != null) {
-            content.append("  ").append(ENVIRONMENT_TEARDOWN_SCRIPT_URL).append(" = ").append(environmentTeardownScriptUrl).append(SEP);
+            content.append("  ").append(ENVIRONMENT_TEARDOWN_SCRIPT_URL).append(" = ").append(environmentTeardownScriptUrl).append(lineSeparator);
         }
         if (environmentConfigUrl != null) {
-            content.append("  ").append(ENVIRONMENT_CONFIG_URL).append(" = ").append(environmentConfigUrl).append(SEP);
+            content.append("  ").append(ENVIRONMENT_CONFIG_URL).append(" = ").append(environmentConfigUrl).append(lineSeparator);
         }
         if (environmentDependencies != null) {
-            content.append("  ").append(ENVIRONMENT_DEPENDENCIES).append(" = ").append(environmentDependencies).append(SEP);
+            content.append("  ").append(ENVIRONMENT_DEPENDENCIES).append(" = ").append(environmentDependencies).append(lineSeparator);
         }
 
-        content.append("  ").append(NAMESPACE_LAZY_CREATE_ENABLED).append(" = ").append(namespaceLazyCreateEnabled).append(SEP);
+        content.append("  ").append(NAMESPACE_LAZY_CREATE_ENABLED).append(" = ").append(namespaceLazyCreateEnabled).append(lineSeparator);
 
-        content.append("  ").append(NAMESPACE_CLEANUP_ENABLED).append(" = ").append(namespaceCleanupEnabled).append(SEP);
-        content.append("  ").append(NAMESPACE_CLEANUP_TIMEOUT).append(" = ").append(namespaceCleanupTimeout).append(SEP);
-        content.append("  ").append(NAMESPACE_CLEANUP_CONFIRM_ENABLED).append(" = ").append(namespaceCleanupConfirmationEnabled).append(SEP);
+        content.append("  ").append(NAMESPACE_CLEANUP_ENABLED).append(" = ").append(namespaceCleanupEnabled).append(lineSeparator);
+        content.append("  ").append(NAMESPACE_CLEANUP_TIMEOUT).append(" = ").append(namespaceCleanupTimeout).append(lineSeparator);
+        content.append("  ").append(NAMESPACE_CLEANUP_CONFIRM_ENABLED).append(" = ").append(namespaceCleanupConfirmationEnabled).append(lineSeparator);
 
-        content.append("  ").append(NAMESPACE_DESTROY_ENABLED).append(" = ").append(namespaceDestroyEnabled).append(SEP);
-        content.append("  ").append(NAMESPACE_DESTROY_CONFIRM_ENABLED).append(" = ").append(namespaceDestroyConfirmationEnabled).append(SEP);
-        content.append("  ").append(NAMESPACE_DESTROY_TIMEOUT).append(" = ").append(namespaceDestroyTimeout).append(SEP);
+        content.append("  ").append(NAMESPACE_DESTROY_ENABLED).append(" = ").append(namespaceDestroyEnabled).append(lineSeparator);
+        content.append("  ").append(NAMESPACE_DESTROY_CONFIRM_ENABLED).append(" = ").append(namespaceDestroyConfirmationEnabled).append(lineSeparator);
+        content.append("  ").append(NAMESPACE_DESTROY_TIMEOUT).append(" = ").append(namespaceDestroyTimeout).append(lineSeparator);
 
-        content.append("  ").append(WAIT_ENABLED).append(" = ").append(waitEnabled).append(SEP);
-        content.append("  ").append(WAIT_TIMEOUT).append(" = ").append(waitTimeout).append(SEP);
-        content.append("  ").append(WAIT_POLL_INTERVAL).append(" = ").append(waitPollInterval).append(SEP);
+        content.append("  ").append(WAIT_ENABLED).append(" = ").append(waitEnabled).append(lineSeparator);
+        content.append("  ").append(WAIT_TIMEOUT).append(" = ").append(waitTimeout).append(lineSeparator);
+        content.append("  ").append(WAIT_POLL_INTERVAL).append(" = ").append(waitPollInterval).append(lineSeparator);
 
-        content.append("  ").append(ANSI_LOGGER_ENABLED).append(" = ").append(ansiLoggerEnabled).append(SEP);
-        content.append("  ").append(ENVIRONMENT_INIT_ENABLED).append(" = ").append(environmentInitEnabled).append(SEP);
-        content.append("  ").append(LOGS_COPY).append(" = ").append(logCopyEnabled).append(SEP);
+        content.append("  ").append(ANSI_LOGGER_ENABLED).append(" = ").append(ansiLoggerEnabled).append(lineSeparator);
+        content.append("  ").append(ENVIRONMENT_INIT_ENABLED).append(" = ").append(environmentInitEnabled).append(lineSeparator);
+        content.append("  ").append(LOGS_COPY).append(" = ").append(logCopyEnabled).append(lineSeparator);
 
 
         if (waitForServiceList != null) {
-            content.append("  ").append(WAIT_FOR_SERVICE_LIST).append(" = ").append(waitForServiceList).append(SEP);
+            content.append("  ").append(WAIT_FOR_SERVICE_LIST).append(" = ").append(waitForServiceList).append(lineSeparator);
         }
         if (logPath != null) {
-            content.append("  ").append(LOGS_PATH).append(" = ").append(logPath).append(SEP);
+            content.append("  ").append(LOGS_PATH).append(" = ").append(logPath).append(lineSeparator);
         }
         if (kubernetesDomain != null) {
-            content.append("  ").append(KUBERNETES_DOMAIN).append(" = ").append(kubernetesDomain).append(SEP);
+            content.append("  ").append(KUBERNETES_DOMAIN).append(" = ").append(kubernetesDomain).append(lineSeparator);
 
         }
 
         if (dockerRegistry != null) {
-            content.append("  ").append(DOCKER_REGISTY).append(" = ").append(dockerRegistry).append(SEP);
+            content.append("  ").append(DOCKER_REGISTY).append(" = ").append(dockerRegistry).append(lineSeparator);
         }
         if (apiVersion != null) {
-            content.append("  ").append(API_VERSION).append(" = ").append(apiVersion).append(SEP);
+            content.append("  ").append(API_VERSION).append(" = ").append(apiVersion).append(lineSeparator);
         }
 
         if (username != null) {
-            content.append("  ").append(USERNAME).append(" = ").append(username).append(SEP);
+            content.append("  ").append(USERNAME).append(" = ").append(username).append(lineSeparator);
         }
         if (password != null) {
-            content.append("  ").append(PASSWORD).append(" = ").append(password).append(SEP);
+            content.append("  ").append(PASSWORD).append(" = ").append(password).append(lineSeparator);
         }
 
         if (token != null) {
-            content.append("  ").append(AUTH_TOKEN).append(" = ").append(token).append(SEP);
+            content.append("  ").append(AUTH_TOKEN).append(" = ").append(token).append(lineSeparator);
         }
-        content.append("  ").append(TRUST_CERTS).append(" = ").append(trustCerts).append(SEP);
+        content.append("  ").append(TRUST_CERTS).append(" = ").append(trustCerts).append(lineSeparator);
 
         return content.toString();
     }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -447,4 +447,86 @@ public class DefaultConfiguration implements Configuration {
     protected void setToken(String token) {
         this.token = token;
     }
+
+    @Override
+    public String toString() {
+
+        String SEP = System.getProperty("line.separator");
+        StringBuilder content = new StringBuilder();
+
+        content.append("CubeKubernetesConfiguration: ").append(SEP);
+        if (namespace != null) {
+            content.append("  ").append(NAMESPACE).append(" = ").append(namespace).append(SEP);
+        }
+        if (masterUrl != null) {
+            content.append("  ").append(MASTER_URL).append(" = ").append(masterUrl).append(SEP);
+        }
+        if (scriptEnvironmentVariables != null) {
+            content.append("  ").append(ENVIRONMENT_SCRIPT_ENV).append(" = ").append(scriptEnvironmentVariables).append(SEP);
+        }
+        if (environmentSetupScriptUrl != null) {
+            content.append("  ").append(ENVIRONMENT_SETUP_SCRIPT_URL).append(" = ").append(environmentSetupScriptUrl).append(SEP);
+        }
+
+        if (environmentTeardownScriptUrl != null) {
+            content.append("  ").append(ENVIRONMENT_TEARDOWN_SCRIPT_URL).append(" = ").append(environmentTeardownScriptUrl).append(SEP);
+        }
+        if (environmentConfigUrl != null) {
+            content.append("  ").append(ENVIRONMENT_CONFIG_URL).append(" = ").append(environmentConfigUrl).append(SEP);
+        }
+        if (environmentDependencies != null) {
+            content.append("  ").append(ENVIRONMENT_DEPENDENCIES).append(" = ").append(environmentDependencies).append(SEP);
+        }
+
+        content.append("  ").append(NAMESPACE_LAZY_CREATE_ENABLED).append(" = ").append(namespaceLazyCreateEnabled).append(SEP);
+
+        content.append("  ").append(NAMESPACE_CLEANUP_ENABLED).append(" = ").append(namespaceCleanupEnabled).append(SEP);
+        content.append("  ").append(NAMESPACE_CLEANUP_TIMEOUT).append(" = ").append(namespaceCleanupTimeout).append(SEP);
+        content.append("  ").append(NAMESPACE_CLEANUP_CONFIRM_ENABLED).append(" = ").append(namespaceCleanupConfirmationEnabled).append(SEP);
+
+        content.append("  ").append(NAMESPACE_DESTROY_ENABLED).append(" = ").append(namespaceDestroyEnabled).append(SEP);
+        content.append("  ").append(NAMESPACE_DESTROY_CONFIRM_ENABLED).append(" = ").append(namespaceDestroyConfirmationEnabled).append(SEP);
+        content.append("  ").append(NAMESPACE_DESTROY_TIMEOUT).append(" = ").append(namespaceDestroyTimeout).append(SEP);
+
+        content.append("  ").append(WAIT_ENABLED).append(" = ").append(waitEnabled).append(SEP);
+        content.append("  ").append(WAIT_TIMEOUT).append(" = ").append(waitTimeout).append(SEP);
+        content.append("  ").append(WAIT_POLL_INTERVAL).append(" = ").append(waitPollInterval).append(SEP);
+
+        content.append("  ").append(ANSI_LOGGER_ENABLED).append(" = ").append(ansiLoggerEnabled).append(SEP);
+        content.append("  ").append(ENVIRONMENT_INIT_ENABLED).append(" = ").append(environmentInitEnabled).append(SEP);
+        content.append("  ").append(LOGS_COPY).append(" = ").append(logCopyEnabled).append(SEP);
+
+
+        if (waitForServiceList != null) {
+            content.append("  ").append(WAIT_FOR_SERVICE_LIST).append(" = ").append(waitForServiceList).append(SEP);
+        }
+        if (logPath != null) {
+            content.append("  ").append(LOGS_PATH).append(" = ").append(logPath).append(SEP);
+        }
+        if (kubernetesDomain != null) {
+            content.append("  ").append(KUBERNETES_DOMAIN).append(" = ").append(kubernetesDomain).append(SEP);
+
+        }
+
+        if (dockerRegistry != null) {
+            content.append("  ").append(DOCKER_REGISTY).append(" = ").append(dockerRegistry).append(SEP);
+        }
+        if (apiVersion != null) {
+            content.append("  ").append(API_VERSION).append(" = ").append(apiVersion).append(SEP);
+        }
+
+        if (username != null) {
+            content.append("  ").append(USERNAME).append(" = ").append(username).append(SEP);
+        }
+        if (password != null) {
+            content.append("  ").append(PASSWORD).append(" = ").append(password).append(SEP);
+        }
+
+        if (token != null) {
+            content.append("  ").append(AUTH_TOKEN).append(" = ").append(token).append(SEP);
+        }
+        content.append("  ").append(TRUST_CERTS).append(" = ").append(trustCerts).append(SEP);
+
+        return content.toString();
+    }
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationFactory.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationFactory.java
@@ -41,6 +41,8 @@ public class DefaultConfigurationFactory<C extends DefaultConfiguration> impleme
     public C create(ArquillianDescriptor arquillian) {
         Map<String, String> config = arquillian.extension(KUBERNETES_EXTENSION_NAME).getExtensionProperties();
         configureProtocolHandlers(config);
-        return (C) DefaultConfiguration.fromMap(config);
+        final DefaultConfiguration configuration = DefaultConfiguration.fromMap(config);
+        System.out.println(configuration);
+        return (C)configuration;
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -339,130 +339,59 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
     @Override
     public String toString() {
 
-        String SEP = System.getProperty("line.separator");
+        String lineSeparator = System.lineSeparator();
         StringBuilder content = new StringBuilder();
 
-        content.append("CubeOpenShiftConfiguration: ").append(SEP);
+        content.append(super.toString()).append(lineSeparator);
 
-        if (getNamespace() != null) {
-            content.append("  ").append(NAMESPACE).append(" = ").append(getNamespace()).append(SEP);
-        }
-        if (getMasterUrl() != null) {
-            content.append("  ").append(MASTER_URL).append(" = ").append(getMasterUrl()).append(SEP);
-        }
-        if (getScriptEnvironmentVariables() != null) {
-            content.append("  ").append(ENVIRONMENT_SCRIPT_ENV).append(" = ").append(getScriptEnvironmentVariables()).append(SEP);
-        }
-        if (getEnvironmentSetupScriptUrl() != null) {
-            content.append("  ").append(ENVIRONMENT_SETUP_SCRIPT_URL).append(" = ").append(getEnvironmentSetupScriptUrl()).append(SEP);
-        }
+        content.append("CubeOpenShiftConfiguration: ").append(lineSeparator);
 
-        if (getEnvironmentTeardownScriptUrl() != null) {
-            content.append("  ").append(ENVIRONMENT_TEARDOWN_SCRIPT_URL).append(" = ").append(getEnvironmentTeardownScriptUrl()).append(SEP);
-        }
-        if (getEnvironmentConfigUrl() != null) {
-            content.append("  ").append(ENVIRONMENT_CONFIG_URL).append(" = ").append(getEnvironmentConfigUrl()).append(SEP);
-        }
-        if (getEnvironmentDependencies() != null) {
-            content.append("  ").append(ENVIRONMENT_DEPENDENCIES).append(" = ").append(getEnvironmentDependencies()).append(SEP);
-        }
-
-        content.append("  ").append(NAMESPACE_LAZY_CREATE_ENABLED).append(" = ").append(isNamespaceLazyCreateEnabled()).append(SEP);
-
-        content.append("  ").append(NAMESPACE_CLEANUP_ENABLED).append(" = ").append(isNamespaceCleanupEnabled()).append(SEP);
-        content.append("  ").append(NAMESPACE_CLEANUP_TIMEOUT).append(" = ").append(getNamespaceCleanupTimeout()).append(SEP);
-        content.append("  ").append(NAMESPACE_CLEANUP_CONFIRM_ENABLED).append(" = ").append(isNamespaceCleanupConfirmationEnabled()).append(SEP);
-
-        content.append("  ").append(NAMESPACE_DESTROY_ENABLED).append(" = ").append(isNamespaceDestroyEnabled()).append(SEP);
-        content.append("  ").append(NAMESPACE_DESTROY_CONFIRM_ENABLED).append(" = ").append(isNamespaceDestroyConfirmationEnabled()).append(SEP);
-        content.append("  ").append(NAMESPACE_DESTROY_TIMEOUT).append(" = ").append(getNamespaceDestroyTimeout()).append(SEP);
-
-        content.append("  ").append(WAIT_ENABLED).append(" = ").append(isWaitEnabled()).append(SEP);
-        content.append("  ").append(WAIT_TIMEOUT).append(" = ").append(getWaitTimeout()).append(SEP);
-        content.append("  ").append(WAIT_POLL_INTERVAL).append(" = ").append(getWaitPollInterval()).append(SEP);
-
-        content.append("  ").append(ANSI_LOGGER_ENABLED).append(" = ").append(isAnsiLoggerEnabled()).append(SEP);
-        content.append("  ").append(ENVIRONMENT_INIT_ENABLED).append(" = ").append(isEnvironmentInitEnabled()).append(SEP);
-        content.append("  ").append(LOGS_COPY).append(" = ").append(isLogCopyEnabled()).append(SEP);
-
-
-        if (getWaitForServiceList() != null) {
-            content.append("  ").append(WAIT_FOR_SERVICE_LIST).append(" = ").append(getWaitForServiceList()).append(SEP);
-        }
-        if (getLogPath() != null) {
-            content.append("  ").append(LOGS_PATH).append(" = ").append(getLogPath()).append(SEP);
-        }
-        if (getKubernetesDomain() != null) {
-            content.append("  ").append(KUBERNETES_DOMAIN).append(" = ").append(getKubernetesDomain()).append(SEP);
-
-        }
-
-        if (getDockerRegistry() != null) {
-            content.append("  ").append(DOCKER_REGISTY).append(" = ").append(getDockerRegistry()).append(SEP);
-        }
-        if (getApiVersion() != null) {
-            content.append("  ").append(API_VERSION).append(" = ").append(getApiVersion()).append(SEP);
-        }
-
-        if (getUsername() != null) {
-            content.append("  ").append(USERNAME).append(" = ").append(getUsername()).append(SEP);
-        }
-        if (getPassword() != null) {
-            content.append("  ").append(PASSWORD).append(" = ").append(getPassword()).append(SEP);
-        }
-
-        if (getToken() != null) {
-            content.append("  ").append(AUTH_TOKEN).append(" = ").append(getToken()).append(SEP);
-        }
-
-        content.append("  ").append(TRUST_CERTS).append(" = ").append(isTrustCerts()).append(SEP);
-
-        content.append("  ").append(KEEP_ALIVE_GIT_SERVER).append(" = ").append(keepAliveGitServer).append(SEP);
+        content.append("  ").append(KEEP_ALIVE_GIT_SERVER).append(" = ").append(keepAliveGitServer).append(lineSeparator);
 
         if (definitions != null) {
-            content.append("  ").append(DEFINITIONS).append(" = ").append(definitions).append(SEP);
+            content.append("  ").append(DEFINITIONS).append(" = ").append(definitions).append(lineSeparator);
         }
         if (definitionsFile != null) {
-            content.append("  ").append(DEFINITIONS_FILE).append(" = ").append(definitionsFile).append(SEP);
+            content.append("  ").append(DEFINITIONS_FILE).append(" = ").append(definitionsFile).append(lineSeparator);
         }
 
         if (autoStartContainers != null) {
-            content.append("  ").append(AUTO_START_CONTAINERS).append(" = ").append(Arrays.toString(autoStartContainers)).append(SEP);
+            content.append("  ").append(AUTO_START_CONTAINERS).append(" = ").append(Arrays.toString(autoStartContainers)).append(lineSeparator);
         }
 
         if (proxiedContainerPorts != null) {
-            content.append("  ").append(PROXIED_CONTAINER_PORTS).append(" = ").append(proxiedContainerPorts).append(SEP);
+            content.append("  ").append(PROXIED_CONTAINER_PORTS).append(" = ").append(proxiedContainerPorts).append(lineSeparator);
         }
 
         if (portForwardBindAddress != null) {
-            content.append("  ").append(PORT_FORWARDER_BIND_ADDRESS).append(" = ").append(portForwardBindAddress).append(SEP);
+            content.append("  ").append(PORT_FORWARDER_BIND_ADDRESS).append(" = ").append(portForwardBindAddress).append(lineSeparator);
         }
 
         if (routerHost != null) {
-            content.append("  ").append(ROUTER_HOST).append(" = ").append(routerHost).append(SEP);
+            content.append("  ").append(ROUTER_HOST).append(" = ").append(routerHost).append(lineSeparator);
         }
 
-        content.append("  ").append(OPENSHIFT_ROUTER_HTTP_PORT).append(" = ").append(openshiftRouterHttpPort).append(SEP);
+        content.append("  ").append(OPENSHIFT_ROUTER_HTTP_PORT).append(" = ").append(openshiftRouterHttpPort).append(lineSeparator);
 
-        content.append("  ").append(OPENSHIFT_ROUTER_HTTPS_PORT).append(" = ").append(openshiftRouterHttpsPort).append(SEP);
+        content.append("  ").append(OPENSHIFT_ROUTER_HTTPS_PORT).append(" = ").append(openshiftRouterHttpsPort).append(lineSeparator);
 
-        content.append("  ").append(ENABLE_IMAGE_STREAM_DETECTION).append(" = ").append(enableImageStreamDetection).append(SEP);
+        content.append("  ").append(ENABLE_IMAGE_STREAM_DETECTION).append(" = ").append(enableImageStreamDetection).append(lineSeparator);
 
-        content.append("  ").append(ROUTER_SNI_PORT).append(" = ").append(routerSniPort).append(SEP);
+        content.append("  ").append(ROUTER_SNI_PORT).append(" = ").append(routerSniPort).append(lineSeparator);
 
         if (templateURL != null) {
-            content.append("  ").append(TEMPLATE_URL).append(" = ").append(templateURL).append(SEP);
+            content.append("  ").append(TEMPLATE_URL).append(" = ").append(templateURL).append(lineSeparator);
         }
         if (templateLabels != null) {
-            content.append("  ").append(TEMPLATE_LABELS).append(" = ").append(templateLabels).append(SEP);
+            content.append("  ").append(TEMPLATE_LABELS).append(" = ").append(templateLabels).append(lineSeparator);
         }
         if (templateParameters != null) {
-            content.append("  ").append(TEMPLATE_PARAMETERS).append(" = ").append(templateParameters).append(SEP);
+            content.append("  ").append(TEMPLATE_PARAMETERS).append(" = ").append(templateParameters).append(lineSeparator);
         }
 
-        content.append("  ").append(TEMPLATE_PROCESS).append(" = ").append(templateProcess).append(SEP);
-        content.append("  ").append(STARTUP_TIMEOUT).append(" = ").append(startupTimeout).append(SEP);
-        content.append("  ").append(HTTP_CLIENT_TIMEOUT).append(" = ").append(httpClientTimeout).append(SEP);
+        content.append("  ").append(TEMPLATE_PROCESS).append(" = ").append(templateProcess).append(lineSeparator);
+        content.append("  ").append(STARTUP_TIMEOUT).append(" = ").append(startupTimeout).append(lineSeparator);
+        content.append("  ").append(HTTP_CLIENT_TIMEOUT).append(" = ").append(httpClientTimeout).append(lineSeparator);
 
         return content.toString();
     }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -6,6 +6,7 @@ import io.sundr.builder.annotations.Buildable;
 import io.sundr.builder.annotations.BuildableReference;
 import java.io.Serializable;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -333,5 +334,136 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
 
     public OpenShiftClient getClient() {
         return client;
+    }
+
+    @Override
+    public String toString() {
+
+        String SEP = System.getProperty("line.separator");
+        StringBuilder content = new StringBuilder();
+
+        content.append("CubeOpenShiftConfiguration: ").append(SEP);
+
+        if (getNamespace() != null) {
+            content.append("  ").append(NAMESPACE).append(" = ").append(getNamespace()).append(SEP);
+        }
+        if (getMasterUrl() != null) {
+            content.append("  ").append(MASTER_URL).append(" = ").append(getMasterUrl()).append(SEP);
+        }
+        if (getScriptEnvironmentVariables() != null) {
+            content.append("  ").append(ENVIRONMENT_SCRIPT_ENV).append(" = ").append(getScriptEnvironmentVariables()).append(SEP);
+        }
+        if (getEnvironmentSetupScriptUrl() != null) {
+            content.append("  ").append(ENVIRONMENT_SETUP_SCRIPT_URL).append(" = ").append(getEnvironmentSetupScriptUrl()).append(SEP);
+        }
+
+        if (getEnvironmentTeardownScriptUrl() != null) {
+            content.append("  ").append(ENVIRONMENT_TEARDOWN_SCRIPT_URL).append(" = ").append(getEnvironmentTeardownScriptUrl()).append(SEP);
+        }
+        if (getEnvironmentConfigUrl() != null) {
+            content.append("  ").append(ENVIRONMENT_CONFIG_URL).append(" = ").append(getEnvironmentConfigUrl()).append(SEP);
+        }
+        if (getEnvironmentDependencies() != null) {
+            content.append("  ").append(ENVIRONMENT_DEPENDENCIES).append(" = ").append(getEnvironmentDependencies()).append(SEP);
+        }
+
+        content.append("  ").append(NAMESPACE_LAZY_CREATE_ENABLED).append(" = ").append(isNamespaceLazyCreateEnabled()).append(SEP);
+
+        content.append("  ").append(NAMESPACE_CLEANUP_ENABLED).append(" = ").append(isNamespaceCleanupEnabled()).append(SEP);
+        content.append("  ").append(NAMESPACE_CLEANUP_TIMEOUT).append(" = ").append(getNamespaceCleanupTimeout()).append(SEP);
+        content.append("  ").append(NAMESPACE_CLEANUP_CONFIRM_ENABLED).append(" = ").append(isNamespaceCleanupConfirmationEnabled()).append(SEP);
+
+        content.append("  ").append(NAMESPACE_DESTROY_ENABLED).append(" = ").append(isNamespaceDestroyEnabled()).append(SEP);
+        content.append("  ").append(NAMESPACE_DESTROY_CONFIRM_ENABLED).append(" = ").append(isNamespaceDestroyConfirmationEnabled()).append(SEP);
+        content.append("  ").append(NAMESPACE_DESTROY_TIMEOUT).append(" = ").append(getNamespaceDestroyTimeout()).append(SEP);
+
+        content.append("  ").append(WAIT_ENABLED).append(" = ").append(isWaitEnabled()).append(SEP);
+        content.append("  ").append(WAIT_TIMEOUT).append(" = ").append(getWaitTimeout()).append(SEP);
+        content.append("  ").append(WAIT_POLL_INTERVAL).append(" = ").append(getWaitPollInterval()).append(SEP);
+
+        content.append("  ").append(ANSI_LOGGER_ENABLED).append(" = ").append(isAnsiLoggerEnabled()).append(SEP);
+        content.append("  ").append(ENVIRONMENT_INIT_ENABLED).append(" = ").append(isEnvironmentInitEnabled()).append(SEP);
+        content.append("  ").append(LOGS_COPY).append(" = ").append(isLogCopyEnabled()).append(SEP);
+
+
+        if (getWaitForServiceList() != null) {
+            content.append("  ").append(WAIT_FOR_SERVICE_LIST).append(" = ").append(getWaitForServiceList()).append(SEP);
+        }
+        if (getLogPath() != null) {
+            content.append("  ").append(LOGS_PATH).append(" = ").append(getLogPath()).append(SEP);
+        }
+        if (getKubernetesDomain() != null) {
+            content.append("  ").append(KUBERNETES_DOMAIN).append(" = ").append(getKubernetesDomain()).append(SEP);
+
+        }
+
+        if (getDockerRegistry() != null) {
+            content.append("  ").append(DOCKER_REGISTY).append(" = ").append(getDockerRegistry()).append(SEP);
+        }
+        if (getApiVersion() != null) {
+            content.append("  ").append(API_VERSION).append(" = ").append(getApiVersion()).append(SEP);
+        }
+
+        if (getUsername() != null) {
+            content.append("  ").append(USERNAME).append(" = ").append(getUsername()).append(SEP);
+        }
+        if (getPassword() != null) {
+            content.append("  ").append(PASSWORD).append(" = ").append(getPassword()).append(SEP);
+        }
+
+        if (getToken() != null) {
+            content.append("  ").append(AUTH_TOKEN).append(" = ").append(getToken()).append(SEP);
+        }
+
+        content.append("  ").append(TRUST_CERTS).append(" = ").append(isTrustCerts()).append(SEP);
+
+        content.append("  ").append(KEEP_ALIVE_GIT_SERVER).append(" = ").append(keepAliveGitServer).append(SEP);
+
+        if (definitions != null) {
+            content.append("  ").append(DEFINITIONS).append(" = ").append(definitions).append(SEP);
+        }
+        if (definitionsFile != null) {
+            content.append("  ").append(DEFINITIONS_FILE).append(" = ").append(definitionsFile).append(SEP);
+        }
+
+        if (autoStartContainers != null) {
+            content.append("  ").append(AUTO_START_CONTAINERS).append(" = ").append(Arrays.toString(autoStartContainers)).append(SEP);
+        }
+
+        if (proxiedContainerPorts != null) {
+            content.append("  ").append(PROXIED_CONTAINER_PORTS).append(" = ").append(proxiedContainerPorts).append(SEP);
+        }
+
+        if (portForwardBindAddress != null) {
+            content.append("  ").append(PORT_FORWARDER_BIND_ADDRESS).append(" = ").append(portForwardBindAddress).append(SEP);
+        }
+
+        if (routerHost != null) {
+            content.append("  ").append(ROUTER_HOST).append(" = ").append(routerHost).append(SEP);
+        }
+
+        content.append("  ").append(OPENSHIFT_ROUTER_HTTP_PORT).append(" = ").append(openshiftRouterHttpPort).append(SEP);
+
+        content.append("  ").append(OPENSHIFT_ROUTER_HTTPS_PORT).append(" = ").append(openshiftRouterHttpsPort).append(SEP);
+
+        content.append("  ").append(ENABLE_IMAGE_STREAM_DETECTION).append(" = ").append(enableImageStreamDetection).append(SEP);
+
+        content.append("  ").append(ROUTER_SNI_PORT).append(" = ").append(routerSniPort).append(SEP);
+
+        if (templateURL != null) {
+            content.append("  ").append(TEMPLATE_URL).append(" = ").append(templateURL).append(SEP);
+        }
+        if (templateLabels != null) {
+            content.append("  ").append(TEMPLATE_LABELS).append(" = ").append(templateLabels).append(SEP);
+        }
+        if (templateParameters != null) {
+            content.append("  ").append(TEMPLATE_PARAMETERS).append(" = ").append(templateParameters).append(SEP);
+        }
+
+        content.append("  ").append(TEMPLATE_PROCESS).append(" = ").append(templateProcess).append(SEP);
+        content.append("  ").append(STARTUP_TIMEOUT).append(" = ").append(startupTimeout).append(SEP);
+        content.append("  ").append(HTTP_CLIENT_TIMEOUT).append(" = ").append(httpClientTimeout).append(SEP);
+
+        return content.toString();
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurationFactory.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurationFactory.java
@@ -32,6 +32,9 @@ public class CubeOpenShiftConfigurationFactory extends DefaultConfigurationFacto
         config.putAll(arquillian.extension(OPENSHIFT_EXTENSION_NAME).getExtensionProperties());
 
         configureProtocolHandlers(config);
-        return CubeOpenShiftConfiguration.fromMap(config);
+
+        final CubeOpenShiftConfiguration openShiftConfiguration = CubeOpenShiftConfiguration.fromMap(config);
+        System.out.println(openShiftConfiguration);
+        return openShiftConfiguration;
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Enabling printing Kubernetes and OpenShift configuration parameters in Console.

#### Changes proposed in this pull request:

- defines toString() methods for Kubernetes and OpenShift Configuration classes.
- makes calls to Kubernetes and OpenShift Configuration classes' toString() methods from respective configuration factory classes.


Fixes #981 
