### PR TITLE
Fix test for Win & filter tests requiring remote resources

### DIFF
--- a/core/src/test/java/org/arquillian/cube/impl/shrinkwrap/asset/CacheUrlAssetTest.java
+++ b/core/src/test/java/org/arquillian/cube/impl/shrinkwrap/asset/CacheUrlAssetTest.java
@@ -5,6 +5,7 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -51,7 +52,7 @@ public class CacheUrlAssetTest {
         CacheUrlAsset cacheUrlAsset = new CacheUrlAsset(new URL("http://arquillian.org/images/arq.txt"));
         CacheUrlAsset.TEMP_LOCATION = newFolder.getAbsolutePath();
         final Path path = Paths.get(newFolder.getAbsolutePath(), "arq.txt");
-        Files.write(path, "Hello".getBytes("UTF-8"));
+        Files.write(path, "Hello".getBytes(StandardCharsets.UTF_8));
         InputStream is = cacheUrlAsset.openStream();
         String content = slurp(is);
 
@@ -62,7 +63,7 @@ public class CacheUrlAssetTest {
     public void shouldDownloadFileIfExpired() throws IOException, InterruptedException {
         final File newFolder = temporaryFolder.newFolder();
         final Path path = Paths.get(newFolder.getAbsolutePath(), "arquillian_crown_icon_glossy_256.png");
-        Files.write(path, "invalidchunk".getBytes("UTF-8"));
+        Files.write(path, "invalidchunk".getBytes(StandardCharsets.UTF_8));
         Thread.sleep(3000);
         CacheUrlAsset cacheUrlAsset =
             new CacheUrlAsset(new URL("http://arquillian.org/images/arquillian_crown_icon_glossy_256.png"), 2,

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
@@ -1,8 +1,8 @@
 package org.arquillian.cube.docker.impl.client;
 
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
@@ -37,7 +37,7 @@ public class CubeDockerConfiguration {
     public static final String CLEAN = "clean";
     public static final String REMOVE_VOLUMES = "removeVolumes";
     public static final String CLEAN_BUILD_IMAGE = "cleanBuildImage";
-    static final String DIND_RESOLUTION = "dockerInsideDockerResolution";
+    public static final String DIND_RESOLUTION = "dockerInsideDockerResolution";
     private static final String DOCKER_VERSION = "serverVersion";
     private static final String USERNAME = "username";
     private static final String PASSWORD = "password";
@@ -185,8 +185,8 @@ public class CubeDockerConfiguration {
             if (stream != null) {
                 cubeConfiguration.dockerContainersContent =
                     DockerContainerDefinitionParser.convert(
-                            IOUtil.asStringPreservingNewLines(stream),
-                            cubeConfiguration.definitionFormat);
+                        IOUtil.asStringPreservingNewLines(stream),
+                        cubeConfiguration.definitionFormat);
             } else {
                 throw new IllegalArgumentException("Resource " + resource + " not found in classpath");
             }
@@ -379,7 +379,8 @@ public class CubeDockerConfiguration {
         return cleanBuildImage;
     }
 
-    @Override public String toString() {
+    @Override
+    public String toString() {
         String lineSeparator = System.lineSeparator();
         StringBuilder content = new StringBuilder();
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolver.java
@@ -29,6 +29,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 
 import static org.arquillian.cube.docker.impl.client.CubeDockerConfigurator.DOCKER_HOST;
@@ -100,15 +101,18 @@ public class CubeDockerConfigurationResolver {
                 String machineVersion = GitHubUtil.getDockerMachineLatestVersion();
                 String machineCustomPath = config.get(CubeDockerConfiguration.DOCKER_MACHINE_CUSTOM_PATH);
                 File dockerMachineFile = CubeDockerConfiguration.resolveMachinePath(machineCustomPath, machineVersion);
-                String dockerMachinePath = dockerMachineFile.getPath();
 
-                boolean dockerMachineFileExist = dockerMachineFile != null && dockerMachineFile.exists();
+                boolean dockerMachineFileExist = dockerMachineFile.exists();
+                String dockerMachinePath = dockerMachineFile.getPath();
 
                 String machineName = config.get(CubeDockerConfiguration.DOCKER_MACHINE_NAME);
                 String machineUrl = CubeDockerConfiguration.resolveUrl(machineVersion);
 
                 if (!dockerMachineFileExist) {
-                    dockerMachineFile.getParentFile().mkdirs();
+                    final File parentFile = dockerMachineFile.getParentFile();
+                    if(!parentFile.exists() && !parentFile.mkdirs()){
+                        log.log(Level.SEVERE, "Failed to create directory: " + parentFile);
+                    }
                     Spacelift.task(DownloadTool.class)
                         .from(machineUrl)
                         .to(dockerMachineFile)

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeSuiteLifecycleController.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeSuiteLifecycleController.java
@@ -53,7 +53,7 @@ public class CubeSuiteLifecycleController {
     private Instance<DockerClientExecutor> dockerClientExecutor;
 
     public void startAutoContainers(@Observes(precedence = 100) BeforeSuite event, CubeConfiguration cubeConfiguration,
-        CubeDockerConfiguration dockerConfiguration) {
+                                    CubeDockerConfiguration dockerConfiguration) {
         beforeAutoStartEvent.fire(new BeforeAutoStart());
         final DockerAutoStartOrder dockerAutoStartOrder = dockerConfiguration.getDockerAutoStartOrder();
         List<String[]> autoStartSteps = dockerAutoStartOrder.getAutoStartOrder(dockerConfiguration);
@@ -104,10 +104,10 @@ public class CubeSuiteLifecycleController {
             try {
                 RuntimeException e = result.getValue().get();
                 if (e != null) {
-                    Logger.getLogger(CubeSuiteLifecycleController.class.getName()).log(Level.SEVERE, message + ": " + result.getKey(), e);
+                    Logger.getLogger(CubeSuiteLifecycleController.class.getName()).log(Level.SEVERE, message + " - Error starting: " + result.getKey(), e);
                 }
             } catch (Exception e) {
-                Logger.getLogger(CubeSuiteLifecycleController.class.getName()).log(Level.SEVERE, message + " process: " + result.getKey(), e);
+                Logger.getLogger(CubeSuiteLifecycleController.class.getName()).log(Level.SEVERE, message + " - Failed to start: " + result.getKey(), e);
             }
         }
     }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/SystemPropertiesCubeSetter.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/SystemPropertiesCubeSetter.java
@@ -32,8 +32,11 @@ public class SystemPropertiesCubeSetter {
 
         final Binding bindings = cube.bindings();
         final String cubePrefix = String.format("%s.%s", PREFIX, cubeId);
-        System.setProperty(String.format("%s.ip", cubePrefix), bindings.getIP());
-        System.setProperty(String.format("%s.internal.ip", cubePrefix), bindings.getInternalIP());
+
+        final String ip = bindings.getIP();
+        final String internalIP = bindings.getInternalIP();
+        System.setProperty(String.format("%s.ip", cubePrefix), null != ip ? ip : "");
+        System.setProperty(String.format("%s.internal.ip", cubePrefix), null != internalIP ? internalIP : "");
 
         for (Binding.PortBinding portBinding : bindings.getPortBindings()) {
             final int exposedPort = portBinding.getExposedPort();

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
@@ -14,6 +14,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.function.BiFunction;
 import java.util.function.Consumer;
+import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
 import org.apache.commons.lang3.ArrayUtils;
@@ -83,7 +84,7 @@ public class DockerContainerObjectBuilder<T> {
     private DockerCube dockerCube;
 
     public DockerContainerObjectBuilder(DockerClientExecutor dockerClientExecutor, CubeController cubeController,
-        CubeRegistry cubeRegistry) {
+                                        CubeRegistry cubeRegistry) {
         this.dockerClientExecutor = dockerClientExecutor;
         this.cubeController = cubeController;
         this.cubeRegistry = cubeRegistry;
@@ -161,11 +162,8 @@ public class DockerContainerObjectBuilder<T> {
      * is stored as part of the metadata of the container object. This object is expected to control the lifecycle of
      * the container object
      *
-     * @param containerObjectContainer
-     *     the container object's container
-     *
+     * @param containerObjectContainer the container object's container
      * @return the current builder instance
-     *
      * @see IsContainerObject
      */
     public DockerContainerObjectBuilder<T> withContainerObjectContainer(Object containerObjectContainer) {
@@ -176,9 +174,7 @@ public class DockerContainerObjectBuilder<T> {
     /**
      * Specifies the container object class to be instantiated
      *
-     * @param containerObjectClass
-     *     container object class to be instantiated
-     *
+     * @param containerObjectClass container object class to be instantiated
      * @return the current builder instance
      */
     public DockerContainerObjectBuilder<T> withContainerObjectClass(Class<T> containerObjectClass) {
@@ -247,11 +243,8 @@ public class DockerContainerObjectBuilder<T> {
      * <p>
      * Currently only supports instances of {@link CubeContainerObjectConfiguration}
      *
-     * @param configuration
-     *     partial configuration to override default container object cube configuration
-     *
+     * @param configuration partial configuration to override default container object cube configuration
      * @return the current builder instance
-     *
      * @see CubeContainerObjectConfiguration
      * @see CubeContainer
      */
@@ -274,9 +267,7 @@ public class DockerContainerObjectBuilder<T> {
     /**
      * Specifies the list of enrichers that will be used to enrich the container object.
      *
-     * @param enrichers
-     *     list of enrichers that will be used to enrich the container object
-     *
+     * @param enrichers list of enrichers that will be used to enrich the container object
      * @return the current builder instance
      */
     public DockerContainerObjectBuilder<T> withEnrichers(Collection<TestEnricher> enrichers) {
@@ -292,9 +283,7 @@ public class DockerContainerObjectBuilder<T> {
      * by the cube controller. Callers must use this callback to register anything necesary for the controller to work
      * and also if they want to keep an instance of the created cube.
      *
-     * @param cubeCreatedCallback
-     *     consumer that will be called when the cube instance is created
-     *
+     * @param cubeCreatedCallback consumer that will be called when the cube instance is created
      * @return the current builder instance
      */
     public DockerContainerObjectBuilder<T> onCubeCreated(Consumer<DockerCube> cubeCreatedCallback) {
@@ -307,13 +296,9 @@ public class DockerContainerObjectBuilder<T> {
      * container object, creates the container object and returns it
      *
      * @return the created container object
-     *
-     * @throws IllegalAccessException
-     *     if there is an error accessing the container object fields
-     * @throws IOException
-     *     if there is an I/O error while preparing the docker build
-     * @throws InvocationTargetException
-     *     if there is an error while calling the DockerFile archive creation
+     * @throws IllegalAccessException    if there is an error accessing the container object fields
+     * @throws IOException               if there is an I/O error while preparing the docker build
+     * @throws InvocationTargetException if there is an error while calling the DockerFile archive creation
      */
     public T build() throws IllegalAccessException, IOException, InvocationTargetException {
         generatedConfigutation = new CubeContainer();
@@ -519,6 +504,8 @@ public class DockerContainerObjectBuilder<T> {
             }
             cubeController.create(containerName);
             cubeController.start(containerName);
+            logger.log(Level.INFO, "Started container:\n" +
+                dockerClientExecutor.getDockerClient().inspectContainerCmd(containerName).exec().toString());
         }
     }
 
@@ -534,7 +521,7 @@ public class DockerContainerObjectBuilder<T> {
     }
 
     private <T extends Annotation> void enrichAnnotatedPortBuildingFields(Class<T> annotationType,
-        BiFunction<T, HasPortBindings, ?> fieldEnricher) throws IllegalAccessException {
+                                                                          BiFunction<T, HasPortBindings, ?> fieldEnricher) throws IllegalAccessException {
         final List<Field> annotatedFields = ReflectionUtil.getFieldsWithAnnotation(containerObjectClass, annotationType);
         if (annotatedFields.isEmpty()) return;
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilder.java
@@ -17,6 +17,8 @@ import java.util.function.Consumer;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
+
+import com.github.dockerjava.api.exception.NotFoundException;
 import org.apache.commons.lang3.ArrayUtils;
 import org.arquillian.cube.ContainerObjectConfiguration;
 import org.arquillian.cube.CubeController;
@@ -504,8 +506,16 @@ public class DockerContainerObjectBuilder<T> {
             }
             cubeController.create(containerName);
             cubeController.start(containerName);
-            logger.log(Level.INFO, "Started container:\n" +
-                dockerClientExecutor.getDockerClient().inspectContainerCmd(containerName).exec().toString());
+            logger.log(Level.INFO, "Started container: " + getContainerInfo(containerName));
+        }
+    }
+
+    private String getContainerInfo(final String containerName) {
+        try {
+            final String detail = dockerClientExecutor.getDockerClient().inspectContainerCmd(containerName).exec().toString();
+            return null != detail ? detail : containerName;
+        } catch (Exception e) {
+            return containerName;
         }
     }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/Ping.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/Ping.java
@@ -1,12 +1,13 @@
 package org.arquillian.cube.docker.impl.util;
 
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.spi.CubeOutput;
+
 import java.io.IOException;
 import java.net.Socket;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
-import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
-import org.arquillian.cube.spi.CubeOutput;
 
 public final class Ping {
 
@@ -17,19 +18,23 @@ public final class Ping {
     }
 
     public static boolean ping(int totalIterations, long sleep, TimeUnit timeUnit, PingCommand command) {
-        boolean result = false;
+        boolean result;
+        boolean loop;
         int iteration = 0;
 
         do {
             result = command.call();
-            if (!result) {
-                iteration++;
+            iteration++;
+            loop = !result && iteration < totalIterations;
+            if (loop) {
                 try {
                     timeUnit.sleep(sleep);
-                } catch (InterruptedException e) {
+                } catch (InterruptedException ignore) {
+                    break;
                 }
             }
-        } while (!result && iteration < totalIterations);
+
+        } while (loop);
 
         return result;
     }

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -1,10 +1,17 @@
 package org.arquillian.cube.docker.impl.client;
 
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.PrintStream;
+import java.nio.file.Paths;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.commons.lang.SystemUtils;
 import org.arquillian.cube.docker.impl.util.Boot2Docker;
 import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
 import org.arquillian.cube.docker.impl.util.DockerMachine;
-import org.arquillian.cube.docker.impl.util.OperatingSystem;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamilyInterface;
 import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
@@ -15,7 +22,6 @@ import org.hamcrest.Matcher;
 import org.hamcrest.core.StringEndsWith;
 import org.jboss.arquillian.config.descriptor.api.ArquillianDescriptor;
 import org.jboss.arquillian.config.descriptor.api.ExtensionDef;
-import org.jboss.arquillian.core.api.InstanceProducer;
 import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.test.AbstractManagerTestBase;
 import org.junit.Assume;
@@ -25,20 +31,16 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
-import java.io.ByteArrayOutputStream;
-import java.io.PrintStream;
-import java.nio.file.Paths;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import static org.hamcrest.CoreMatchers.*;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.collection.IsMapContaining.hasEntry;
 import static org.hamcrest.collection.IsMapContaining.hasKey;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assume.assumeThat;
-import static org.mockito.Mockito.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CubeConfiguratorTest extends AbstractManagerTestBase {
@@ -57,11 +59,11 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
     Top top;
 
     private static Matcher<String> defaultDockerMachineCertPath() {
-        return containsString(".docker/machine/machines");
+        return containsString(".docker" + File.separator + "machine" + File.separator + "machines");
     }
 
     private static Matcher<String> defaultBootToDockerCertPath() {
-        return containsString(".boot2docker/certs");
+        return containsString(".boot2docker" + File.separator + "certs");
     }
 
     private static Matcher<String> pathEndsWith(String suffix) {

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/DockerContainerObjectBuilderTest.java
@@ -1,18 +1,5 @@
 package org.arquillian.cube.docker.impl.client.containerobject;
 
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasItems;
-import static org.hamcrest.Matchers.notNullValue;
-import static org.hamcrest.Matchers.nullValue;
-import static org.hamcrest.core.Is.is;
-import static org.junit.Assert.fail;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Matchers.any;
-import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-
 import java.io.File;
 import java.io.IOException;
 import java.lang.reflect.Field;
@@ -23,7 +10,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
-
+import com.github.dockerjava.api.DockerClient;
 import org.apache.commons.io.FileUtils;
 import org.arquillian.cube.CubeController;
 import org.arquillian.cube.CubeIp;
@@ -53,6 +40,21 @@ import org.junit.Before;
 import org.junit.Test;
 import org.mockito.invocation.InvocationOnMock;
 
+import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasItems;
+import static org.hamcrest.Matchers.notNullValue;
+import static org.hamcrest.Matchers.nullValue;
+import static org.hamcrest.core.Is.is;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Matchers.any;
+import static org.mockito.Mockito.RETURNS_DEEP_STUBS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
 public class DockerContainerObjectBuilderTest {
 
     public static final String BASE_IMAGE = "tomee:8-jre-1.7.2-webprofile";
@@ -67,6 +69,8 @@ public class DockerContainerObjectBuilderTest {
     public void initMocks() {
         cubeController = mock(CubeController.class);
         dockerClientExecutor = mock(DockerClientExecutor.class);
+        when(dockerClientExecutor.isDockerInsideDockerResolution()).thenReturn(true);
+        when(dockerClientExecutor.getDockerClient()).thenReturn(mock(DockerClient.class, RETURNS_DEEP_STUBS));
         cubeRegistry = mock(CubeRegistry.class);
         cubeContainerObjectTestEnricher = mock(CubeContainerObjectTestEnricher.class);
         doAnswer(DockerContainerObjectBuilderTest::objectContainerEnricherMockEnrich)

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/graphene/location/CubeDockerCustomizableURLResourceProviderTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/graphene/location/CubeDockerCustomizableURLResourceProviderTest.java
@@ -1,7 +1,6 @@
 package org.arquillian.cube.docker.graphene.location;
 
 import java.net.URL;
-import org.arquillian.cube.docker.drone.SeleniumContainers;
 import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
 import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
 import org.arquillian.cube.docker.impl.util.ConfigUtil;

--- a/docker/ftest-boot2docker/src/test/java/org/arquillian/cube/persistence/UserRepositoryTest.java
+++ b/docker/ftest-boot2docker/src/test/java/org/arquillian/cube/persistence/UserRepositoryTest.java
@@ -1,7 +1,8 @@
 package org.arquillian.cube.persistence;
 
-import java.io.IOException;
 import javax.inject.Inject;
+import java.io.IOException;
+import org.arquillian.cube.remote.requirement.RequiresRemoteResource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -9,9 +10,11 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@Category({RequiresRemoteResource.class})
 public class UserRepositoryTest {
 
     @Inject

--- a/docker/ftest-docker-junit5/pom.xml
+++ b/docker/ftest-docker-junit5/pom.xml
@@ -26,12 +26,11 @@
       </plugin>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
         <dependencies>
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.0.2</version>
+            <version>1.3.2</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/docker/ftest-system-properties/src/test/java/org/arquillian/cube/docker/systemproperties/SystemPropertiesJUnitRuleIT.java
+++ b/docker/ftest-system-properties/src/test/java/org/arquillian/cube/docker/systemproperties/SystemPropertiesJUnitRuleIT.java
@@ -4,13 +4,11 @@ import java.util.Properties;
 import org.arquillian.cube.docker.impl.requirement.RequiresDocker;
 import org.arquillian.cube.docker.impl.requirement.RequiresDockerMachine;
 import org.arquillian.cube.docker.junit.rule.ContainerDslRule;
-import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.arquillian.cube.requirement.RequirementRule;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.runner.RunWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/docker/ftest/src/test/java/org/arquillian/cube/persistence/UserRepositoryTest.java
+++ b/docker/ftest/src/test/java/org/arquillian/cube/persistence/UserRepositoryTest.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.persistence;
 
 import java.io.IOException;
 import javax.inject.Inject;
+import org.arquillian.cube.remote.requirement.RequiresRemoteResource;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
@@ -9,9 +10,11 @@ import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.asset.StringAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 @RunWith(Arquillian.class)
+@Category({RequiresRemoteResource.class})
 public class UserRepositoryTest {
 
     @Inject

--- a/docker/junit5/pom.xml
+++ b/docker/junit5/pom.xml
@@ -39,12 +39,11 @@
     <plugins>
       <plugin>
         <artifactId>maven-surefire-plugin</artifactId>
-        <version>2.19.1</version>
         <dependencies>
           <dependency>
             <groupId>org.junit.platform</groupId>
             <artifactId>junit-platform-surefire-provider</artifactId>
-            <version>1.0.2</version>
+            <version>1.3.2</version>
           </dependency>
         </dependencies>
       </plugin>

--- a/docker/reporter/src/main/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironment.java
+++ b/docker/reporter/src/main/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironment.java
@@ -1,5 +1,21 @@
 package org.arquillian.cube.docker.impl.client.reporter;
 
+import javax.imageio.ImageIO;
+import javax.swing.*;
+import java.awt.*;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import com.github.dockerjava.api.command.InspectContainerResponse;
 import com.github.dockerjava.api.model.Version;
 import com.mxgraph.layout.hierarchical.mxHierarchicalLayout;
@@ -27,24 +43,16 @@ import org.jboss.arquillian.core.api.annotation.Observes;
 import org.jboss.arquillian.test.spi.event.suite.After;
 import org.jboss.arquillian.test.spi.event.suite.Before;
 
-import javax.imageio.ImageIO;
-import javax.swing.*;
-import java.awt.*;
-import java.awt.image.BufferedImage;
-import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
-import java.util.logging.Level;
-import java.util.logging.Logger;
-
-import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.*;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_API_VERSION;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_ARCH;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_COMPOSITION_SCHEMA;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_ENVIRONMENT;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_HOST_INFORMATION;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_KERNEL;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_OS;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.DOCKER_VERSION;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.LOG_PATH;
+import static org.arquillian.cube.docker.impl.client.reporter.DockerEnvironmentReportKey.NETWORK_TOPOLOGY_SCHEMA;
 
 /**
  * Class that reports generic Docker information like orchestration or docker version.

--- a/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
+++ b/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
@@ -87,7 +87,6 @@ public class TakeDockerEnvironmentTest {
 
     @Before
     public void setUpCubeDockerExecutorAndBuilder() throws IOException {
-        when(dockerClientExecutor.isDockerInsideDockerResolution()).thenReturn(true);
         configureDockerExecutor();
         configureCube();
         BuilderLoader.load();

--- a/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
+++ b/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeDockerEnvironmentTest.java
@@ -99,6 +99,7 @@ public class TakeDockerEnvironmentTest {
         when(version.getApiVersion()).thenReturn("1.12");
         when(version.getArch()).thenReturn("x86");
         when(dockerClientExecutor.dockerHostVersion()).thenReturn(version);
+        when(dockerClientExecutor.isDockerInsideDockerResolution()).thenReturn(true);
     }
 
     private void configureCube() throws IOException {

--- a/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeVncDroneVideoTest.java
+++ b/docker/reporter/src/test/java/org/arquillian/cube/docker/impl/client/reporter/TakeVncDroneVideoTest.java
@@ -1,5 +1,9 @@
 package org.arquillian.cube.docker.impl.client.reporter;
 
+import java.io.File;
+import java.lang.reflect.Method;
+import java.nio.file.Paths;
+import java.util.LinkedHashMap;
 import org.arquillian.cube.docker.drone.event.AfterVideoRecorded;
 import org.arquillian.reporter.api.builder.BuilderLoader;
 import org.arquillian.reporter.api.event.SectionEvent;
@@ -17,10 +21,6 @@ import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
-
-import java.lang.reflect.Method;
-import java.nio.file.Paths;
-import java.util.LinkedHashMap;
 
 import static org.arquillian.reporter.impl.asserts.ReportAssert.assertThatReport;
 import static org.arquillian.reporter.impl.asserts.SectionAssert.assertThatSection;
@@ -97,7 +97,7 @@ public class TakeVncDroneVideoTest {
         assertThatReport(report)
                 .hasName(methodName)
                 .hasNumberOfEntries(1)
-                .hasEntriesContaining(new KeyValueEntry(DockerEnvironmentReportKey.VIDEO_PATH, new FileEntry("surefire-report/myvideo.mp4")));
+                .hasEntriesContaining(new KeyValueEntry(DockerEnvironmentReportKey.VIDEO_PATH, new FileEntry("surefire-report" + File.separatorChar + "myvideo.mp4")));
     }
 
     private ReporterConfiguration getReporterConfiguration() {

--- a/docs/enrichers.adoc
+++ b/docs/enrichers.adoc
@@ -110,8 +110,8 @@ URL will be `http://<docker_host>:<bind_port>/`
 
 === Docker Inside Docker / Docker On Docker
 
-If you are running your tests inside your continuous integration/delivery server (for example in Jenkins) and at the same time the server is running inside Docker. Then the docker containers started for Cube are run inside a Docker container.
-So you effectively face the Docker inside Docker problem.
+If you are running your tests on your continuous integration/delivery server (for example on Jenkins or GitLab runners) and at the same time the server is running inside Docker. Then the docker containers started for Cube are run inside a Docker container.
+So you effectively face the Docker inside Docker problem - DockerHost is **not** the machine where your test is running.
 
 From Arquillian Cube perspective we cannot do a lot of things, more then adapting to this situation by changing the `serverUri`.
 Basically it ignores any `SERVER_URI`, `Boot2Docker` or `docker-machine` properties and sets the `serverUri` to `unix:///var/run/docker.sock`.

--- a/fabric8-maven-plugin-build/src/test/java/org/fabric8/maven/plugin/build/ResourceGeneratorBuilderIT.java
+++ b/fabric8-maven-plugin-build/src/test/java/org/fabric8/maven/plugin/build/ResourceGeneratorBuilderIT.java
@@ -1,7 +1,5 @@
 package org.fabric8.maven.plugin.build;
 
-import io.fabric8.kubernetes.client.DefaultKubernetesClient;
-import io.fabric8.kubernetes.client.KubernetesClient;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -9,7 +7,10 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.stream.Collectors;
+import io.fabric8.kubernetes.client.DefaultKubernetesClient;
+import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.remote.requirement.RequiresRemoteResource;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
@@ -22,7 +23,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 // If you want to run it from the IDE against latest code changes you have to set system property `arquillian-cube.version` with latest project.version.
 
-@Category(RequiresOpenshift.class)
+@Category({RequiresOpenshift.class, RequiresRemoteResource.class})
 @RequiresOpenshift
 public class ResourceGeneratorBuilderIT {
 

--- a/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationTest.java
+++ b/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/DefaultConfigurationTest.java
@@ -1,11 +1,9 @@
 package org.arquillian.cube.kubernetes.impl;
 
+import java.util.Map;
 import org.junit.Test;
 
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.assertj.core.api.Assertions.*;
+import static org.assertj.core.api.Assertions.assertThat;
 
 
 public class DefaultConfigurationTest {

--- a/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/PodInjection.java
+++ b/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/PodInjection.java
@@ -19,15 +19,18 @@ import io.fabric8.kubernetes.api.model.Pod;
 import io.fabric8.kubernetes.api.model.PodList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.annotations.Named;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
+@Category({RequiresKubernetes.class})
 public class PodInjection {
 
     @ArquillianResource

--- a/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/ReplicationControllerInjection.java
+++ b/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/ReplicationControllerInjection.java
@@ -19,15 +19,18 @@ import io.fabric8.kubernetes.api.model.ReplicationController;
 import io.fabric8.kubernetes.api.model.ReplicationControllerList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.annotations.Named;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
+@Category({RequiresKubernetes.class})
 public class ReplicationControllerInjection {
 
     @ArquillianResource

--- a/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/ServiceInjection.java
+++ b/kubernetes/kubernetes/src/test/java/org/arquillian/cube/kubernetes/impl/ServiceInjection.java
@@ -19,15 +19,18 @@ import io.fabric8.kubernetes.api.model.Service;
 import io.fabric8.kubernetes.api.model.ServiceList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import org.arquillian.cube.kubernetes.annotations.Named;
+import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
 @RunWith(Arquillian.class)
+@Category({RequiresKubernetes.class})
 public class ServiceInjection {
 
     @ArquillianResource

--- a/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftITCase.java
+++ b/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentOpenShiftITCase.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.openshift.ftest;
 
 import java.net.URL;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
+import org.arquillian.cube.remote.requirement.RequiresRemoteResource;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.test.api.ArquillianResource;
@@ -13,7 +14,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-@Category(RequiresOpenshift.class)
+@Category({RequiresOpenshift.class, RequiresRemoteResource.class})
 @RequiresOpenshift
 @RunWith(ArquillianConditionalRunner.class)
 public class HelloPodDeploymentOpenShiftITCase {

--- a/requirement-spi/src/main/java/org/arquillian/cube/remote/requirement/RequiresRemoteResource.java
+++ b/requirement-spi/src/main/java/org/arquillian/cube/remote/requirement/RequiresRemoteResource.java
@@ -1,0 +1,16 @@
+package org.arquillian.cube.remote.requirement;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.arquillian.cube.spi.requirement.Constraint;
+import org.arquillian.cube.spi.requirement.Requires;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Requires(Constraint.class)
+public @interface RequiresRemoteResource {
+
+    String name() default "";
+}


### PR DESCRIPTION
Trivial cleanups

#### Short description of what this resolves:

Fix tests on Win and allow filtering of tests that attempt to access remote resources (eg, blocked by a firewall).

#### Changes proposed in this pull request:

- Flag tests with RequiresRemoteResource to enable filtering
- Remove unused imports
- Update junit5 version
- Log useful info and error conditions

Preparation of #1107 - Which is a much larger WIP PR for later
