### PR TITLE
fix(#1011): filter pods ends with -deploy in awaitApplicationReadine

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
@@ -403,7 +403,7 @@ public class KubernetesAssistant {
         await().atMost(5, TimeUnit.MINUTES).until(() -> {
                 List<Pod> list = client.pods().inNamespace(namespace).list().getItems();
                 return list.stream()
-                    .filter(pod -> pod.getMetadata().getName().startsWith(applicationName))
+                    .filter(pod -> pod.getMetadata().getName().startsWith(applicationName) && !pod.getMetadata().getName().endsWith("-deploy"))
                     .filter(this::isRunning)
                     .collect(Collectors.toList()).size() >= 1;
             }

--- a/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantIT.java
+++ b/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantIT.java
@@ -30,6 +30,21 @@ public class HelloWorldOpenShiftAssistantIT {
     }
 
     @Test
+    public void should_deploy_app_programmatically() throws IOException {
+        openShiftAssistant.deployApplication("hello-openshift-deployment-config", "deployment.yml");
+
+        openShiftAssistant.awaitApplicationReadinessOrFail();
+
+        assertThat(openShiftAssistant.getClient()
+            .pods()
+            .inNamespace(openShiftAssistant.getCurrentProjectName())
+            .withLabel("name", "hello-openshift-deployment-config")
+            .list()
+            .getItems()
+            .size()).isGreaterThan(1);
+    }
+
+    @Test
     public void should_apply_route_programmatically() throws IOException {
 
         openShiftAssistant.deployApplication("hello-world", "hello-route.json");

--- a/openshift/ftest-openshift-assistant/src/test/resources/deployment.yml
+++ b/openshift/ftest-openshift-assistant/src/test/resources/deployment.yml
@@ -1,0 +1,26 @@
+kind: "DeploymentConfig"
+apiVersion: "v1"
+metadata:
+  name: "hello-openshift-deployment-config"
+spec:
+  template:
+    metadata:
+      labels:
+        name: "hello-openshift-deployment-config"
+    spec:
+      containers:
+        - name: "helloworld"
+          image: "openshift/hello-openshift:v3.6.0"
+          ports:
+            - containerPort: 8080
+              protocol: "TCP"
+  replicas: 2
+  selector:
+      name: "hello-openshift-deployment-config"
+  triggers:
+    - type: "ConfigChange"
+  strategy:
+    type: "Rolling"
+  paused: false
+  revisionHistoryLimit: 2
+  minReadySeconds: 0

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -234,7 +234,7 @@ public class OpenShiftAssistant extends KubernetesAssistant {
             .findFirst();
     }
 
-    private OpenShiftClient getClient() {
+    public OpenShiftClient getClient() {
         return client.adapt(OpenShiftClient.class);
     }
 }


### PR DESCRIPTION

#### Short description of what this resolves:
If user is deploying pod with deploymentconfig, it creates extra pod which ends with `-deploy` to manage replica. We should filter it for `awaitApplicationReadinessOrFail`

#### Changes proposed in this pull request:

-  filter pods ends with `-deploy`
- Adds ftest


Fixes #1011
