### PR TITLE
OpenShiftAssistant : add a scale method with applicationName

### DIFF
--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/KubernetesAssistant.java
@@ -397,14 +397,23 @@ public class KubernetesAssistant {
     }
 
     /**
-     * Awaits at most 5 minutes until all pods of the application are running.
+     * Awaits at most 5 minutes until all pods of the last deployed application are running.
      */
     public void awaitApplicationReadinessOrFail() {
+        awaitApplicationReadinessOrFail(this.applicationName);
+    }
+
+    /**
+     * Awaits at most 5 minutes until all pods of the application are running.
+     * 
+     * @param applicationName name of the application to wait for pods readiness
+     */
+    public void awaitApplicationReadinessOrFail(final String applicationName) {
         await().atMost(5, TimeUnit.MINUTES).until(() -> {
                 return client
                     .replicationControllers()
                     .inNamespace(this.namespace)
-                    .withName(this.applicationName).isReady();
+                    .withName(applicationName).isReady();
             }
         );
     }
@@ -430,32 +439,29 @@ public class KubernetesAssistant {
     }
 
     /**
-     * Scaling the application to given replicas
+     * Scaling the last deployed application to given replicas
      *
      * @param replicas to scale the application
      */
     public void scale(final int replicas) {
-        log.info(String.format("Scaling replicas from %s to %s.", getPods("deployment").size(), replicas));
-        this.client
+        scale(this.applicationName, replicas);
+    }
+
+    /**
+     * Scaling the application to given replicas
+     * 
+     * @param applicationName name of the application to scale
+     * @param replicas to scale the application
+     */
+    public void scale(final String applicationName, final int replicas) {
+        final ReplicationController replicationController = this.client
             .replicationControllers()
             .inNamespace(this.namespace)
-            .withName(this.applicationName)
+            .withName(applicationName)
             .scale(replicas);
-
-        // ideally, we'd look at deployment status.availableReplicas field,
-        // but that's only available since OpenShift 3.5
-        await().atMost(5, TimeUnit.MINUTES)
-            .until(() -> {
-                final List<Pod> pods = getPods("deployment");
-                try {
-                    return pods.size() == replicas && pods.stream()
-                        .allMatch(Readiness::isPodReady);
-                } catch (final IllegalStateException e) {
-                    // the 'Ready' condition can be missing sometimes, in which case Readiness.isPodReady throws an exception
-                    // here, we'll swallow that exception in hope that the 'Ready' condition will appear later
-                    return false;
-                }
-            });
+        final int availableReplicas = replicationController.getStatus().getAvailableReplicas();
+        log.info(String.format("Scaling replicas from %d to %d for application %s.", availableReplicas, replicas, applicationName));
+        awaitApplicationReadinessOrFail(applicationName);
     }
 
     protected List<Pod> getPods(String label) {

--- a/openshift/ftest-openshift-assistant-operational-methods/src/test/resources/hello-scale-template.yaml
+++ b/openshift/ftest-openshift-assistant-operational-methods/src/test/resources/hello-scale-template.yaml
@@ -1,0 +1,28 @@
+kind: "DeploymentConfig"
+apiVersion: "v1"
+metadata:
+  name: "hello-openshift-scale-deployment-config"
+spec:
+  template:
+    metadata:
+      labels:
+        name: "hello-openshift-scale-deployment-config"
+    spec:
+      containers:
+        - name: "helloworld"
+          image: "openshift/hello-openshift:v3.6.0"
+          ports:
+            - containerPort: 8080
+              protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 8080
+            initialDelaySeconds: 1
+  replicas: 1
+  selector:
+      name: "hello-openshift-scale-deployment-config"
+  triggers:
+    - type: "ConfigChange"
+  strategy:
+    type: "Rolling"

--- a/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantIT.java
+++ b/openshift/ftest-openshift-assistant/src/test/java/org/arquillian/cube/openshift/standalone/HelloWorldOpenShiftAssistantIT.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.openshift.standalone;
 
 import java.io.IOException;
 import java.net.URL;
+import java.util.List;
 import java.util.Optional;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
@@ -13,6 +14,9 @@ import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
+
+import io.fabric8.kubernetes.api.model.v3_1.Pod;
+import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -35,13 +39,14 @@ public class HelloWorldOpenShiftAssistantIT {
 
         openShiftAssistant.awaitApplicationReadinessOrFail();
 
-        assertThat(openShiftAssistant.getClient()
+        List<Pod> pods = openShiftAssistant.getClient()
             .pods()
             .inNamespace(openShiftAssistant.getCurrentProjectName())
             .withLabel("name", "hello-openshift-deployment-config")
             .list()
-            .getItems()
-            .size()).isGreaterThan(1);
+            .getItems();
+        assertThat(pods.size()).isGreaterThan(1);
+        assertThat(pods).allMatch(Readiness::isPodReady);
     }
 
     @Test

--- a/openshift/ftest-openshift-assistant/src/test/resources/deployment.yml
+++ b/openshift/ftest-openshift-assistant/src/test/resources/deployment.yml
@@ -14,6 +14,11 @@ spec:
           ports:
             - containerPort: 8080
               protocol: "TCP"
+          readinessProbe:
+            httpGet:
+              path: "/"
+              port: 8080
+            initialDelaySeconds: 1
   replicas: 2
   selector:
       name: "hello-openshift-deployment-config"

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -149,6 +149,20 @@ public class OpenShiftAssistant extends KubernetesAssistant {
     }
 
     /**
+     * Awaits at most 5 minutes until all pods of the application are running.
+     */
+    @Override
+    public void awaitApplicationReadinessOrFail() {
+        await().atMost(5, TimeUnit.MINUTES).until(() -> {
+                return getClient()
+                    .deploymentConfigs()
+                    .inNamespace(this.namespace)
+                    .withName(this.applicationName).isReady();
+            }
+        );
+    }
+
+    /**
      * Method that returns the current deployment configuration object
      * @return Current deployment config object.
      */

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftAssistant.java
@@ -1,13 +1,8 @@
 package org.arquillian.cube.openshift.impl.client;
 
-import io.fabric8.kubernetes.api.model.v3_1.HasMetadata;
-import io.fabric8.kubernetes.api.model.v3_1.Pod;
-import io.fabric8.kubernetes.clnt.v3_1.internal.readiness.Readiness;
-import io.fabric8.openshift.api.model.v3_1.DeploymentConfig;
-import io.fabric8.openshift.api.model.v3_1.Project;
-import io.fabric8.openshift.api.model.v3_1.Route;
-import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
-import org.arquillian.cube.kubernetes.impl.KubernetesAssistant;
+import static org.arquillian.cube.openshift.impl.client.OpenShiftRouteLocator.createUrlFromRoute;
+import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
+import static org.awaitility.Awaitility.await;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -19,9 +14,13 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
 
-import static org.arquillian.cube.openshift.impl.client.OpenShiftRouteLocator.createUrlFromRoute;
-import static org.arquillian.cube.openshift.impl.client.ResourceUtil.awaitRoute;
-import static org.awaitility.Awaitility.await;
+import org.arquillian.cube.kubernetes.impl.KubernetesAssistant;
+
+import io.fabric8.kubernetes.api.model.v3_1.HasMetadata;
+import io.fabric8.openshift.api.model.v3_1.DeploymentConfig;
+import io.fabric8.openshift.api.model.v3_1.Project;
+import io.fabric8.openshift.api.model.v3_1.Route;
+import io.fabric8.openshift.clnt.v3_1.OpenShiftClient;
 
 /**
  * Class that allows you to deploy undeploy and wait for resources programmatically in a test.
@@ -120,44 +119,53 @@ public class OpenShiftAssistant extends KubernetesAssistant {
     }
 
     /**
-     * Scaling the application to given replicas
+     * Scaling the last deployed application to given replicas
+     * 
      * @param replicas to scale the application
      */
     @Override
     public void scale(final int replicas) {
-        log.info(String.format("Scaling replicas from %s to %s.", getPods("deploymentconfig").size(), replicas));
-        getClient()
+        scale(this.applicationName, replicas);
+    }
+
+    /**
+     * Scaling the application to given replicas
+     * 
+     * @param applicationName name of the application to scale
+     * @param replicas to scale the application
+     */
+    @Override
+    public void scale(final String applicationName, final int replicas) {
+        final DeploymentConfig deploymentConfig = getClient()
             .deploymentConfigs()
             .inNamespace(this.namespace)
-            .withName(this.applicationName)
+            .withName(applicationName)
             .scale(replicas);
+        final int availableReplicas = deploymentConfig.getStatus().getAvailableReplicas();
+        log.info(String.format("Scaling replicas from %d to %d for application %s.", availableReplicas, replicas, applicationName));
+        awaitApplicationReadinessOrFail(applicationName);
+    }
 
-        // ideally, we'd look at deployment config's status.availableReplicas field,
-        // but that's only available since OpenShift 3.5
-        await().atMost(5, TimeUnit.MINUTES)
-            .until(() -> {
-                final List<Pod> pods = getPods("deploymentconfig");
-                try {
-                    return pods.size() == replicas && pods.stream()
-                        .allMatch(Readiness::isPodReady);
-                } catch (final IllegalStateException e) {
-                    // the 'Ready' condition can be missing sometimes, in which case Readiness.isPodReady throws an exception
-                    // here, we'll swallow that exception in hope that the 'Ready' condition will appear later
-                    return false;
-                }
-            });
+    /**
+     * Awaits at most 5 minutes until all pods of the last deployed application are running.
+     */
+    @Override
+    public void awaitApplicationReadinessOrFail() {
+        awaitApplicationReadinessOrFail(this.applicationName);
     }
 
     /**
      * Awaits at most 5 minutes until all pods of the application are running.
+     * 
+     * @param applicationName name of the application to wait for pods readiness
      */
     @Override
-    public void awaitApplicationReadinessOrFail() {
+    public void awaitApplicationReadinessOrFail(final String applicationName) {
         await().atMost(5, TimeUnit.MINUTES).until(() -> {
                 return getClient()
                     .deploymentConfigs()
                     .inNamespace(this.namespace)
-                    .withName(this.applicationName).isReady();
+                    .withName(applicationName).isReady();
             }
         );
     }


### PR DESCRIPTION
#### Short description of what this resolves:

I have got a Wildfly Swarm application using jaxrs, and JPA. My application is linked with a PostgreSQL database.

I want to test my application when the database is down (scale defined to 0) to ensure that my rest api will respond as expected (custom json response with custom response code).

However, using OpenShiftAssistant, is not currently possible because the scale method used the last deployed application name.

To run my application I need to run PostgreSQL first and then my Wildfly application to avoid it to crash on startup.

#### Changes proposed in this pull request:

On this pull request I have added a scale method with applicationName and desired scale parameters on both OpenShiftAssistant and KubernetesAssistant.

I have mutualized some methods like awaitApplicationReadinessOrFail.

Regards,
Damien

Fixes #1052
