### PR TITLE
fix(#1006): adds state checks in BuildablePodCube stop and destroy lifecycle events.

### DIFF
--- a/openshift/openshift/pom.xml
+++ b/openshift/openshift/pom.xml
@@ -207,7 +207,17 @@
       <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
-
+    <dependency>
+      <groupId>org.jboss.arquillian.core</groupId>
+      <artifactId>arquillian-core-impl-base</artifactId>
+      <classifier>tests</classifier>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.jboss.arquillian.junit</groupId>
+      <artifactId>arquillian-junit-container</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
 </project>

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -1,26 +1,37 @@
 package org.arquillian.cube.openshift.impl;
 
 import org.arquillian.cube.impl.client.enricher.StandaloneCubeUrlResourceProvider;
-import org.arquillian.cube.kubernetes.api.*;
+import org.arquillian.cube.kubernetes.api.ConfigurationFactory;
+import org.arquillian.cube.kubernetes.api.FeedbackProvider;
+import org.arquillian.cube.kubernetes.api.KubernetesResourceLocator;
+import org.arquillian.cube.kubernetes.api.NamespaceService;
+import org.arquillian.cube.kubernetes.api.ResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.DefaultConfigurationFactory;
 import org.arquillian.cube.kubernetes.impl.enricher.KuberntesServiceUrlResourceProvider;
 import org.arquillian.cube.kubernetes.impl.feedback.DefaultFeedbackProvider;
 import org.arquillian.cube.kubernetes.impl.install.DefaultResourceInstaller;
 import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
 import org.arquillian.cube.kubernetes.impl.namespace.DefaultNamespaceService;
-import org.arquillian.cube.openshift.impl.client.*;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfigurationFactory;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftRegistrar;
+import org.arquillian.cube.openshift.impl.client.OpenShiftAssistantCreator;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClientCreator;
+import org.arquillian.cube.openshift.impl.client.OpenShiftSuiteLifecycleController;
 import org.arquillian.cube.openshift.impl.enricher.RouteURLEnricher;
 import org.arquillian.cube.openshift.impl.enricher.external.OpenShiftAssistantResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigListResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.internal.DeploymentConfigResourceProvider;
 import org.arquillian.cube.openshift.impl.enricher.internal.OpenshiftClientResourceProvider;
-import org.arquillian.cube.openshift.impl.ext.*;
+import org.arquillian.cube.openshift.impl.ext.ExternalDeploymentScenarioGenerator;
+import org.arquillian.cube.openshift.impl.ext.LocalConfigurationResourceProvider;
+import org.arquillian.cube.openshift.impl.ext.OpenShiftHandleResourceProvider;
+import org.arquillian.cube.openshift.impl.ext.TemplateContainerStarter;
+import org.arquillian.cube.openshift.impl.ext.UtilsArchiveAppender;
 import org.arquillian.cube.openshift.impl.feedback.OpenshiftFeedbackProvider;
 import org.arquillian.cube.openshift.impl.graphene.location.OpenShiftCustomizableURLResourceProvider;
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
 import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
-import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentScenarioGenerator;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -70,7 +81,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
         if (Validate.classExists("org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender")
             && doesNotContainStandaloneExtension()) {
             builder.service(AuxiliaryArchiveAppender.class, UtilsArchiveAppender.class);
-            builder.override(DeploymentScenarioGenerator.class, AnnotationDeploymentScenarioGenerator.class, ExternalDeploymentScenarioGenerator.class);
+            builder.service(DeploymentScenarioGenerator.class, ExternalDeploymentScenarioGenerator.class);
             builder.observer(TemplateContainerStarter.class);
             builder.service(ResourceProvider.class, OpenShiftHandleResourceProvider.class);
         }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/CubeOpenshiftExtension.java
@@ -20,6 +20,7 @@ import org.arquillian.cube.openshift.impl.graphene.location.OpenShiftCustomizabl
 import org.arquillian.cube.openshift.impl.install.OpenshiftResourceInstaller;
 import org.arquillian.cube.openshift.impl.locator.OpenshiftKubernetesResourceLocator;
 import org.arquillian.cube.openshift.impl.namespace.OpenshiftNamespaceService;
+import org.jboss.arquillian.container.test.impl.client.deployment.AnnotationDeploymentScenarioGenerator;
 import org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender;
 import org.jboss.arquillian.container.test.spi.client.deployment.DeploymentScenarioGenerator;
 import org.jboss.arquillian.core.spi.LoadableExtension;
@@ -69,7 +70,7 @@ public class CubeOpenshiftExtension implements LoadableExtension {
         if (Validate.classExists("org.jboss.arquillian.container.test.spi.client.deployment.AuxiliaryArchiveAppender")
             && doesNotContainStandaloneExtension()) {
             builder.service(AuxiliaryArchiveAppender.class, UtilsArchiveAppender.class);
-            builder.service(DeploymentScenarioGenerator.class, ExternalDeploymentScenarioGenerator.class);
+            builder.override(DeploymentScenarioGenerator.class, AnnotationDeploymentScenarioGenerator.class, ExternalDeploymentScenarioGenerator.class);
             builder.observer(TemplateContainerStarter.class);
             builder.service(ResourceProvider.class, OpenShiftHandleResourceProvider.class);
         }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -138,6 +138,9 @@ public class BuildablePodCube extends BaseCube<Void> {
 
     @Override
     public void stop() throws CubeControlException {
+        if (state == State.STOPPED || state == State.PRE_RUNNING || state == State.DESTROYED) {
+            return;
+        }
         try {
             lifecycle.fire(new BeforeStop(id));
             destroyPod(holder.getPod());
@@ -156,6 +159,9 @@ public class BuildablePodCube extends BaseCube<Void> {
 
     @Override
     public void destroy() throws CubeControlException {
+        if (state != State.STOPPED) {
+            return;
+        }
         try {
             lifecycle.fire(new BeforeDestroy(id));
             List<Exception> exceptions = client.clean(holder);

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/model/BuildablePodCube.java
@@ -55,7 +55,8 @@ public class BuildablePodCube extends BaseCube<Void> {
     private OpenShiftClient client;
 
     private PortBindings portBindings;
-    private ResourceHolder holder;
+
+    ResourceHolder holder;
 
     @Inject
     private Event<CubeLifecyleEvent> lifecycle;

--- a/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/DnsServiceTest.java
+++ b/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/DnsServiceTest.java
@@ -1,4 +1,4 @@
-package org.arquillian.cube.openshift;
+package org.arquillian.cube.openshift.impl;
 
 import io.fabric8.openshift.api.model.v3_1.Route;
 import io.fabric8.openshift.api.model.v3_1.RouteList;

--- a/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/model/BuildablePodCubeTest.java
+++ b/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/model/BuildablePodCubeTest.java
@@ -75,7 +75,7 @@ public class BuildablePodCubeTest extends AbstractManagerTestBase {
 
     @Test
     public void shouldFireLifecycleEventsDuringCreateAfterDestroyed() {
-        // given calling entire lifecycle to destroy cube
+        // given calling entire lifecycle to destroy buildablePodCube
         buildablePodCube.create();
         buildablePodCube.start();
         buildablePodCube.stop();
@@ -84,7 +84,7 @@ public class BuildablePodCubeTest extends AbstractManagerTestBase {
         // when
         buildablePodCube.create();
 
-        // then event count is 2 which is for two cube.create()
+        // then event count is 2 which is for two buildablePodCube.create()
         assertEventFired(BeforeCreate.class, 2);
         assertEventFired(AfterCreate.class, 2);
     }
@@ -105,7 +105,7 @@ public class BuildablePodCubeTest extends AbstractManagerTestBase {
 
     @Test
     public void shouldFireLifecycleEventsDuringDestroy() {
-        buildablePodCube.stop(); // require a stopped Cube to destroy it.
+        buildablePodCube.stop(); // require a stopped buildablePodCube to destroy it.
         buildablePodCube.destroy();
         assertEventFired(BeforeDestroy.class, 1);
         assertEventFired(AfterDestroy.class, 1);
@@ -120,7 +120,7 @@ public class BuildablePodCubeTest extends AbstractManagerTestBase {
         // when
         buildablePodCube.stop();
 
-        // then - event count is 1 which is for first cube.stop()
+        // then - event count is 1 which is for first buildablePodCube.stop()
         assertEventFired(BeforeStop.class, 1);
         assertEventFired(AfterStop.class, 1);
     }
@@ -133,7 +133,7 @@ public class BuildablePodCubeTest extends AbstractManagerTestBase {
         // when
         buildablePodCube.stop();
 
-        // then  - event count is 1 which is for first cube.stop()
+        // then  - event count is 1 which is for first buildablePodCube.stop()
         assertEventFired(BeforeStop.class, 1);
         assertEventFired(AfterStop.class, 1);
     }

--- a/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/model/BuildablePodCubeTest.java
+++ b/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/model/BuildablePodCubeTest.java
@@ -1,0 +1,132 @@
+package org.arquillian.cube.openshift.impl.model;
+
+import io.fabric8.kubernetes.api.model.v3_1.ObjectMeta;
+import io.fabric8.kubernetes.api.model.v3_1.Pod;
+import io.fabric8.kubernetes.api.model.v3_1.PodSpec;
+import io.fabric8.openshift.clnt.v3_1.DefaultOpenShiftClient;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.arquillian.cube.openshift.impl.client.OpenShiftClient;
+import org.arquillian.cube.spi.event.lifecycle.AfterCreate;
+import org.arquillian.cube.spi.event.lifecycle.AfterDestroy;
+import org.arquillian.cube.spi.event.lifecycle.AfterStart;
+import org.arquillian.cube.spi.event.lifecycle.AfterStop;
+import org.arquillian.cube.spi.event.lifecycle.BeforeCreate;
+import org.arquillian.cube.spi.event.lifecycle.BeforeDestroy;
+import org.arquillian.cube.spi.event.lifecycle.BeforeStart;
+import org.arquillian.cube.spi.event.lifecycle.BeforeStop;
+import org.jboss.arquillian.core.api.Injector;
+import org.jboss.arquillian.core.api.Instance;
+import org.jboss.arquillian.core.api.annotation.Inject;
+import org.jboss.arquillian.core.test.AbstractManagerTestBase;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.arquillian.cube.openshift.impl.client.OpenShiftClient.ResourceHolder;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Mockito.when;
+
+@Category(OpenShiftClient.class)
+@RunWith(MockitoJUnitRunner.class)
+public class BuildablePodCubeTest extends AbstractManagerTestBase {
+
+    @Mock
+    private CubeOpenShiftConfiguration cubeOpenShiftConfiguration;
+
+    @Mock
+    private OpenShiftClient openShiftClient;
+
+    @Inject
+    private Instance<Injector> injectorInst;
+
+    private BuildablePodCube buildablePodCube;
+
+    @Before
+    public void setup() throws Exception {
+
+        final Pod pod = new Pod("v1", "Pod", new ObjectMeta(), new PodSpec(), null);
+
+        when(openShiftClient.getClientExt()).thenReturn(new DefaultOpenShiftClient());
+        when(openShiftClient.build(anyObject())).thenReturn(new ResourceHolder(pod));
+        when(cubeOpenShiftConfiguration.isNamespaceCleanupEnabled()).thenReturn(true);
+
+        buildablePodCube = injectorInst.get().inject(new BuildablePodCube(pod, openShiftClient, cubeOpenShiftConfiguration));
+        buildablePodCube.holder = new ResourceHolder(pod);
+    }
+
+    @Test
+    public void shouldFireLifecycleEventsDuringCreate() {
+        buildablePodCube.create();
+        assertEventFired(BeforeCreate.class, 1);
+        assertEventFired(AfterCreate.class, 1);
+    }
+
+    @Test
+    public void shouldFireLifecycleEventsDuringCreateAfterDestroyed() {
+        // given calling entire lifecycle to destroy cube
+        buildablePodCube.create();
+        buildablePodCube.start();
+        buildablePodCube.stop();
+        buildablePodCube.destroy();
+
+        // when
+        buildablePodCube.create();
+
+        // then event count is 2 which is for two cube.create()
+        assertEventFired(BeforeCreate.class, 2);
+        assertEventFired(AfterCreate.class, 2);
+    }
+
+    @Test
+    public void shouldFireLifecycleEventsDuringStart() {
+        buildablePodCube.start();
+        assertEventFired(BeforeStart.class, 1);
+        assertEventFired(AfterStart.class, 1);
+    }
+
+    @Test
+    public void shouldFireLifecycleEventsDuringStop() {
+        buildablePodCube.stop();
+        assertEventFired(BeforeStop.class, 1);
+        assertEventFired(AfterStop.class, 1);
+    }
+
+    @Test
+    public void shouldFireLifecycleEventsDuringDestroy() {
+        buildablePodCube.stop(); // require a stopped Cube to destroy it.
+        buildablePodCube.destroy();
+        assertEventFired(BeforeDestroy.class, 1);
+        assertEventFired(AfterDestroy.class, 1);
+    }
+
+    @Test
+    public void shouldNotFireLifecycleEventsIfTryingToStopAlreadyDestroyedCube() {
+        // given
+        buildablePodCube.stop();
+        buildablePodCube.destroy();
+
+        // when
+        buildablePodCube.stop();
+
+        // then - event count is 1 which is for first cube.stop()
+        assertEventFired(BeforeStop.class, 1);
+        assertEventFired(AfterStop.class, 1);
+    }
+
+    @Test
+    public void shouldNotFireLifecycleEventsIfTryingToStopAlreadyStoppedCube() {
+        // given
+        buildablePodCube.stop();
+
+        // when
+        buildablePodCube.stop();
+
+        // then  - event count is 1 which is for first cube.stop()
+        assertEventFired(BeforeStop.class, 1);
+        assertEventFired(AfterStop.class, 1);
+    }
+}
+


### PR DESCRIPTION
#### Short description of what this resolves:

Adds state checks before `stop` and `destroy` events for BuildablePodCube to fix NPE.

#### Changes proposed in this pull request:

- Adds state checks before `stop` and `destroy` events for BuildablePodCube
- Adds Unit Tests for the Lifecycle Events. 

Fixes: #1006 
