### PR TITLE
Execute commands after container start

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/afterStart/AfterStartActionFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/afterStart/AfterStartActionFactory.java
@@ -1,0 +1,13 @@
+package org.arquillian.cube.docker.impl.afterStart;
+
+import org.arquillian.cube.docker.impl.client.config.CustomAfterStartAction;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.impl.model.CubeId;
+import org.arquillian.cube.spi.afterStart.AfterStartAction;
+
+public class AfterStartActionFactory {
+
+    public static final AfterStartAction create(DockerClientExecutor dockerClientExecutor, CubeId containerId, CustomAfterStartAction afterStartStrategy) {
+        return new CustomAfterStartActionInstantiator(containerId, dockerClientExecutor, afterStartStrategy);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/afterStart/CustomAfterStartActionInstantiator.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/afterStart/CustomAfterStartActionInstantiator.java
@@ -1,0 +1,65 @@
+package org.arquillian.cube.docker.impl.afterStart;
+
+import org.arquillian.cube.docker.impl.client.config.CustomAfterStartAction;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.impl.model.CubeId;
+import org.arquillian.cube.spi.afterStart.AfterStartAction;
+
+import java.beans.IntrospectionException;
+import java.beans.Introspector;
+import java.beans.PropertyDescriptor;
+import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+
+public class CustomAfterStartActionInstantiator implements AfterStartAction {
+    private CubeId containerId;
+    private DockerClientExecutor dockerClientExecutor;
+    private CustomAfterStartAction customAfterStartAction;
+
+    public CustomAfterStartActionInstantiator(CubeId containerId, DockerClientExecutor dockerClientExecutor,
+                                              CustomAfterStartAction customAfterStartAction) {
+        this.containerId = containerId;
+        this.dockerClientExecutor = dockerClientExecutor;
+        this.customAfterStartAction = customAfterStartAction;
+    }
+
+    @Override
+    public void doAfterStart() {
+        try {
+            String classname = customAfterStartAction.getStrategy();
+            Class<? extends AfterStartAction> customStrategy =
+                (Class<? extends AfterStartAction>) Class.forName(classname);
+            AfterStartAction customStrategyInstance = customStrategy.newInstance();
+
+            // Inject if there is a field of type Cube, DockerClientExecutor
+            final Field[] fields = customStrategyInstance.getClass().getDeclaredFields();
+            for (Field field : fields) { // Inject if there is a field of type Cube, DockerClientExecutor
+                if (field.getType().isAssignableFrom(DockerClientExecutor.class)) {
+                    field.setAccessible(true);
+                    field.set(customStrategyInstance, this.dockerClientExecutor);
+                } else if (field.getType().isAssignableFrom(CubeId.class)) {
+                    field.setAccessible(true);
+                    field.set(customStrategyInstance, this.containerId);
+                }
+            }
+
+            for (PropertyDescriptor propertyDescriptor : Introspector.getBeanInfo(customStrategyInstance.getClass())
+                .getPropertyDescriptors()) {
+                final Method writeMethod = propertyDescriptor.getWriteMethod();
+                if (writeMethod != null) {
+                    if (writeMethod.getParameterTypes()[0].isAssignableFrom(CubeId.class)) {
+                        writeMethod.invoke(customStrategyInstance, this.containerId);
+                    } else if (writeMethod.getParameterTypes()[0].isAssignableFrom(DockerClientExecutor.class)) {
+                        writeMethod.invoke(customStrategyInstance, this.dockerClientExecutor);
+                    }
+                }
+            }
+
+            // Finally, we call the afterStart method
+            customStrategyInstance.doAfterStart();
+        } catch (ClassNotFoundException | IllegalAccessException | InstantiationException | IntrospectionException | InvocationTargetException e) {
+            throw new IllegalArgumentException(e);
+        }
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AfterStartContainerObserver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AfterStartContainerObserver.java
@@ -1,0 +1,63 @@
+package org.arquillian.cube.docker.impl.client;
+
+import org.arquillian.cube.docker.impl.afterStart.AfterStartActionFactory;
+import org.arquillian.cube.docker.impl.client.config.AfterStart;
+import org.arquillian.cube.docker.impl.client.config.Copy;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.CustomAfterStartAction;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.impl.model.DefaultCubeId;
+import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+import java.io.File;
+import java.util.Collection;
+
+public class AfterStartContainerObserver {
+
+    public void processCommands(@Observes org.arquillian.cube.spi.event.lifecycle.AfterStart afterStart,
+        CubeRegistry cubeRegistry,
+        DockerClientExecutor dockerClientExecutor) {
+
+        Cube<CubeContainer> cube = cubeRegistry.getCube(afterStart.getCubeId(), DockerCube.class);
+        CubeContainer configuration = cube.configuration();
+
+        if (configuration.getAfterStart() != null) {
+            Collection<AfterStart> afterStartConfiguration = configuration.getAfterStart();
+
+            for (AfterStart map : afterStartConfiguration) {
+                if (map.getCopy() != null) {
+                    Copy copyConfiguration = map.getCopy();
+                    executeCopyAction(dockerClientExecutor, afterStart.getCubeId(), copyConfiguration);
+                }
+                if (map.getCustomAfterStartAction() != null) {
+                    CustomAfterStartAction customAfterStartAction = map.getCustomAfterStartAction();
+                    executeCustomAfterStartAction(dockerClientExecutor, afterStart.getCubeId(), customAfterStartAction);
+                }
+            }
+        }
+    }
+
+    private void executeCustomAfterStartAction(DockerClientExecutor dockerClientExecutor, String containerId,
+        CustomAfterStartAction customAfterStartAction) {
+        AfterStartActionFactory.create(dockerClientExecutor, new DefaultCubeId(containerId), customAfterStartAction)
+            .doAfterStart();
+    }
+
+    private void executeCopyAction(DockerClientExecutor dockerClientExecutor, String containerId,
+        Copy configurationParameters) {
+        String to;
+        String from;
+        if (configurationParameters.getTo() != null && configurationParameters.getFrom() != null) {
+            to = configurationParameters.getTo();
+            from = configurationParameters.getFrom();
+        } else {
+            throw new IllegalArgumentException(
+                String.format("to and from property is mandatory when copying files to container %s.", containerId));
+        }
+
+        dockerClientExecutor.copyStreamToContainer(containerId, new File(from), to);
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
@@ -23,6 +23,7 @@ public class CubeDockerExtension implements LoadableExtension {
             .observer(CubeDockerRegistrar.class)
             .observer(CubeSuiteLifecycleController.class)
             //.observer(ClientCubeControllerCreator.class)
+            .observer(AfterStartContainerObserver.class)
             .observer(BeforeStopContainerObserver.class)
             .observer(Boot2DockerCreator.class)
             .observer(DockerMachineCreator.class)

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/AfterStart.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/AfterStart.java
@@ -1,0 +1,27 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class AfterStart {
+
+    private Copy copy;
+
+    private CustomAfterStartAction customAfterStartAction;
+
+    public AfterStart() {
+    }
+
+    public Copy getCopy() {
+        return copy;
+    }
+
+    public void setCopy(Copy copy) {
+        this.copy = copy;
+    }
+
+    public CustomAfterStartAction getCustomAfterStartAction() {
+        return customAfterStartAction;
+    }
+
+    public void setCustomAfterStartAction(CustomAfterStartAction customAfterStartAction) {
+        this.customAfterStartAction = customAfterStartAction;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
@@ -66,6 +66,7 @@ public class CubeContainer {
 
     private BuildImage buildImage;
 
+    private Collection<AfterStart> afterStart;
     private Collection<BeforeStop> beforeStop;
 
     public Image getImage() {
@@ -422,6 +423,18 @@ public class CubeContainer {
 
     public void setExtends(String extendsImage) {
         this.extendsImage = extendsImage;
+    }
+
+    public Collection<AfterStart> getAfterStart() {
+        return afterStart;
+    }
+
+    public void setAfterStart(Collection<AfterStart> afterStart) {
+        this.afterStart = afterStart;
+    }
+
+    public boolean hasAfterStart() {
+        return this.afterStart != null && !this.afterStart.isEmpty();
     }
 
     public Collection<BeforeStop> getBeforeStop() {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CustomAfterStartAction.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CustomAfterStartAction.java
@@ -1,0 +1,14 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class CustomAfterStartAction {
+
+    private String strategy;
+
+    public String getStrategy() {
+        return strategy;
+    }
+
+    public void setStrategy(String strategy) {
+        this.strategy = strategy;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
@@ -123,6 +123,10 @@ public class DockerCompositions {
                     cubeContainer.setAwait(overrideCubeContainer.getAwait());
                 }
 
+                if (overrideCubeContainer.hasAfterStart()) {
+                    cubeContainer.setAfterStart(overrideCubeContainer.getAfterStart());
+                }
+
                 if (overrideCubeContainer.hasBeforeStop()) {
                     cubeContainer.setBeforeStop(overrideCubeContainer.getBeforeStop());
                 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -1017,6 +1017,17 @@ public class DockerClientExecutor {
         }
     }
 
+    public void copyStreamToContainer(String containerId, File from, String to) {
+        this.readWriteLock.readLock().lock();
+        try {
+            dockerClient.copyArchiveToContainerCmd(containerId)
+                .withRemotePath(to)
+                .withHostResource(from.getAbsolutePath()).exec();
+        } finally {
+            this.readWriteLock.readLock().unlock();
+        }
+    }
+
     public void connectToNetwork(String networkId, String containerID) {
         this.readWriteLock.readLock().lock();
         try {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/afterStart/AfterStartActionTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/afterStart/AfterStartActionTest.java
@@ -1,0 +1,43 @@
+package org.arquillian.cube.docker.impl.afterStart;
+
+import org.arquillian.cube.docker.impl.client.config.AfterStart;
+import org.arquillian.cube.docker.impl.client.config.CustomAfterStartAction;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.impl.model.DefaultCubeId;
+import org.arquillian.cube.spi.afterStart.AfterStartAction;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import static org.hamcrest.CoreMatchers.instanceOf;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AfterStartActionTest {
+
+    private String containerId = "test";
+
+    @Mock
+    private DockerClientExecutor dockerClientExecutor;
+
+    @Test
+    public void should_be_able_to_create_custom_after_start_actions() {
+        AfterStart afterStart = new AfterStart();
+        CustomAfterStartAction customAfterStartAction = new CustomAfterStartAction();
+        customAfterStartAction.setStrategy("org.arquillian.cube.docker.impl.afterStart.CustomAfterStartActionImpl");
+        afterStart.setCustomAfterStartAction(customAfterStartAction);
+
+        AfterStartAction afterStartAction =
+            AfterStartActionFactory.create(dockerClientExecutor, new DefaultCubeId(containerId), customAfterStartAction);
+
+        assertThat(afterStartAction, instanceOf(CustomAfterStartActionInstantiator.class));
+        CustomAfterStartActionInstantiator customAfterStartActionInstantiator =
+            (CustomAfterStartActionInstantiator) afterStartAction;
+
+        customAfterStartActionInstantiator.doAfterStart();
+        verify(dockerClientExecutor, times(1)).getDockerUri();
+    }
+}

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/afterStart/CustomAfterStartActionImpl.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/afterStart/CustomAfterStartActionImpl.java
@@ -1,0 +1,21 @@
+package org.arquillian.cube.docker.impl.afterStart;
+
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.impl.model.CubeId;
+import org.arquillian.cube.spi.afterStart.AfterStartAction;
+
+/**
+ * A test class used in the {{@link org.arquillian.cube.docker.impl.client.AfterStartContainerObserverTest}} and in
+ * {{@link AfterStartActionTest}}
+ */
+public class CustomAfterStartActionImpl implements AfterStartAction {
+
+    private DockerClientExecutor dockerClientExecutor;
+    private CubeId containerID;
+
+    @Override
+    public void doAfterStart() {
+        dockerClientExecutor.getDockerUri();
+        containerID.toString();
+    }
+}

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/AfterStartContainerObserverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/AfterStartContainerObserverTest.java
@@ -1,0 +1,105 @@
+package org.arquillian.cube.docker.impl.client;
+
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.docker.impl.util.ConfigUtil;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.arquillian.cube.spi.event.lifecycle.AfterStart;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.test.AbstractManagerTestBase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AfterStartContainerObserverTest extends AbstractManagerTestBase {
+
+    private static final String CUBE_CONTAINER_NAME = "test";
+
+    private static final String CONTAINER_COPY_CONFIGURATION =
+        "tomcat_default:\n" +
+            "  image: tutum/tomcat:7.0\n" +
+            "  afterStart:\n" +
+            "    - copy:\n" +
+            "        to: /test\n" +
+            "        from: ";
+
+    private static final String CONTAINER_CUSTOM_AFTER_START_ACTION_CONFIGURATION =
+        "tomcat_default:\n" +
+            "  image: tutum/tomcat:7.0\n" +
+            "  afterStart:\n" +
+            "    - customAfterStartAction:\n" +
+            "        strategy: org.arquillian.cube.docker.impl.afterStart.CustomAfterStartActionImpl";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private DockerCube cube;
+
+    @Mock
+    private CubeRegistry registry;
+
+    @Mock
+    private DockerClientExecutor dockerClientExecutor;
+
+    @BeforeClass
+    public static void startDockerStub() {
+    }
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        super.addExtensions(extensions);
+        extensions.add(AfterStartContainerObserver.class);
+    }
+
+    @Before
+    public void setup() {
+        bind(ApplicationScoped.class, DockerClientExecutor.class,
+            dockerClientExecutor);
+
+        Mockito.when(registry.getCube(CUBE_CONTAINER_NAME, DockerCube.class)).thenReturn(
+            cube);
+        bind(ApplicationScoped.class, CubeRegistry.class, registry);
+    }
+
+    @Test
+    public void shouldCopyFileToContainer() throws IOException {
+        File newFolder = temporaryFolder.newFolder();
+        String content = CONTAINER_COPY_CONFIGURATION;
+        content += newFolder.getAbsolutePath();
+
+        DockerCompositions configuration = ConfigUtil.load(content);
+        CubeContainer config = configuration.get("tomcat_default");
+
+        Mockito.when(cube.configuration()).thenReturn(config);
+        fire(new AfterStart(CUBE_CONTAINER_NAME));
+        verify(dockerClientExecutor).copyStreamToContainer(eq(CUBE_CONTAINER_NAME), eq(newFolder), eq("/test"));
+    }
+
+    @Test
+    public void shouldExecuteCustomAfterStartOperationForContainer() throws IOException {
+        DockerCompositions configuration = ConfigUtil.load(CONTAINER_CUSTOM_AFTER_START_ACTION_CONFIGURATION);
+        CubeContainer config = configuration.get("tomcat_default");
+        Mockito.when(cube.configuration()).thenReturn(config);
+        fire(new AfterStart(CUBE_CONTAINER_NAME));
+        verify(dockerClientExecutor, times(1)).getDockerUri();
+    }
+}
+

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfigurationTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfigurationTest.java
@@ -63,6 +63,10 @@ public class CubeConfigurationTest {
             "  image: tutum/tomcat:8.0\n" +
             "  await:\n" +
             "    strategy: polling\n" +
+            "  afterStart: \n" +
+            "    - copy:\n" +
+            "        from: /tmp\n" +
+            "        to: /test\n" +
             "  beforeStop: \n" +
             "    - copy:\n" +
             "        from: /test\n" +
@@ -417,6 +421,7 @@ public class CubeConfigurationTest {
         assertThat(tomcat, is(notNullValue()));
         assertThat(tomcat.getImage().getTag(), is("7.0"));
         assertThat(tomcat.getAwait().getStrategy(), is("polling"));
+        assertThat(tomcat.getAfterStart().size(), is(1));
         assertThat(tomcat.getBeforeStop().size(), is(1));
     }
 

--- a/spi/src/main/java/org/arquillian/cube/spi/afterStart/AfterStartAction.java
+++ b/spi/src/main/java/org/arquillian/cube/spi/afterStart/AfterStartAction.java
@@ -1,0 +1,5 @@
+package org.arquillian.cube.spi.afterStart;
+
+public interface AfterStartAction {
+    void doAfterStart();
+}


### PR DESCRIPTION
#### Short description of what this resolves:
I want to copy files and execute commands after a container started (similar to the before stop commands)

#### Changes proposed in this pull request:
Implemented AfterStart observer similar to BeforeStopObserver


Fixes #
