### PR TITLE
fix(#1051): improve waiting feature on application readiness

### DIFF
--- a/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantIT.java
+++ b/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantIT.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.openshift.standalone;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -13,6 +14,9 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import io.fabric8.kubernetes.api.model.v3_1.Pod;
+import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,13 +39,14 @@ public class HelloWorldOpenShiftAssistantIT {
 
         openShiftAssistant.awaitApplicationReadinessOrFail();
 
-        assertThat(openShiftAssistant.getClient()
+        List<Pod> pods = openShiftAssistant.getClient()
             .pods()
             .inNamespace(openShiftAssistant.getCurrentProjectName())
             .withLabel("name", "hello-openshift-deployment-config")
             .list()
-            .getItems()
-            .size()).isGreaterThan(1);
+            .getItems();
+        assertThat(pods.size()).isGreaterThan(1);
+        assertThat(pods).allMatch(Readiness::isPodReady);
     }
 
     @Test

--- a/openshift/ftest-openshift-assistant/src/test/resources/deployment.yml
+++ b/openshift/ftest-openshift-assistant/src/test/resources/deployment.yml
@@ -14,6 +14,11 @@ spec:
           ports:
             - containerPort: 8080
               protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 8080
+            initialDelaySeconds: 1
   replicas: 2
   selector:
       name: "hello-openshift-deployment-config"

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -149,6 +149,20 @@ public class OpenShiftAssistant extends KubernetesAssistant {
     }
 
     /**
+     * Awaits at most 5 minutes until all pods of the application are running.
+     */
+    @Override
+    public void awaitApplicationReadinessOrFail() {
+        await().atMost(5, TimeUnit.MINUTES).until(() -> {
+                return getClient()
+                    .deploymentConfigs()
+                    .inNamespace(this.namespace)
+                    .withName(this.applicationName).isReady();
+            }
+        );
+    }
+
+    /**
      * Method that returns the current deployment configuration object
      * @return Current deployment config object.
      */


### PR DESCRIPTION
#### Short description of what this resolves:

The method **awaitApplicationReadinessOrFail** was not able to wait for an application to be in a ready state but just in a running state.  Unfortunately a pod not ready is running. 
Ready means that the Pod is running and the ready probe was used and is ok.

#### Changes proposed in this pull request:

for Kubernetes:

Use isReady from the replicationController to ensure that the application is ready.

for Openshift:

Use isReady from the deploymentConfigs to ensure that the application is ready.

I have updated **awaitPodReadinessOrFail** on Pod to filter by using Readiness::isPodReady instead of running state.

Regarding testing, I can only make them on OpenShift. I have updated it **HelloWorldOpenShiftAssistantIT** to ensure that all pods (2) in the test are ready.