### PR TITLE
Issue 1069

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
@@ -1,20 +1,42 @@
 package org.arquillian.cube.docker.impl.docker.compose;
 
-import org.arquillian.cube.docker.impl.client.config.*;
+import org.arquillian.cube.docker.impl.client.config.BuildImage;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.Device;
+import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
+import org.arquillian.cube.docker.impl.client.config.ExposedPort;
+import org.arquillian.cube.docker.impl.client.config.Image;
+import org.arquillian.cube.docker.impl.client.config.Link;
+import org.arquillian.cube.docker.impl.client.config.PortBinding;
+import org.arquillian.cube.docker.impl.client.config.RestartPolicy;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Properties;
+import java.util.Random;
+import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import static org.arquillian.cube.docker.impl.util.YamlUtil.*;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asBoolean;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asInt;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asListOfString;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asLong;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asMap;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asMapOfStrings;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.asString;
 
 
 public class ContainerBuilder {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
@@ -1,42 +1,20 @@
 package org.arquillian.cube.docker.impl.docker.compose;
 
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asBoolean;
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asInt;
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asListOfString;
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asLong;
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asMap;
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asMapOfStrings;
-import static org.arquillian.cube.docker.impl.util.YamlUtil.asString;
+import org.arquillian.cube.docker.impl.client.config.*;
 
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashSet;
-import java.util.List;
-import java.util.ArrayList;
-import java.util.Map;
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Properties;
-import java.util.Random;
-import java.util.Set;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
-import org.arquillian.cube.docker.impl.client.config.BuildImage;
-import org.arquillian.cube.docker.impl.client.config.CubeContainer;
-import org.arquillian.cube.docker.impl.client.config.Device;
-import org.arquillian.cube.docker.impl.client.config.ExposedPort;
-import org.arquillian.cube.docker.impl.client.config.Image;
-import org.arquillian.cube.docker.impl.client.config.Link;
-import org.arquillian.cube.docker.impl.client.config.PortBinding;
-import org.arquillian.cube.docker.impl.client.config.RestartPolicy;
-import org.yaml.snakeyaml.Yaml;
+import static org.arquillian.cube.docker.impl.util.YamlUtil.*;
 
 
 public class ContainerBuilder {
@@ -682,21 +660,15 @@ public class ContainerBuilder {
     }
 
     public ContainerBuilder extend(Path location, String service) {
-        File extendLocation = this.dockerComposeRootLocation.resolve(location).toFile();
-        try(FileInputStream inputStream = new FileInputStream(extendLocation)) {
-            // resolve parameters
-            String content = DockerComposeEnvironmentVarResolver.replaceParameters(inputStream);
-            Map<String, Object> extendedDockerComposeFile = (Map<String, Object>) new Yaml().load(content);
-            Map<String, Object> serviceDockerComposeConfiguration = asMap(extendedDockerComposeFile, service);
+        Path extendLocation = this.dockerComposeRootLocation.resolve(location);
+        DockerCompositions dockerCompositions = DockerComposeConverter.create(extendLocation).convert();
+        CubeContainer cubeContainer = dockerCompositions.getContainers().get(service);
+
+        if (cubeContainer == null) {
+            throw new IllegalArgumentException(String.format("Service name %s is not present at %s", service, extendLocation.toAbsolutePath()));
+        } else {
             ContainerBuilder containerBuilder = new ContainerBuilder(dockerComposeRootLocation, configuration);
-            configuration = containerBuilder.build(serviceDockerComposeConfiguration);
-
-            if(serviceDockerComposeConfiguration == null) {
-                throw new IllegalArgumentException(String.format("Service name %s is not present at %s", service, extendLocation.getAbsolutePath()));
-            }
-
-        } catch (IOException e) {
-            throw new IllegalArgumentException(e);
+            configuration.merge(cubeContainer);
         }
         return this;
     }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverterTest.java
@@ -99,6 +99,22 @@ public class DockerComposeConverterTest {
     assertThat(ports, containsInAnyOrder(PortBinding.valueOf("8080->8080")));
   }
 
+
+  @Test
+  public void shouldExtendDockerComposeV2() throws URISyntaxException, IOException {
+    URI readEnvsDockerCompose = DockerComposeConverterTest.class.getResource("/extends-docker-compose-v2.yml").toURI();
+    DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(readEnvsDockerCompose));
+
+    DockerCompositions convert = dockerComposeConverter.convert();
+    CubeContainer webapp = convert.get("web");
+    assertThat(webapp.getEnv(), is(notNullValue()));
+    Collection<String> env = webapp.getEnv();
+    assertThat(env, containsInAnyOrder("REDIS_HOST=redis-production.example.com"));
+    assertThat(webapp.getPortBindings(), is(notNullValue()));
+    Collection<PortBinding> ports = webapp.getPortBindings();
+    assertThat(ports, containsInAnyOrder(PortBinding.valueOf("8080->8080")));
+  }
+
   @Test
   public void shouldExtendDockerComposeWithEnvResolution() throws URISyntaxException, IOException {
 
@@ -107,6 +123,30 @@ public class DockerComposeConverterTest {
 
     try {
       URI readEnvsDockerCompose = DockerComposeConverterTest.class.getResource("/extends-docker-compose-env.yml").toURI();
+      DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(readEnvsDockerCompose));
+
+      DockerCompositions convert = dockerComposeConverter.convert();
+      CubeContainer webapp = convert.get("web");
+      assertThat(webapp.getEnv(), is(notNullValue()));
+      Collection<String> env = webapp.getEnv();
+      assertThat(env, containsInAnyOrder("REDIS_HOST=redis-production.example.com"));
+      assertThat(webapp.getPortBindings(), is(notNullValue()));
+      Collection<PortBinding> ports = webapp.getPortBindings();
+      assertThat(ports, containsInAnyOrder(PortBinding.valueOf("9090->8080")));
+    } finally {
+      System.clearProperty("ports");
+      if (oldValue != null)
+        System.setProperty("ports", oldValue);
+    }
+  }
+
+  @Test
+  public void shouldExtendDockerComposeV2WithEnvResolution() throws URISyntaxException, IOException {
+    String oldValue = System.getProperty("ports");
+    System.setProperty("ports", "9090:8080");
+
+    try {
+      URI readEnvsDockerCompose = DockerComposeConverterTest.class.getResource("/extends-docker-compose-env-v2.yml").toURI();
       DockerComposeConverter dockerComposeConverter = DockerComposeConverter.create(Paths.get(readEnvsDockerCompose));
 
       DockerCompositions convert = dockerComposeConverter.convert();

--- a/docker/docker/src/test/resources/commons-v2.yml
+++ b/docker/docker/src/test/resources/commons-v2.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  web:
+    image: ubuntu
+    ports:
+      - "8080:8080"
+    environment:
+      - REDIS_HOST=redis-demo.example.com

--- a/docker/docker/src/test/resources/extends-docker-compose-env-v2.yml
+++ b/docker/docker/src/test/resources/extends-docker-compose-env-v2.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  web:
+    extends:
+      file: commons-env.yml
+      service: web
+    environment:
+      - REDIS_HOST=redis-production.example.com

--- a/docker/docker/src/test/resources/extends-docker-compose-v2.yml
+++ b/docker/docker/src/test/resources/extends-docker-compose-v2.yml
@@ -1,0 +1,9 @@
+version: "2"
+
+services:
+  web:
+    extends:
+      file: commons.yml
+      service: web
+    environment:
+      - REDIS_HOST=redis-production.example.com


### PR DESCRIPTION
#### Short description of what this resolves:

Allows docker-compose `extend` with `version: "2"`.

#### Changes proposed in this pull request:

- Use `DockerCompseConverter` in `ContainerBuilder#extend()`

Fixes #1069
