### PR TITLE
Docker health

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
@@ -37,6 +37,8 @@ public class AwaitStrategyFactory {
                         return new SleepingAwaitStrategy(cube, await);
                     case HttpAwaitStrategy.TAG:
                         return new HttpAwaitStrategy(cube, dockerClientExecutor, await);
+                    case DockerHealthAwaitStrategy.TAG:
+                        return new DockerHealthAwaitStrategy(cube, dockerClientExecutor, await);
                     default:
                         return new CustomAwaitStrategyInstantiator(cube, dockerClientExecutor, await);
                 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/DockerHealthAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/DockerHealthAwaitStrategy.java
@@ -1,0 +1,113 @@
+package org.arquillian.cube.docker.impl.await;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.api.command.InspectExecResponse;
+import com.github.dockerjava.api.exception.NotFoundException;
+import com.github.dockerjava.core.command.ExecStartResultCallback;
+import java.io.ByteArrayOutputStream;
+import java.util.logging.Logger;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.util.Ping;
+import org.arquillian.cube.docker.impl.util.PingCommand;
+import org.arquillian.cube.spi.Cube;
+
+public class DockerHealthAwaitStrategy extends SleepingAwaitStrategyBase {
+
+    private static final Logger log = Logger.getLogger(DockerHealthAwaitStrategy.class.getName());
+
+    public static final String TAG = "docker_health";
+
+    private static final int DEFAULT_POLL_ITERATIONS = 10;
+
+    private int pollIterations;
+
+    private Cube<?> cube;
+    private DockerClient client;
+    private String[] command;
+
+    public DockerHealthAwaitStrategy(Cube<?> cube, DockerClientExecutor dockerClientExecutor, Await params) {
+        super(params.getSleepPollingTime());
+        this.cube = cube;
+        this.client = dockerClientExecutor.getDockerClient();
+
+        this.pollIterations = getIterations(params);
+        this.command = params.getCommand();
+    }
+
+    @Override
+    public boolean await() {
+        PingCommand pingCommand;
+        if (command != null) {
+            pingCommand = new ExecPingCommand();
+        } else {
+            pingCommand = new DockerHealthPingCommand();
+        }
+        return Ping.ping(pollIterations, getSleepTime(), getTimeUnit(), pingCommand);
+    }
+
+    private int getIterations(Await params) {
+        if (params.getIterations() != null) {
+            return params.getIterations();
+        } else {
+            return DEFAULT_POLL_ITERATIONS;
+        }
+    }
+
+    private class ExecPingCommand implements PingCommand {
+        @Override
+        public boolean call() {
+            try {
+                final String execID = client
+                    .execCreateCmd(cube.getId())
+                    .withCmd(command)
+                    .withAttachStdout(true)
+                    .withAttachStderr(true)
+                    .exec()
+                    .getId();
+
+                final ByteArrayOutputStream stdout = new ByteArrayOutputStream();
+                final ByteArrayOutputStream stderr = new ByteArrayOutputStream();
+                final ExecStartResultCallback execStartResultCallback = new ExecStartResultCallback(stdout, stderr);
+                client
+                    .execStartCmd(cube.getId())
+                    .withTty(true)
+                    .withExecId(execID)
+                    .withDetach(false)
+                    .exec(execStartResultCallback).awaitCompletion();
+
+                final InspectExecResponse inspectExecResponse = client
+                    .inspectExecCmd(execID)
+                    .exec();
+
+                log.info(() -> String.format(
+                    "docker exec %s, exit status:%d, stdout:\n%s\n, stderr: \n%s\n",
+                    String.join(" ", command),
+                    inspectExecResponse.getExitCode(),
+                    stdout.toString(),
+                    stderr.toString()));
+
+                return inspectExecResponse.getExitCode() == 0;
+            } catch (InterruptedException e) {
+                return false;
+            }
+        }
+    }
+
+    private class DockerHealthPingCommand implements PingCommand {
+        @Override
+        public boolean call() {
+            try {
+                return client
+                    .inspectContainerCmd(cube.getId())
+                    .exec()
+                    .getState()
+                    .getHealth()
+                    .getStatus()
+                    .equals("healthy");
+            } catch (NotFoundException e) {
+                return false;
+            }
+        }
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/Await.java
@@ -36,6 +36,9 @@ public class Await {
     //waitforit and log
     private Integer timeout = 15;
 
+    // docker exec
+    private String[] command;
+
     public Await() {
     }
 
@@ -166,4 +169,8 @@ public class Await {
     public void setTimeout(Integer timeout) {
         this.timeout = timeout;
     }
+
+    public String[] getCommand() { return command;}
+
+    public void setCommand(String[] command) { this.command = command; }
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/AwaitStrategyTest.java
@@ -10,6 +10,7 @@ import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.util.ConfigUtil;
 import org.arquillian.cube.spi.Cube;
 import org.arquillian.cube.spi.await.AwaitStrategy;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
@@ -310,5 +311,22 @@ public class AwaitStrategyTest {
         assertThat(log.isStdOut(), is(false));
         assertThat(log.isStdErr(), is(true));
         assertThat(log.getOccurrences(), is(3));
+    }
+
+    @Test
+    public void should_parse_command() {
+        String containerDefinition = "tomcat:\n"
+            + "  image: tutum/tomcat:7.0\n"
+            + "  exposedPorts: [8089/tcp]\n"
+            + "  await:\n"
+            + "    strategy: docker_health\n"
+            + "    iterations: 5 # <1>\n"
+            + "    sleepPollingTime: 200 s # <2>\n"
+            + "    command: [\"curl\", \"localhost:8089\"] # <3>";
+
+        final DockerCompositions load = ConfigUtil.load(new ByteArrayInputStream(containerDefinition.getBytes()));
+        Await await = load.get("tomcat").getAwait();
+        String[] expected = {"curl", "localhost:8089"};
+        Assert.assertArrayEquals(expected, await.getCommand());
     }
 }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/DockerHealthAwaitStrategyTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/await/DockerHealthAwaitStrategyTest.java
@@ -1,0 +1,168 @@
+package org.arquillian.cube.docker.impl.await;
+
+import com.github.dockerjava.api.DockerClient;
+import com.github.dockerjava.core.DockerClientBuilder;
+import com.github.dockerjava.core.command.BuildImageResultCallback;
+import java.io.File;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.List;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.spi.Cube;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.mockito.Mockito.when;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DockerHealthAwaitStrategyTest {
+
+    private static final String DOCKER_HOST = "DOCKER_HOST";
+
+    private static DockerClient dockerClient;
+    private static String healthSuccessImageId;
+    private static String healthFailureImageId;
+
+    @ClassRule
+    public static final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
+    @Mock
+    private DockerClientExecutor dockerClientExecutor;
+
+    @Mock
+    private Cube<?> cube;
+
+    private List<String> containerIds;
+
+    @BeforeClass
+    public static void createDockerClient() {
+        if (!System.getenv().containsKey(DOCKER_HOST) || System.getenv(DOCKER_HOST).equals("")){
+            environmentVariables.set(DOCKER_HOST, "unix:///var/run/docker.sock");
+        }
+        dockerClient = DockerClientBuilder.getInstance().build();
+        healthSuccessImageId = dockerBuild("DockerHealthAwait/HealthSuccess/Dockerfile");
+        healthFailureImageId = dockerBuild("DockerHealthAwait/HealthFailure/Dockerfile");
+    }
+
+    @Before
+    public void setup() {
+        containerIds = new ArrayList<>();
+    }
+
+    @After
+    public void cleanContainers() {
+        for (String containerId : containerIds) {
+            if (containerId != null) {
+                dockerRm(containerId);
+            }
+        }
+    }
+
+    @AfterClass
+    public static void cleanImages() {
+        dockerRmi(healthSuccessImageId);
+        dockerRmi(healthFailureImageId);
+    }
+
+    @Test
+    public void shouldSuccessHealthCheck() {
+        verifyDockerHealthCheckResult(healthSuccessImageId, true);
+    }
+
+    @Test
+    public void shouldFailHealthcheck() {
+        verifyDockerHealthCheckResult(healthFailureImageId, false);
+    }
+
+    @Test
+    public void shouldSuccessCustomExec() {
+        verifyAwait(healthFailureImageId, true, new String[] {"true"});
+    }
+
+    @Test
+    public void shouldSuccessWithLongCommands() {
+        verifyAwait(healthFailureImageId, true, new String[] {"sh", "-c", "echo start;sleep 2;echo stop"}, "3s");
+    }
+
+    @Test
+    public void shouldFailCustomExecFailed() {
+        verifyAwait(healthSuccessImageId, false, new String[] {"sh", "-c", "exit 1"});
+    }
+
+    @Test
+    public void shouldFailNonExistingCommand() {
+        verifyAwait(healthSuccessImageId, false, new String[] {"this command does not exist"});
+    }
+
+    private static String dockerBuild(String path) {
+        URL url = DockerHealthAwaitStrategyTest.class.getClassLoader().getResource(path);
+        return dockerClient.buildImageCmd(new File(url.getFile()).getParentFile())
+            .exec(new BuildImageResultCallback()).awaitImageId();
+    }
+
+    private static void dockerRmi(String imageId) {
+        if (imageId != null) {
+            try {
+                dockerClient.removeImageCmd(imageId).exec();
+                System.out.printf("cleaned test image %s\n", imageId);
+            } catch (Throwable t) {
+                System.out.printf("Failed to clean test image %s: %s\n", imageId, t.toString());
+            }
+        }
+    }
+
+    private String dockerRun(String imageId) {
+        String containerId = dockerClient.createContainerCmd(imageId).exec().getId();
+        dockerClient.startContainerCmd(containerId).exec();
+        return containerId;
+    }
+
+    private static void dockerRm(String containerId) {
+        try {
+            dockerClient.killContainerCmd(containerId).exec();
+        } catch (Throwable t) {
+            // pass if the container is not running, no need to kill it
+        }
+        try {
+            dockerClient.removeContainerCmd(containerId).exec();
+            System.out.printf("cleaned test container %s\n", containerId);
+        } catch (Throwable t) {
+            System.out.printf("Failed to clean test container %s: %s\n", containerId, t.toString());
+        }
+    }
+
+    private void verifyDockerHealthCheckResult(String path, boolean status) {
+        verifyAwait(path, status, null);
+    }
+
+    private void verifyAwait(String imageId, boolean status, String[] command) {
+        verifyAwait(imageId, status, command, "500ms");
+    }
+
+    private void verifyAwait(String imageId, boolean status, String[] command, String timeout) {
+        String containerId = dockerRun(imageId);
+        containerIds.add(containerId);
+        when(cube.getId()).thenReturn(containerId);
+        when(dockerClientExecutor.getDockerClient()).thenReturn(dockerClient);
+
+        Await params = new Await();
+        params.setIterations(2);
+        params.setSleepPollingTime(timeout);
+        params.setCommand(command);
+
+        DockerHealthAwaitStrategy dockerHealthAwaitStrategy = new DockerHealthAwaitStrategy(
+            cube, dockerClientExecutor, params
+        );
+        Assert.assertEquals(status, dockerHealthAwaitStrategy.await());
+    }
+}

--- a/docker/docker/src/test/resources/DockerHealthAwait/HealthFailure/Dockerfile
+++ b/docker/docker/src/test/resources/DockerHealthAwait/HealthFailure/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+CMD ["tail", "-f", "/dev/null"]
+HEALTHCHECK --interval=50ms --timeout=100ms CMD ["false"]

--- a/docker/docker/src/test/resources/DockerHealthAwait/HealthSuccess/Dockerfile
+++ b/docker/docker/src/test/resources/DockerHealthAwait/HealthSuccess/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine
+CMD ["tail", "-f", "/dev/null"]
+HEALTHCHECK --interval=50ms CMD ["true"]

--- a/docs/configuration.adoc
+++ b/docs/configuration.adoc
@@ -267,6 +267,7 @@ static:: similar to _polling_ but it uses the host ip and specified list of port
 sleeping:: sleeps current thread for the specified amount of time. You can specify the time in seconds or milliseconds.
 log:: it looking for a specified pattern in container log to detect service startup. This can be used when there is no port to connect or connecting to the port successfully doesn't mean the service is fully initialized.
 http:: polls through a configured http endpoint checking for http response code and optionally the answer content or headers.
+docker_health:: polls the docker API to wait for the container to match the docker healthy definition (see: link:https://docs.docker.com/engine/reference/builder/#healthcheck[here]).
 <fullyqualifiedclassname>:: if you specify a fully qualified class name, Arquillian Cube will instantiate the given class. In this way you can implement your own await strategies. There are two rules to follow, the first one is that class must implement `AwaitStrategy` and the second one is that one default constructor must be provided. Optionally you can add fields/setters for types `Cube`, `DockerClientExecutor` or `Await` to inject them into the await strategy.
 
 By default in case you don't specify any _await_ strategy, polling with _ss_ command is used with automatic fallback to _wait-fo_it_ strategy.
@@ -361,6 +362,22 @@ tomcat:
 <4> Optional parameter to configure sleeping time between each call in case of fail. You can set in seconds using _s_ or miliseconds using _ms_. By default time unit is miliseconds and value 500.
 <5> Optional parameter to configure number of retries to be done. By default 10 iterations are done.
 <6> Optional parameter to check header's value returned by service.
+
+[source, yaml]
+.Example docker_health
+----
+tomcat:
+  image: tutum/tomcat:7.0
+  exposedPorts: [8089/tcp]
+  await:
+    strategy: docker_health
+    iterations: 5 # <1>
+    sleepPollingTime: 200 s # <2>
+    command: ["curl", "localhost:8089"] # <3>
+----
+<1> Optional parameter to configure number of retries to be done. By default 10 iterations are done.
+<2> Optional parameter to configure sleeping time between each call in case of fail. You can set in seconds using _s_ or miliseconds using _ms_. By default time unit is miliseconds and value 500.
+<3> Optional parameter to configure a command line to execute inside the container instead of using the docker API to get container health.
 
 Custom Await strategy:
 


### PR DESCRIPTION
#### Short description of what this resolves:

Add support for docker based health checks

#### Changes proposed in this pull request:

This commit adds support for docker-managed health checks.
    
There are 2 ways of using it:
- either let docker manage the health check on its own and inspect the
   status thanks to the docker API
- or use the docker API to run a custom health check command in the
   container

