### PR TITLE
Make it possible to generate image streams

### DIFF
--- a/docs/kubernetes.adoc
+++ b/docs/kubernetes.adoc
@@ -212,6 +212,44 @@ You can use `@OpenShiftResource` either at class level which implies that resour
 
 You can see an example of OpenShift resources usage at https://github.com/arquillian/arquillian-cube/blob/master/openshift/ftest-openshift-resources-standalone/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftResourcesIT.java
 
+===== `@OpenShiftDynamicImageStreamResource`
+
+The `@OpenShiftResource` annotation makes it possible to add image stream definitions. To run some specific tests
+we need to be able to override the image stream definition and point to the container image we want to test.
+Very often these images are stored in insecure registries and the tags applied are different (in many cases newer)
+than expected by the original image stream definition.
+
+For this purpose the `@OpenShiftDynamicImageStreamResource` was created. We can create an image stream definition
+by providing only required information, without the need to construct the JSON or YAML object expected by OpenShift.
+Required resource will be created dynamically and deployed in OpenShift together with other resources.
+
+[cols="2,1", options="header"]
+|===
+| Parameter                              | Description
+
+| `name`                                 | Image stream name
+| `version`                              | Image stream version
+| `image`                                | Image name with registry and tag
+| `insecure`                             | If the registry is insecure, by default `true`
+
+|===
+
+[source, java]
+.OpenShiftDynamicImageStreamResourceTest.java
+----
+
+    @RunWith(Arquillian.class)
+    @Template(url = "https://raw.githubusercontent.com/${template.repository:jboss-openshift}/application-templates/${template.branch:master}/eap/eap71-sso-s2i.json")
+    @OpenShiftDynamicImageStreamResource(name = "${imageStream.eap64.name:jboss-eap64-openshift}", image = "${imageStream.eap64.image:registry.access.redhat.com/jboss-eap-6/eap64-openshift:1.8}", version = "${imageStream.eap64.version:1.8}")
+    public class OpenShiftDynamicImageStreamResourceTest {
+
+      @Test
+      public void testStuff() throws Exception {
+       //Do stuff...
+      }
+    }
+----
+
 === Namespaces
 
 The default behavior of the extension is to create a unique testing namespace per test suite. The namespace is created

--- a/openshift/api/src/main/java/org/arquillian/cube/openshift/api/OpenShiftDynamicImageStreamResource.java
+++ b/openshift/api/src/main/java/org/arquillian/cube/openshift/api/OpenShiftDynamicImageStreamResource.java
@@ -1,0 +1,77 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2015 Red Hat Inc. and/or its affiliates and other
+ * contributors as indicated by the @author tags. All rights reserved.
+ * See the copyright.txt in the distribution for a full listing of
+ * individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.arquillian.cube.openshift.api;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Repeatable;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation to generate dynamically OpenShift image stream resource before test execution.
+ *
+ * @author <a href="mailto:mgoldman@redhat.com">Marek Goldmann</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+@Repeatable(OpenShiftDynamicImageStreamResource.List.class)
+public @interface OpenShiftDynamicImageStreamResource {
+    /**
+     * Name of the image stream. This is important to use the same name
+     * as defined in template later.
+     *
+     * @return Name of the image stream
+     */
+    String name();
+
+    /**
+     * Full image name (including registry and tag)
+     *
+     * @return full image name, with tag
+     */
+    String image();
+
+    /**
+     * Version of the image stream
+     *
+     * @return
+     */
+    String version();
+
+    /**
+     * Defines if the image stream should be marked as insecure. Use
+     * 'true' or 'false' strings. By default every image stream is marked
+     * as insecure.
+     *
+     * @return string representation of boolean name
+     */
+    String insecure() default "true";
+
+    @Retention(RetentionPolicy.RUNTIME)
+    @Target({ElementType.TYPE, ElementType.ANNOTATION_TYPE, ElementType.METHOD})
+    @interface List {
+        OpenShiftDynamicImageStreamResource[] value();
+    }
+}

--- a/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/resources/OpenShiftResourceFactoryTest.java
+++ b/openshift/openshift/src/test/java/org/arquillian/cube/openshift/impl/resources/OpenShiftResourceFactoryTest.java
@@ -1,0 +1,83 @@
+package org.arquillian.cube.openshift.impl.resources;
+
+import org.arquillian.cube.impl.util.IOUtil;
+import org.arquillian.cube.openshift.api.OpenShiftDynamicImageStreamResource;
+import org.arquillian.cube.openshift.impl.adapter.OpenShiftAdapter;
+import org.arquillian.cube.openshift.impl.client.CubeOpenShiftConfiguration;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.ByteArrayInputStream;
+import java.util.List;
+import java.util.Properties;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.*;
+
+@OpenShiftDynamicImageStreamResource(name = "stream-1.0", image = "registry.host.com/imageFamily/imageName", version = "1.0", insecure = "true")
+class OpenShiftDynamicImageStreamResourceExample {
+
+}
+
+@OpenShiftDynamicImageStreamResource(name = "stream-1.0", image = "registry.host.com/imageFamily/imageName", version = "1.0", insecure = "false")
+class SecureOpenShiftDynamicImageStreamResourceExample {
+
+}
+
+@OpenShiftDynamicImageStreamResource(name = "stream-1.0", image = "registry.host.com/imageFamily/one", version = "1.0", insecure = "false")
+@OpenShiftDynamicImageStreamResource(name = "stream-2.0", image = "registry.host.com/imageFamily/two", version = "2.0", insecure = "true")
+class MultipleOpenShiftDynamicImageStreamResourceExample {
+
+}
+
+@RunWith(MockitoJUnitRunner.class)
+public class OpenShiftResourceFactoryTest {
+
+    @Mock
+    OpenShiftAdapter adapter;
+
+    @Mock
+    CubeOpenShiftConfiguration configuration;
+
+    @Before
+    public void prepareEnv() {
+        when(configuration.getProperties()).thenReturn(new Properties());
+    }
+
+    @Test
+    public void testInsecureDynamicOpenShiftResource() throws Exception {
+        OpenShiftResourceFactory.createResources("key", adapter, OpenShiftDynamicImageStreamResourceExample.class, configuration.getProperties());
+        ArgumentCaptor<ByteArrayInputStream> captor = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+
+        verify(adapter, times(1)).createResource(eq("key"), captor.capture());
+        assertEquals("{\"metadata\":{\"name\":\"stream-1.0\",\"annotations\":{\"openshift.io\\/image.insecureRepository\":true}},\"apiVersion\":\"v1\",\"kind\":\"ImageStream\",\"spec\":{\"tags\":[{\"importPolicy\":{\"insecure\":true},\"name\":\"1.0\",\"annotations\":{\"version\":\"1.0\"},\"from\":{\"kind\":\"DockerImage\",\"name\":\"registry.host.com\\/imageFamily\\/imageName\"}}]}}", IOUtil.asString(captor.getValue()));
+    }
+
+    @Test
+    public void testSecureDynamicOpenShiftResource() throws Exception {
+        OpenShiftResourceFactory.createResources("key", adapter, SecureOpenShiftDynamicImageStreamResourceExample.class, configuration.getProperties());
+        ArgumentCaptor<ByteArrayInputStream> captor = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+
+        verify(adapter, times(1)).createResource(eq("key"), captor.capture());
+        assertEquals("{\"metadata\":{\"name\":\"stream-1.0\",\"annotations\":{\"openshift.io\\/image.insecureRepository\":false}},\"apiVersion\":\"v1\",\"kind\":\"ImageStream\",\"spec\":{\"tags\":[{\"importPolicy\":{\"insecure\":false},\"name\":\"1.0\",\"annotations\":{\"version\":\"1.0\"},\"from\":{\"kind\":\"DockerImage\",\"name\":\"registry.host.com\\/imageFamily\\/imageName\"}}]}}", IOUtil.asString(captor.getValue()));
+    }
+
+    @Test
+    public void testMultipleDynamicOpenShiftResource() throws Exception {
+        OpenShiftResourceFactory.createResources("key", adapter, MultipleOpenShiftDynamicImageStreamResourceExample.class, configuration.getProperties());
+        ArgumentCaptor<ByteArrayInputStream> captor = ArgumentCaptor.forClass(ByteArrayInputStream.class);
+
+        verify(adapter, times(2)).createResource(eq("key"), captor.capture());
+
+        List<ByteArrayInputStream> is = captor.getAllValues();
+
+        assertEquals(2, is.size());
+        assertEquals("{\"metadata\":{\"name\":\"stream-1.0\",\"annotations\":{\"openshift.io\\/image.insecureRepository\":false}},\"apiVersion\":\"v1\",\"kind\":\"ImageStream\",\"spec\":{\"tags\":[{\"importPolicy\":{\"insecure\":false},\"name\":\"1.0\",\"annotations\":{\"version\":\"1.0\"},\"from\":{\"kind\":\"DockerImage\",\"name\":\"registry.host.com\\/imageFamily\\/one\"}}]}}", IOUtil.asString(is.get(0)));
+        assertEquals("{\"metadata\":{\"name\":\"stream-2.0\",\"annotations\":{\"openshift.io\\/image.insecureRepository\":true}},\"apiVersion\":\"v1\",\"kind\":\"ImageStream\",\"spec\":{\"tags\":[{\"importPolicy\":{\"insecure\":true},\"name\":\"2.0\",\"annotations\":{\"version\":\"2.0\"},\"from\":{\"kind\":\"DockerImage\",\"name\":\"registry.host.com\\/imageFamily\\/two\"}}]}}", IOUtil.asString(is.get(1)));
+    }
+}


### PR DESCRIPTION
#### Short description of what this resolves:

It is now possible to use the `@OpenShiftDynamicImageStreamResource`
annotation to generate an image stream. This image stream will be added
to the freshly generated project and removed afterwards.

This makes it easy to specify which images should be used for the test.

#### Background

Issue with testing OpenShift images is that we need to be able to specify which image should be tested. If you put tests in a pipeline you don't know what the image will be, but once it is executed, we know that information.

By definition tests should self-contained and prepare everything that is required to run the test. This includes image streams too IMHO. This is why generating an image stream beforehand and deploying it outside of the test is not really the way to go.

We can generate the image stream definition and it would be picked by the ARQ cube, but it looks pretty hacky to me.

Other option I investigated is to add another annotation, similar to the general one `@OpenShiftResource`, which would let me point to an existing IS definition and the processors inside Cube would just replace the image with the image provided, and possibly specify the insecurity of the repository. I implemented it that way, but I did not submit that idea because it looked a bit hacky (parsing JSON and YAML and replacing things).

#### Changes proposed in this pull request:

- Add `@OpenShiftDynamicImageStreamResource` annotation
