### PR TITLE
fix(#1026): update imagePullPolicy to IfNotPresent

### DIFF
--- a/kubernetes/ftest-kubernetes-assistant/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes-assistant/src/test/resources/kubernetes.json
@@ -39,6 +39,7 @@
         "spec" : {
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
+            "imagePullPolicy": "IfNotPresent",
             "name" : "hello-world-container",
             "ports" : [ {
               "name" : "http",

--- a/kubernetes/ftest-kubernetes-logs/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes-logs/src/test/resources/kubernetes.json
@@ -12,6 +12,7 @@
                 "containers": [
                     {
                         "image": "busybox",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "only-container",
                         "command": ["/bin/sh"],
                         "args": ["-c", "while true; do  sleep 1; file=\"/tmp/healthy\"; if [[ ! -f $file ]]; then touch $file; fi; echo only-one; done"],
@@ -37,6 +38,7 @@
                 "containers": [
                     {
                         "image": "busybox",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "first-container",
                         "command": ["/bin/sh"],
                         "args": ["-c", "while true; do  sleep 1; file=\"/tmp/healthy\"; if [[ ! -f $file ]]; then touch $file; fi; echo first; done"],
@@ -50,6 +52,7 @@
                     },
                     {
                         "image": "busybox",
+                        "imagePullPolicy": "IfNotPresent",
                         "name": "second-container",
                         "command": ["/bin/sh"],
                         "args": ["-c", "while true; do  sleep 1; file=\"/tmp/healthy\"; if [[ ! -f $file ]]; then touch $file; fi; echo second; done"],

--- a/kubernetes/ftest-kubernetes-reporter/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes-reporter/src/test/resources/kubernetes.json
@@ -37,6 +37,7 @@
         "spec" : {
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
+            "imagePullPolicy": "IfNotPresent",
             "name" : "hello-world-container",
             "ports" : [ {
               "name" : "http",

--- a/kubernetes/ftest-kubernetes-resources/src/test/resources/hello-world-2.yaml
+++ b/kubernetes/ftest-kubernetes-resources/src/test/resources/hello-world-2.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       containers:
       - image: openshift/hello-openshift:v3.6.0
+        imagePullPolicy: IfNotPresent
         name: hello-world-container
         ports:
         - name: http

--- a/kubernetes/ftest-kubernetes-resources/src/test/resources/hello-world.yaml
+++ b/kubernetes/ftest-kubernetes-resources/src/test/resources/hello-world.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       containers:
       - image: openshift/hello-openshift:v3.6.0
+        imagePullPolicy: IfNotPresent
         name: hello-world-container
         ports:
         - name: http

--- a/kubernetes/ftest-kubernetes/src/test/resources/kubernetes.yaml
+++ b/kubernetes/ftest-kubernetes/src/test/resources/kubernetes.yaml
@@ -27,6 +27,7 @@ spec:
     spec:
       containers:
       - image: openshift/hello-openshift:v3.6.0
+        imagePullPolicy: Always
         name: hello-world-container
         ports:
         - name: http

--- a/openshift/ftest-containerless/src/test/resources/hello_pod.json
+++ b/openshift/ftest-containerless/src/test/resources/hello_pod.json
@@ -11,13 +11,14 @@
 		"containers": [{
 			"name": "hello-openshift",
 			"image": "arquillian:./src/test/resources/wildfly",
-            "ports": [
-                {
-                    "hostPort": 8080,
-                    "containerPort": 8080,
-                    "protocol": "TCP"
-                }
-            ]
+      "imagePullPolicy": "IfNotPresent",
+      "ports": [
+          {
+              "hostPort": 8080,
+              "containerPort": 8080,
+              "protocol": "TCP"
+          }
+      ]
 		}]
 	}
 }

--- a/openshift/ftest-oc-proxy/src/test/resources/openshift.json
+++ b/openshift/ftest-oc-proxy/src/test/resources/openshift.json
@@ -40,6 +40,7 @@
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
             "name" : "hello-world-container",
+            "imagePullPolicy": "IfNotPresent",
             "ports" : [ {
               "name" : "http",
               "protocol" : "TCP",

--- a/openshift/ftest-openshift-assistant/src/test/resources/openshift.json
+++ b/openshift/ftest-openshift-assistant/src/test/resources/openshift.json
@@ -40,6 +40,7 @@
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
             "name" : "hello-world-container",
+            "imagePullPolicy": "IfNotPresent",
             "ports" : [ {
               "name" : "http",
               "protocol" : "TCP",

--- a/openshift/ftest-openshift-graphene/src/test/resources/openshift.json
+++ b/openshift/ftest-openshift-graphene/src/test/resources/openshift.json
@@ -40,6 +40,7 @@
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
             "name" : "hello-world-container",
+            "imagePullPolicy": "IfNotPresent",
             "ports" : [ {
               "name" : "http",
               "protocol" : "TCP",

--- a/openshift/ftest-openshift-resources-standalone/src/test/resources/hello-openshift.json
+++ b/openshift/ftest-openshift-resources-standalone/src/test/resources/hello-openshift.json
@@ -39,6 +39,7 @@
         "spec" : {
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
+            "imagePullPolicy": "IfNotPresent",
             "name" : "hello-world-container",
             "ports" : [ {
               "name" : "http",

--- a/openshift/ftest-openshift-restassured/src/test/resources/openshift.json
+++ b/openshift/ftest-openshift-restassured/src/test/resources/openshift.json
@@ -40,6 +40,7 @@
           "containers" : [ {
             "image" : "openshift/hello-openshift:v3.6.0",
             "name" : "hello-openshift-container",
+            "imagePullPolicy": "IfNotPresent",
             "ports" : [ {
               "name" : "http",
               "protocol" : "TCP",

--- a/openshift/ftest/src/test/resources/hello_pod.json
+++ b/openshift/ftest/src/test/resources/hello_pod.json
@@ -11,16 +11,17 @@
 		"containers": [{
 			"name": "hello-openshift",
 			"image": "arquillian:./src/test/resources/wildfly",
-            "ports": [
-                {
-                    "containerPort": 8080,
-                    "protocol": "TCP"
-                },
-                {
-                    "containerPort": 9990,
-                    "protocol": "TCP"
-                }
-            ],
+      "imagePullPolicy": "IfNotPresent",
+      "ports": [
+          {
+              "containerPort": 8080,
+              "protocol": "TCP"
+          },
+          {
+              "containerPort": 9990,
+              "protocol": "TCP"
+          }
+      ],
 			"readinessProbe" : {
 				"exec": {
 					"command": [


### PR DESCRIPTION
#### Short description of what this resolves:
K8s/openshift has default imagePullPolicy to always, which will try to pull image even if it's present on hosts which needs some time. Updated `imagePullPolicy: ifNotPresent` to reduce build time

Fixes #1026
