### PR TITLE
fix(#1001): logs watcher events to console if resources not in the ready state.

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -1,8 +1,6 @@
 package org.arquillian.cube.kubernetes.impl;
 
-import io.fabric8.kubernetes.api.model.v3_1.Container;
 import io.fabric8.kubernetes.api.model.v3_1.Endpoints;
-import io.fabric8.kubernetes.api.model.v3_1.Event;
 import io.fabric8.kubernetes.api.model.v3_1.HasMetadata;
 import io.fabric8.kubernetes.api.model.v3_1.Pod;
 import io.fabric8.kubernetes.api.model.v3_1.PodList;
@@ -14,16 +12,7 @@ import io.fabric8.kubernetes.api.model.v3_1.ServicePort;
 import io.fabric8.kubernetes.api.model.v3_1.extensions.ReplicaSet;
 import io.fabric8.kubernetes.api.model.v3_1.extensions.ReplicaSetList;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
-import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientException;
 import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientTimeoutException;
-import io.fabric8.kubernetes.clnt.v3_1.Watch;
-import io.fabric8.kubernetes.clnt.v3_1.Watcher;
-import io.fabric8.kubernetes.clnt.v3_1.dsl.LogWatch;
-import java.io.Closeable;
-import java.io.File;
-import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
-import java.io.FileWriter;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
@@ -32,11 +21,8 @@ import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.kubernetes.api.AnnotationProvider;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
@@ -48,7 +34,6 @@ import org.arquillian.cube.kubernetes.api.ResourceInstaller;
 import org.arquillian.cube.kubernetes.api.Session;
 import org.arquillian.cube.kubernetes.api.SessionCreatedListener;
 import org.jboss.arquillian.core.spi.Validate;
-import org.xnio.IoUtils;
 
 import static org.arquillian.cube.impl.util.SystemEnvironmentVariables.propertyToEnvironmentVariableName;
 import static org.arquillian.cube.kubernetes.impl.utils.ProcessUtil.runCommand;
@@ -66,16 +51,10 @@ public class SessionManager implements SessionCreatedListener {
     private final FeedbackProvider feedbackProvider;
 
     private final List<HasMetadata> resources = new ArrayList<>();
-    private final Map<String, Collection<Closeable>> watchersMap = new ConcurrentHashMap<>();
-    private Watch watchLog;
-    private Watch watchEvents;
 
     private final AtomicReference<ShutdownHook> shutdownHookRef = new AtomicReference<>();
 
-    private String logPath;
-    private FileWriter eventLogWriter;
-    private String currentClassName;
-    private String currentMethodName;
+    private WatchListener watchListener;
 
     public SessionManager(Session session, KubernetesClient client, Configuration configuration,
         AnnotationProvider annotationProvider, NamespaceService namespaceService,
@@ -100,6 +79,8 @@ public class SessionManager implements SessionCreatedListener {
         this.dependencyResolver = dependencyResolver;
         this.resourceInstaller = resourceInstaller;
         this.feedbackProvider = feedbackProvider;
+
+        this.watchListener = new WatchListener(session, client, configuration);
     }
 
     private String getSessionStatus() {
@@ -184,7 +165,7 @@ public class SessionManager implements SessionCreatedListener {
                             .waitUntilReady(configuration.getWaitTimeout(), TimeUnit.MILLISECONDS);
                     } catch (KubernetesClientTimeoutException t) {
                         log.warn("There are resources in not ready state:");
-                        watchEventLog();
+                        watchListener.setupEventListener();
                         for (HasMetadata r : t.getResourcesNotReady()) {
                             log.error(
                                 r.getKind() + " name: " + r.getMetadata().getName() + " namespace:" + r.getMetadata()
@@ -205,45 +186,15 @@ public class SessionManager implements SessionCreatedListener {
         }
     }
 
-    private void watchEventLog() throws InterruptedException {
-        Logger logger = session.getLogger();
-        final CountDownLatch closeLatch = new CountDownLatch(1);
-        logger.info(String.format("%s %21s %14s %5s %28s %10s %10s %10s %10s %25s", "LASTSEEN", "FIRSTSEEN", "COUNT",
-            "NAME", "KIND", "SUBOBJECT", "TYPE", "REASON", "SOURCE", "MESSAGE"));
-        try (final Watch watch = client.events().inNamespace(session.getNamespace()).watch(new Watcher<Event>() {
-            @Override
-            public void eventReceived(Action action, Event resource) {
-                logger.info(String.format("%s %s %s %s %s %s %s %s %s %s", resource.getLastTimestamp(),
-                    resource.getFirstTimestamp(),
-                    resource.getCount(), resource.getMetadata().getName(), resource.getInvolvedObject().getKind(),
-                    resource.getInvolvedObject().getFieldPath()
-                    , resource.getType(), resource.getReason(), resource.getSource(), resource.getMessage()
-                ));
-            }
-
-            @Override
-            public void onClose(KubernetesClientException e) {
-                logger.status("Watcher onClose");
-                if (e != null) {
-                    logger.error(e.getMessage() + e);
-                    closeLatch.countDown();
-                }
-            }
-        })) {
-            closeLatch.await(10, TimeUnit.SECONDS);
-        } catch (KubernetesClientException | InterruptedException e) {
-            logger.error("Could not watch resources" + e);
-        }
-        Thread.sleep(60000l);
-    }
-
     @Override
     public void start() {
         Logger log = session.getLogger();
         log.status("Using Kubernetes at: " + client.getMasterUrl());
         createNamespace();
-        setupConsoleListener();
-        setupEventListener();
+        watchListener.setupConsoleListener();
+        if (configuration.isLogCopyEnabled()) {
+            watchListener.setupEventListener();
+        }
 
         addShutdownHook();
         try {
@@ -254,189 +205,11 @@ public class SessionManager implements SessionCreatedListener {
         }
     }
 
-    private void addConsole(final String podName) {
-        if (watchersMap.containsKey(podName))
-            return;
-
-        String className = session.getCurrentClassName();
-        String methodName = session.getCurrentMethodName();
-        String fileName = logPath;
-
-        if (Strings.isNullOrEmpty(className))
-            className = "NOCLASS";
-        fileName += String.format("/%s", className);
-
-        if (Strings.isNotNullOrEmpty(methodName))
-            fileName += String.format("-%s", methodName);
-
-        try {
-            Collection<Closeable> fds = new ArrayList<Closeable>();
-            List<Container> containers = client.pods().inNamespace(session.getNamespace()).withName(podName).get()
-                    .getSpec().getContainers();
-            if (containers.size() == 1) {
-                fileName += String.format("-%s.log", podName);
-                final FileOutputStream stream = new FileOutputStream(fileName);
-                LogWatch lw = client.pods().inNamespace(session.getNamespace()).withName(podName).watchLog(stream);
-                fds.add(lw);
-                fds.add(stream);
-            } else {
-                for (Container container : containers) {
-                    String containerName = container.getName();
-                    String fileNameContainer = String.format("%s-%s-%s.log", fileName, podName, containerName);
-                    final FileOutputStream stream = new FileOutputStream(fileNameContainer);
-                    LogWatch lw = client.pods().inNamespace(session.getNamespace()).withName(podName).inContainer(containerName).watchLog(stream);
-                    fds.add(lw);
-                    fds.add(stream);
-                }
-            }
-
-            watchersMap.put(podName, fds);
-        } catch (FileNotFoundException e) {
-            throw new RuntimeException(String.format("Error storing the console log for pod %s", podName), e);
-        }
-
-    }
-
-    private void delConsole(String podName) {
-        Collection<Closeable> lw = watchersMap.get(podName);
-        if (lw == null)
-            return;
-
-        watchersMap.remove(podName);
-        IoUtils.safeClose(lw.toArray(new Closeable[0]));
-    }
-
-    private void setupConsoleListener() {
-        if (!configuration.isLogCopyEnabled()) {
-            return;
-        }
-
-        logPath = configuration.getLogPath();
-        if (Strings.isNullOrEmpty(logPath))
-            logPath = String.format("%s/target/surefire-reports", System.getProperty("user.dir"));
-        session.getLogger().info(String.format("Storing pods console logs into dir %s", logPath));
-        new File(logPath).mkdirs();
-
-        final Watcher<Pod> watcher = new Watcher<Pod>() {
-            @Override
-            public void eventReceived(Action action, Pod pod) {
-                switch (action) {
-                    case ADDED:
-                    case MODIFIED:
-                        if (pod.getStatus().getPhase().equalsIgnoreCase("Running")) {
-                            addConsole(pod.getMetadata().getName());
-                        }
-                        break;
-                    case DELETED:
-                    case ERROR:
-                        delConsole(pod.getMetadata().getName());
-                        break;
-                }
-            }
-
-            @Override
-            public void onClose(KubernetesClientException cause) {
-            }
-        };
-
-        watchLog = client.pods().inNamespace(session.getNamespace()).watch(watcher);
-    }
-
-    private void cleanupConsoleListener() {
-        if (watchLog != null) {
-            watchLog.close();
-        }
-        watchersMap.forEach((k, v) -> {
-            IoUtils.safeClose(v.toArray(new Closeable[0]));
-        });
-        watchersMap.clear();
-    }
-
-    private void setupEventLogWriter() {
-        String className = session.getCurrentClassName();
-        String methodName = session.getCurrentMethodName();
-
-        if (className != null && className.equals(currentClassName)
-                && methodName != null && methodName.equals(currentMethodName))
-            return;
-
-        currentClassName = className;
-        currentMethodName = methodName;
-        String fileName = logPath;
-
-        if (Strings.isNullOrEmpty(className))
-            className = "NOCLASS";
-        fileName += String.format("/%s", className);
-
-        if (Strings.isNotNullOrEmpty(methodName))
-            fileName += String.format("-%s", methodName);
-        fileName += "-KUBE_EVENTS.log";
-
-        try {
-            if (eventLogWriter != null) {
-                eventLogWriter.close();
-            }
-            eventLogWriter = new FileWriter(fileName, true);
-        } catch (IOException e) {
-            throw new RuntimeException("Error storing kubernetes events", e);
-        }
-
-    }
-
-    private void setupEventListener() {
-        if (!configuration.isLogCopyEnabled()) {
-            return;
-        }
-
-
-        final Watcher<Event> watcher = new Watcher<Event>() {
-            @Override
-            public void eventReceived(Action action, Event event) {
-                switch (action) {
-                    case ADDED:
-                    case MODIFIED:
-                    case DELETED:
-                    case ERROR:
-                    try {
-                        setupEventLogWriter();
-                        eventLogWriter.append(String.format("[%s] [%s] [%s:%s]: (%s) %s\n",
-                                event.getLastTimestamp(), event.getType(),
-                                event.getInvolvedObject().getKind(), event.getInvolvedObject().getName(),
-                                event.getReason(), event.getMessage()));
-                        eventLogWriter.flush();
-                    } catch (IOException e) {
-                        throw new RuntimeException("Error storing kubernetes events", e);
-                    }
-                }
-            }
-
-            @Override
-            public void onClose(KubernetesClientException cause) {
-            }
-        };
-
-        watchEvents = client.events().inNamespace(session.getNamespace()).watch(watcher);
-    }
-
-    private void cleanupEventsListener() {
-        if (watchEvents != null) {
-            watchEvents.close();
-        }
-
-        if (eventLogWriter != null) {
-            try {
-                eventLogWriter.close();
-            } catch (IOException e) {
-                session.getLogger().error("Error closing kubernetes events file: " + e);
-            }
-        }
-    }
-
     @Override
     public void stop() {
         try {
-            cleanupConsoleListener();
-            cleanupEventsListener();
+            watchListener.cleanupConsoleListener();
+            watchListener.cleanupEventsListener();
             clean(getSessionStatus());
         } finally {
            removeShutdownHook();
@@ -556,12 +329,7 @@ public class SessionManager implements SessionCreatedListener {
     }
 
     private void addShutdownHook() {
-        ShutdownHook hook = new ShutdownHook(new Runnable() {
-            @Override
-            public void run() {
-                SessionManager.this.clean(Constants.ABORTED_STATUS);
-            }
-        });
+        ShutdownHook hook = new ShutdownHook(() -> SessionManager.this.clean(Constants.ABORTED_STATUS));
 
         Runtime.getRuntime().addShutdownHook(hook);
         shutdownHookRef.set(hook);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/WatchListener.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/WatchListener.java
@@ -1,0 +1,230 @@
+package org.arquillian.cube.kubernetes.impl;
+
+import io.fabric8.kubernetes.api.model.v3_1.Container;
+import io.fabric8.kubernetes.api.model.v3_1.Event;
+import io.fabric8.kubernetes.api.model.v3_1.Pod;
+import io.fabric8.kubernetes.clnt.v3_1.KubernetesClient;
+import io.fabric8.kubernetes.clnt.v3_1.KubernetesClientException;
+import io.fabric8.kubernetes.clnt.v3_1.Watch;
+import io.fabric8.kubernetes.clnt.v3_1.Watcher;
+import io.fabric8.kubernetes.clnt.v3_1.dsl.LogWatch;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.arquillian.cube.impl.util.Strings;
+import org.arquillian.cube.kubernetes.api.Configuration;
+import org.arquillian.cube.kubernetes.api.Logger;
+import org.arquillian.cube.kubernetes.api.Session;
+import org.xnio.IoUtils;
+
+public class WatchListener {
+
+    private final Session session;
+    private final KubernetesClient client;
+    private final Configuration configuration;
+
+    private FileWriter eventLogWriter;
+    private String currentClassName;
+    private String currentMethodName;
+
+    private final Map<String, Collection<Closeable>> watchersMap = new ConcurrentHashMap<>();
+    private Watch watchLog;
+
+    private Watch watchEvents;
+
+    private String logPath;
+
+    WatchListener(Session session, KubernetesClient client, Configuration configuration) {
+        this.session = session;
+        this.client = client;
+        this.configuration = configuration;
+    }
+
+    void setupEventListener() {
+        final Watcher<Event> watcher = new Watcher<Event>() {
+            @Override
+            public void eventReceived(Action action, Event event) {
+                final Logger logger = session.getLogger();
+
+                final String watcherLogs = String.format("[%s] [%s] [%s:%s]: (%s) %s\n",
+                    event.getLastTimestamp(), event.getType(),
+                    event.getInvolvedObject().getKind(), event.getInvolvedObject().getName(),
+                    event.getReason(), event.getMessage());
+
+                logger.info(watcherLogs);
+
+                switch (action) {
+                    case ADDED:
+                    case MODIFIED:
+                    case DELETED:
+                    case ERROR:
+                        try {
+                            if (configuration.isLogCopyEnabled()) {
+                                setupEventLogWriter();
+                                eventLogWriter.append(watcherLogs);
+                                eventLogWriter.flush();
+                            }
+                        } catch (IOException e) {
+                            throw new RuntimeException("Error storing kubernetes events", e);
+                        }
+                }
+            }
+
+            @Override
+            public void onClose(KubernetesClientException cause) {
+            }
+        };
+
+        watchEvents = client.events().inNamespace(session.getNamespace()).watch(watcher);
+    }
+
+    void cleanupEventsListener() {
+        if (watchEvents != null) {
+            watchEvents.close();
+        }
+
+        if (eventLogWriter != null) {
+            try {
+                eventLogWriter.close();
+            } catch (IOException e) {
+                session.getLogger().error("Error closing kubernetes events file: " + e);
+            }
+        }
+    }
+
+    void setupConsoleListener() {
+        if (!configuration.isLogCopyEnabled()) {
+            return;
+        }
+
+        logPath = configuration.getLogPath();
+        if (Strings.isNullOrEmpty(logPath))
+            logPath = String.format("%s/target/surefire-reports", System.getProperty("user.dir"));
+        session.getLogger().info(String.format("Storing pods console logs into dir %s", logPath));
+        new File(logPath).mkdirs();
+
+        final Watcher<Pod> watcher = new Watcher<Pod>() {
+            @Override
+            public void eventReceived(Action action, Pod pod) {
+                switch (action) {
+                    case ADDED:
+                    case MODIFIED:
+                        if (pod.getStatus().getPhase().equalsIgnoreCase("Running")) {
+                            addConsole(pod.getMetadata().getName());
+                        }
+                        break;
+                    case DELETED:
+                    case ERROR:
+                        delConsole(pod.getMetadata().getName());
+                        break;
+                }
+            }
+
+            @Override
+            public void onClose(KubernetesClientException cause) {
+            }
+        };
+
+        watchLog = client.pods().inNamespace(session.getNamespace()).watch(watcher);
+    }
+
+    void cleanupConsoleListener() {
+        if (watchLog != null) {
+            watchLog.close();
+        }
+        watchersMap.forEach((k, v) -> {
+            IoUtils.safeClose(v.toArray(new Closeable[0]));
+        });
+        watchersMap.clear();
+    }
+
+    private void addConsole(final String podName) {
+        if (watchersMap.containsKey(podName))
+            return;
+
+        String className = session.getCurrentClassName();
+        String methodName = session.getCurrentMethodName();
+        String fileName = logPath;
+
+        if (Strings.isNullOrEmpty(className))
+            className = "NOCLASS";
+        fileName += String.format("/%s", className);
+
+        if (Strings.isNotNullOrEmpty(methodName))
+            fileName += String.format("-%s", methodName);
+
+        try {
+            Collection<Closeable> fds = new ArrayList<Closeable>();
+            List<Container> containers = client.pods().inNamespace(session.getNamespace()).withName(podName).get()
+                .getSpec().getContainers();
+            if (containers.size() == 1) {
+                fileName += String.format("-%s.log", podName);
+                final FileOutputStream stream = new FileOutputStream(fileName);
+                LogWatch lw = client.pods().inNamespace(session.getNamespace()).withName(podName).watchLog(stream);
+                fds.add(lw);
+                fds.add(stream);
+            } else {
+                for (Container container : containers) {
+                    String containerName = container.getName();
+                    String fileNameContainer = String.format("%s-%s-%s.log", fileName, podName, containerName);
+                    final FileOutputStream stream = new FileOutputStream(fileNameContainer);
+                    LogWatch lw = client.pods().inNamespace(session.getNamespace()).withName(podName).inContainer(containerName).watchLog(stream);
+                    fds.add(lw);
+                    fds.add(stream);
+                }
+            }
+
+            watchersMap.put(podName, fds);
+        } catch (FileNotFoundException e) {
+            throw new RuntimeException(String.format("Error storing the console log for pod %s", podName), e);
+        }
+
+    }
+
+    private void delConsole(String podName) {
+        Collection<Closeable> lw = watchersMap.get(podName);
+        if (lw == null)
+            return;
+
+        watchersMap.remove(podName);
+        IoUtils.safeClose(lw.toArray(new Closeable[0]));
+    }
+
+    private void setupEventLogWriter() {
+        String className = session.getCurrentClassName();
+        String methodName = session.getCurrentMethodName();
+
+        if (className != null && className.equals(currentClassName)
+            && methodName != null && methodName.equals(currentMethodName))
+            return;
+
+        currentClassName = className;
+        currentMethodName = methodName;
+        String fileName = logPath;
+
+        if (Strings.isNullOrEmpty(className))
+            className = "NOCLASS";
+        fileName += String.format("/%s", className);
+
+        if (Strings.isNotNullOrEmpty(methodName))
+            fileName += String.format("-%s", methodName);
+        fileName += "-KUBE_EVENTS.log";
+
+        try {
+            if (eventLogWriter != null) {
+                eventLogWriter.close();
+            }
+            eventLogWriter = new FileWriter(fileName, true);
+        } catch (IOException e) {
+            throw new RuntimeException("Error storing kubernetes events", e);
+        }
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:
Increases verbosity by appending watcher logs for events to console if resources are not in the ready state. 

```
LASTSEEN             FIRSTSEEN          COUNT  NAME                       KIND  SUBOBJECT       TYPE     REASON     SOURCE                   MESSAGE
2018-03-05T05:14:20Z 2018-03-05T05:14:20Z 1 hello-openshift.1518ee466716f9c9 Pod null Normal Scheduled EventSource(component=default-scheduler, host=null, additionalProperties={}) Successfully assigned hello-openshift to localhost
2018-03-05T05:14:21Z 2018-03-05T05:14:21Z 1 hello-openshift.1518ee4692267810 Pod spec.containers{hello-openshift} Normal Pulled EventSource(component=kubelet, host=localhost, additionalProperties={}) Container image "openshift/hello-openshift" already present on machine
2018-03-05T05:14:21Z 2018-03-05T05:14:21Z 1 hello-openshift.1518ee469ce37549 Pod spec.containers{hello-openshift} Normal Created EventSource(component=kubelet, host=localhost, additionalProperties={}) Created container
2018-03-05T05:14:21Z 2018-03-05T05:14:21Z 1 hello-openshift.1518ee46ad1382c1 Pod spec.containers{hello-openshift} Normal Started EventSource(component=kubelet, host=localhost, additionalProperties={}) Started container
Watcher onClose
```

#### Changes proposed in this pull request:

- logs watcher events to console. 

Fixes #1001 
