### PR TITLE
feat(#996): inject arquillian.xml properties in @RouteUrl

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -98,6 +98,11 @@
       <artifactId>snakeyaml</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.github.stefanbirkner</groupId>
+      <artifactId>system-rules</artifactId>
+      <scope>test</scope>
+    </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>

--- a/core/src/main/java/org/arquillian/cube/impl/ConfigurationParameters.java
+++ b/core/src/main/java/org/arquillian/cube/impl/ConfigurationParameters.java
@@ -1,0 +1,24 @@
+package org.arquillian.cube.impl;
+
+import java.util.HashMap;
+import java.util.Map;
+
+public class ConfigurationParameters {
+
+    private Map<String, String> configParams;
+
+    public ConfigurationParameters(Map<String, String> configParams) {
+        this.configParams = configParams;
+    }
+
+    Map<String, String> getConfigParams() {
+        return configParams;
+    }
+
+    public static ConfigurationParameters from(String key, String value) {
+        final HashMap<String, String> map = new HashMap<>();
+        map.put(key, value);
+
+        return new ConfigurationParameters(map);
+    }
+}

--- a/core/src/main/java/org/arquillian/cube/impl/EnricherExpressionResolver.java
+++ b/core/src/main/java/org/arquillian/cube/impl/EnricherExpressionResolver.java
@@ -1,0 +1,33 @@
+package org.arquillian.cube.impl;
+
+import java.util.Map;
+import org.jboss.arquillian.config.impl.extension.StringPropertyReplacer;
+
+public class EnricherExpressionResolver {
+
+    private ConfigurationParameters configurationParameters;
+
+    public EnricherExpressionResolver(ConfigurationParameters configurationParameters) {
+        this.configurationParameters = configurationParameters;
+    }
+
+    public String resolve(String property) {
+        final String replacedProperties = StringPropertyReplacer.replaceProperties(property);
+        if (!property.equals(replacedProperties)) {
+            return replacedProperties;
+        } else {
+            final Map<String, String> configParams = configurationParameters.getConfigParams();
+            final String propertyValue = configParams.get(propertyWithoutExpression(property));
+
+            return propertyValue != null ? propertyValue : property;
+        }
+    }
+
+    private String propertyWithoutExpression(String property) {
+        if (property.startsWith("${") && property.endsWith("}")) {
+            property = property.substring(2, property.length() - 1);
+        }
+
+        return property;
+    }
+}

--- a/core/src/test/java/org/arquillian/cube/impl/EnricherExpressionResolverTest.java
+++ b/core/src/test/java/org/arquillian/cube/impl/EnricherExpressionResolverTest.java
@@ -1,0 +1,54 @@
+package org.arquillian.cube.impl;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.contrib.java.lang.system.RestoreSystemProperties;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class EnricherExpressionResolverTest {
+
+    @Rule
+    public final RestoreSystemProperties restoreSystemProperties = new RestoreSystemProperties();
+
+    @Test
+    public void should_resolve_property_from_config_map() {
+        // given
+        final EnricherExpressionResolver resolver =
+            new EnricherExpressionResolver(ConfigurationParameters.from("app.name", "myapp"));
+
+        // when
+        final String resolvedString = resolver.resolve("${app.name}");
+
+        // then
+        assertThat(resolvedString).isEqualTo("myapp");
+    }
+
+    @Test
+    public void should_overwrite_system_property_if_property_present_in_config_map() {
+        // given
+        System.setProperty("app.name", "systemProperty");
+
+        final EnricherExpressionResolver resolver =
+            new EnricherExpressionResolver(ConfigurationParameters.from("app.name", "myapp"));
+
+        // when
+        final String resolvedString = resolver.resolve("${app.name}");
+
+        // then
+        assertThat(resolvedString).isEqualTo("systemProperty");
+    }
+
+    @Test
+    public void should_not_resolve_property_if_not_set_in_config_and_system_property() {
+        // given
+        final EnricherExpressionResolver resolver =
+            new EnricherExpressionResolver(ConfigurationParameters.from("foo", "bar"));
+
+        // when
+        final String resolvedString = resolver.resolve("${app.name}");
+
+        // then
+        assertThat(resolvedString).isEqualTo("${app.name}");
+    }
+}

--- a/docs/enrichers.adoc
+++ b/docs/enrichers.adoc
@@ -70,9 +70,21 @@ When running Arquillian Cube against a OpenShift's pod you can retrieve the rout
 @RouteURL("app-name")
 private URL url;
 ----
+
 This annotation also has a `path` parameter which can change the path part of the injected URL.
+
+OR
+
+[source, java]
+.RouterURLEnricher.java
+----
+include::../openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesIT.java[tag=enricher_expression_resolver_example]
+----
+
 You can also use an additional annotation `@AwaitRoute` to wait until the route becomes available.
 That is, it responds with a known good HTTP status code in given timeout.
+
+To resolve expression `"${route.name}"`, it looks in hierarchy of `system property` -> `environment variable` -> `properties defined in arquillian.xml`.
 
 If the route is not resolvable, you need to set the `routerHost` setting to the IP address of the OpenShift router.
 You can configure it in arquillian.xml:
@@ -80,10 +92,10 @@ You can configure it in arquillian.xml:
 .arquillian.xml
 ----
  <extension qualifier="openshift">
-        ....
-        <property name="routerHost">192.168.10.10</property>
-        ...
-    </extension>
+    ....
+    <property name="routerHost">192.168.10.10</property>
+    ...
+ </extension>
 ----
 Or just by setting the system property `openshift.router.host`.
 To obtain the router address from your OpenShift instance you can execute the command below:

--- a/docs/enrichers.adoc
+++ b/docs/enrichers.adoc
@@ -73,7 +73,7 @@ private URL url;
 
 This annotation also has a `path` parameter which can change the path part of the injected URL.
 
-OR
+or
 
 [source, java]
 .RouterURLEnricher.java

--- a/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesIT.java
+++ b/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesIT.java
@@ -27,7 +27,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @OpenShiftResource("classpath:hello-route.yaml")
 public class HelloWorldOpenShiftResourcesIT {
 
-    @RouteURL("hello-world")
+    @RouteURL("${route.name}")
     @AwaitRoute
     private URL url;
 

--- a/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesIT.java
+++ b/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesIT.java
@@ -27,9 +27,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 @OpenShiftResource("classpath:hello-route.yaml")
 public class HelloWorldOpenShiftResourcesIT {
 
+    // tag::enricher_expression_resolver_example[]
     @RouteURL("${route.name}")
     @AwaitRoute
     private URL url;
+    // end::enricher_expression_resolver_example[]
 
     @ArquillianResource
     private OpenShiftClient openShiftClient;

--- a/openshift/ftest-openshift-resources-standalone/src/test/resources/arquillian.xml
+++ b/openshift/ftest-openshift-resources-standalone/src/test/resources/arquillian.xml
@@ -4,6 +4,7 @@
   xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
   <extension qualifier="openshift">
+    <property name="route.name">hello-world</property>
     <property name="env.config.resource.name">hello-openshift.json</property>
   </extension>
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurationFactory.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfigurationFactory.java
@@ -16,14 +16,22 @@ package org.arquillian.cube.openshift.impl.client;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.arquillian.cube.impl.ConfigurationParameters;
 import org.arquillian.cube.kubernetes.api.ConfigurationFactory;
 import org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
+import org.jboss.arquillian.core.api.InstanceProducer;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.api.annotation.Inject;
 
 public class CubeOpenShiftConfigurationFactory extends DefaultConfigurationFactory<CubeOpenShiftConfiguration>
     implements ConfigurationFactory<CubeOpenShiftConfiguration> {
 
     private static final String OPENSHIFT_EXTENSION_NAME = "openshift";
+
+    @Inject
+    @ApplicationScoped
+    private InstanceProducer<ConfigurationParameters> configurationParamProducer;
 
     @Override
     public CubeOpenShiftConfiguration create(ArquillianDescriptor arquillian) {
@@ -32,6 +40,7 @@ public class CubeOpenShiftConfigurationFactory extends DefaultConfigurationFacto
         config.putAll(arquillian.extension(OPENSHIFT_EXTENSION_NAME).getExtensionProperties());
 
         configureProtocolHandlers(config);
+        configurationParamProducer.set(new ConfigurationParameters(config));
 
         final CubeOpenShiftConfiguration openShiftConfiguration = CubeOpenShiftConfiguration.fromMap(config);
         System.out.println(openShiftConfiguration);

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/RouteURLEnricher.java
@@ -2,6 +2,8 @@ package org.arquillian.cube.openshift.impl.enricher;
 
 import io.fabric8.openshift.api.model.v3_1.Route;
 import io.fabric8.openshift.api.model.v3_1.RouteList;
+import org.arquillian.cube.impl.ConfigurationParameters;
+import org.arquillian.cube.impl.EnricherExpressionResolver;
 import org.arquillian.cube.impl.util.ReflectionUtil;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
@@ -36,6 +38,9 @@ public class RouteURLEnricher implements TestEnricher {
 
     @Inject
     private Instance<Configuration> configurationInstance;
+
+    @Inject
+    private Instance<ConfigurationParameters> configurationParametersInstance;
 
     @Override
     public void enrich(Object testCase) {
@@ -87,7 +92,8 @@ public class RouteURLEnricher implements TestEnricher {
             throw new NullPointerException("RouteURL is null!");
         }
 
-        final String routeName = StringPropertyReplacer.replaceProperties(routeURL.value());
+        final EnricherExpressionResolver expressionResolver = new EnricherExpressionResolver(configurationParametersInstance.get());
+        final String routeName  = expressionResolver.resolve(routeURL.value());
         if (routeName == null || routeName.length() == 0) {
             throw new NullPointerException("Route name is null, must specify a route name!");
         }


### PR DESCRIPTION


#### Changes proposed in this pull request:

- Introducing `ConfigurationParameters` class to store configuration read from arquillian.xml
- Creating ApplicationScoped Instance of `ConfigurationParameters` to store config params.
- Using store ConfigParams while resolving Enricher expression. 



Fixes #996
