### PR TITLE
fix(#1084): If Docker Compose is v3 it uses v2 logic instead of failing

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverter.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverter.java
@@ -65,8 +65,8 @@ public class DockerComposeConverter implements Converter {
 
         Set<String> names = dockerComposeDefinitionMap.keySet();
 
-        boolean isV2 = names.contains(DOCKER_COMPOSE_VERSION_KEY) && DOCKER_COMPOSE_VERSION_2_VALUE.equals(dockerComposeDefinitionMap.get(DOCKER_COMPOSE_VERSION_KEY));
-        if (isV2) {
+        boolean isV2OrGreater = names.contains(DOCKER_COMPOSE_VERSION_KEY) && Integer.parseInt((String) dockerComposeDefinitionMap.get(DOCKER_COMPOSE_VERSION_KEY)) > 1;
+        if (isV2OrGreater) {
             dockerCompositions = convertCompose(dockerComposeDefinitionMap);
         } else {
             for(String name : names) {


### PR DESCRIPTION
#### Short description of what this resolves:

If Docker Compose is v3 it uses v2 logic instead of failing

#### Changes proposed in this pull request:

- Compare by integer instead of by a string


Fixes #1084 
