### PR TITLE
#1098 VideoConversionLifecycleManager & VncRecorderLifecycleManager

### DIFF
--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/CubeDroneConfiguration.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/CubeDroneConfiguration.java
@@ -36,6 +36,8 @@ public class CubeDroneConfiguration {
      */
     private String containerNamePrefix = null;
 
+    private String dockerRegistry = "";
+
     public static CubeDroneConfiguration fromMap(Map<String, String> config) {
         CubeDroneConfiguration cubeDroneConfiguration = new CubeDroneConfiguration();
 
@@ -61,6 +63,21 @@ public class CubeDroneConfiguration {
 
         if (config.containsKey("containerNamePrefix")) {
             cubeDroneConfiguration.containerNamePrefix = config.get("containerNamePrefix");
+        }
+
+        if (config.containsKey("dockerRegistry")) {
+            String dockerRegistry = config.get("dockerRegistry");
+
+            if(null != dockerRegistry) {
+
+                dockerRegistry = dockerRegistry.trim();
+
+                if(!dockerRegistry.endsWith("/")){
+                    dockerRegistry = dockerRegistry + "/";
+                }
+
+                cubeDroneConfiguration.dockerRegistry = dockerRegistry;
+            }
         }
 
         return cubeDroneConfiguration;
@@ -109,7 +126,11 @@ public class CubeDroneConfiguration {
     public String getContainerNamePrefix(){
         return this.containerNamePrefix;
     }
-    
+
+    public String getDockerRegistry() {
+        return dockerRegistry;
+    }
+
     public static enum RecordMode {
         ALL, ONLY_FAILING, NONE;
     }

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VideoConversionLifecycleManager.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/VideoConversionLifecycleManager.java
@@ -2,12 +2,16 @@ package org.arquillian.cube.docker.drone;
 
 import org.arquillian.cube.docker.drone.event.AfterConversion;
 import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeControlException;
 import org.arquillian.cube.spi.CubeRegistry;
 import org.jboss.arquillian.core.api.Event;
 import org.jboss.arquillian.core.api.Instance;
 import org.jboss.arquillian.core.api.annotation.Inject;
 import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.event.suite.AfterSuite;
+
+import java.util.logging.Level;
+import java.util.logging.Logger;
 
 public class VideoConversionLifecycleManager {
 
@@ -22,12 +26,16 @@ public class VideoConversionLifecycleManager {
     public void startConversion(@Observes AfterSuite afterSuite, CubeDroneConfiguration cubeDroneConfiguration,
         CubeRegistry cubeRegistry) {
 
-        if (cubeDroneConfiguration.isRecording()) {
-            initConversionCube(cubeRegistry);
-            flv2mp4.create();
-            flv2mp4.start();
-    
-            afterConversionEvent.fire(new AfterConversion());
+        try {
+            if (cubeDroneConfiguration.isRecording()) {
+                initConversionCube(cubeRegistry);
+                flv2mp4.create();
+                flv2mp4.start();
+
+                afterConversionEvent.fire(new AfterConversion());
+            }
+        } catch (CubeControlException e) {
+            Logger.getLogger(VideoConversionLifecycleManager.class.getName()).log(Level.WARNING, "Failed to start flv2mp4", e);
         }
     }
 
@@ -49,8 +57,12 @@ public class VideoConversionLifecycleManager {
     public void stopContainer(@Observes AfterConversion afterConversion) {
 
         if (this.flv2mp4 != null) {
-            flv2mp4.stop();
-            flv2mp4.destroy();
+            try {
+                flv2mp4.stop();
+                flv2mp4.destroy();
+            } catch (CubeControlException e) {
+                Logger.getLogger(VideoConversionLifecycleManager.class.getName()).log(Level.WARNING, "Failed to stop flv2mp4", e);
+            }
         }
     }
 }

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/util/VolumeCreator.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/util/VolumeCreator.java
@@ -17,7 +17,7 @@ public class VolumeCreator {
 
     /**
      * Creates a new temporary folder with password file for VNC server.
-     * The folder is relative to the root of the project.
+     * The folder is relative to the root of the project target/vnc folder.
      *
      * @param password
      *     value to generate password file.
@@ -25,7 +25,7 @@ public class VolumeCreator {
      * @return Path of generated file.
      */
     public static final Path createTemporaryVolume(String password) {
-        final File tmpFile = new File(".tmp" + System.currentTimeMillis());
+        final File tmpFile = new File("target/vnc/.tmp" + System.currentTimeMillis());
 
         if (!tmpFile.mkdirs()) {
             throw new IllegalArgumentException("Temporary Folder for storing recordings could not be created.");

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -9,6 +9,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import java.util.HashMap;
+
 import static org.hamcrest.CoreMatchers.both;
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
@@ -95,6 +97,7 @@ public class SeleniumContainersTest {
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
         when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
+        when(cubeDroneConfiguration.getDockerRegistry()).thenReturn("");
 
         final SeleniumContainers firefox = SeleniumContainers.create("firefox", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("firefox"));
@@ -109,6 +112,7 @@ public class SeleniumContainersTest {
         when(cubeDroneConfiguration.isBrowserDockerfileDirectorySet()).thenReturn(false);
         when(cubeDroneConfiguration.isBrowserImageSet()).thenReturn(false);
         when(cubeDroneConfiguration.getContainerNameStrategy()).thenReturn(ContainerNameStrategy.STATIC);
+        when(cubeDroneConfiguration.getDockerRegistry()).thenReturn("");
 
         final SeleniumContainers firefox = SeleniumContainers.create("chrome", cubeDroneConfiguration);
         assertThat(firefox.getBrowser(), is("chrome"));
@@ -155,5 +159,45 @@ public class SeleniumContainersTest {
         assertThat(seleniumContainers.getSeleniumContainerName(), is("browser"));
         assertThat(seleniumContainers.getVncContainerName(), is("vnc"));
         assertThat(seleniumContainers.getVideoConverterContainerName(), is("flv2mp4"));
+    }
+
+    @Test
+    public void shouldHaveDockerRegistry() {
+
+        final CubeDroneConfiguration conf = CubeDroneConfiguration.fromMap( new HashMap<String, String>() {{
+            put("containerNameStrategy",ContainerNameStrategy.STATIC_PREFIX.toString());
+            put("dockerRegistry","my.registry");
+        }});
+
+        checkRegistry(conf);
+    }
+
+    @Test
+    public void shouldHaveDockerRegistrySlash() {
+
+        final CubeDroneConfiguration conf = CubeDroneConfiguration.fromMap( new HashMap<String, String>() {{
+            put("containerNameStrategy",ContainerNameStrategy.STATIC_PREFIX.toString());
+            put("dockerRegistry","my.registry/");
+        }});
+
+        checkRegistry(conf);
+    }
+
+    @Test
+    public void shouldHaveDockerRegistryNewline() {
+
+        final CubeDroneConfiguration conf = CubeDroneConfiguration.fromMap( new HashMap<String, String>() {{
+            put("containerNameStrategy",ContainerNameStrategy.STATIC_PREFIX.toString());
+            put("dockerRegistry","my.registry/\r\n ");
+        }});
+
+        checkRegistry(conf);
+    }
+
+    private void checkRegistry(CubeDroneConfiguration conf) {
+        final SeleniumContainers seleniumContainers = SeleniumContainers.create("firefox", conf);
+        assertThat(seleniumContainers.getSeleniumContainer().getImage().toString(), startsWith("my.registry/selenium"));
+        assertThat(seleniumContainers.getVideoConverterContainer().getImage().toString(), startsWith("my.registry/arquillian"));
+        assertThat(seleniumContainers.getVncContainer().getImage().toString(), startsWith("my.registry/richnorth"));
     }
 }

--- a/docker/ftest-container-star-operator/pom.xml
+++ b/docker/ftest-container-star-operator/pom.xml
@@ -68,6 +68,12 @@
       <artifactId>wildfly-arquillian-container-remote</artifactId>
       <version>${version.wildfly}</version>
       <scope>test</scope>
+      <exclusions>
+        <exclusion>
+          <artifactId>jconsole</artifactId>
+          <groupId>sun.jdk</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
 

--- a/docs/drone.adoc
+++ b/docs/drone.adoc
@@ -47,6 +47,7 @@ browserImage:: Docker image to be used as custom browser image instead of the of
 browserDockerfileLocation:: Dockerfile location to be used to built custom docker image instead of the official one. This property has preference over browserImage.
 containerNameStrategy:: Sets the strategy for generating the container name. Valid values are `STATIC, STATIC_PREFIX, RANDOM` with the default being `STATIC`. `STATIC` will always use the same name, `STATIC_PREFIX` lets you define a prefix and enables running different tests in parallel and `RANDOM` generates a unique container name on every test run enabling running the same test in parallel.
 containerNamePrefix:: The prefix for the `STATIC_PREFIX` container name strategy.
+dockerRegistry:: Use this to override the default docker registry with a user specified registry.
 
 IMPORTANT: Your custom images must expose the webdriver port `4444` and if you plan to use VNC, expose the default port `5900` as well
 


### PR DESCRIPTION
#### Short description of what this resolves:

Catch and log errors in `@Observes` methods, but do not fail the suite and allow cleanups - This should actually be the default for any `@Observes` method, as the CDI events are synchronous - A failure prevents other observers from running, such as cleanups etc.

Also, the Cube internal images might need to be pulled from a user specified docker registry. So this PR also adds and new "dockerRegistry" property - I did think about using the _docker_ qualifier, but using _cubedrone_ allows for a different registry if required (actually have a use case for this). 

#### Changes proposed in this pull request:

- Added try/catch/log to `@Observes` methods in above classes
- VolumeCreator.java should use a better path
- Added "dockerRegistry" property & documentation


Fixes #1098
