### PR TITLE
WIP: Allow browser image, name and port override and enhance for DinD

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/AwaitStrategyFactory.java
@@ -15,28 +15,39 @@ public class AwaitStrategyFactory {
         super();
     }
 
-    public static final AwaitStrategy create(DockerClientExecutor dockerClientExecutor, Cube<?> cube,
-        CubeContainer options) {
+    /**
+     * Build an await strategy for the provided Cube
+     *
+     * @param dockerClientExecutor Docker client
+     * @param cube                 The cube for which the strategy is required
+     * @param options              The container options
+     * @return The configure await strategy, ot the default polling strategy
+     */
+    public static AwaitStrategy create(final DockerClientExecutor dockerClientExecutor,
+                                       final Cube<?> cube,
+                                       final CubeContainer options) {
 
         if (options.getAwait() != null) {
             Await await = options.getAwait();
 
             if (await.getStrategy() != null) {
 
-                String strategy = await.getStrategy().toLowerCase();
-                switch (strategy) {
+                await.setIp((dockerClientExecutor.isDockerInsideDockerResolution()
+                    ? dockerClientExecutor.getDockerServerIp() : dockerClientExecutor.getDockerUri().getHost()));
+
+                switch (await.getStrategy().toLowerCase()) {
                     case PollingAwaitStrategy.TAG:
                         return new PollingAwaitStrategy(cube, dockerClientExecutor, await);
+                    case StaticAwaitStrategy.TAG:
+                        return new StaticAwaitStrategy(cube, dockerClientExecutor, await);
+                    case HttpAwaitStrategy.TAG:
+                        return new HttpAwaitStrategy(cube, dockerClientExecutor, await);
                     case LogScanningAwaitStrategy.TAG:
                         return new LogScanningAwaitStrategy(cube, dockerClientExecutor, await);
                     case NativeAwaitStrategy.TAG:
                         return new NativeAwaitStrategy(cube, dockerClientExecutor);
-                    case StaticAwaitStrategy.TAG:
-                        return new StaticAwaitStrategy(cube, await);
                     case SleepingAwaitStrategy.TAG:
                         return new SleepingAwaitStrategy(cube, await);
-                    case HttpAwaitStrategy.TAG:
-                        return new HttpAwaitStrategy(cube, dockerClientExecutor, await);
                     case DockerHealthAwaitStrategy.TAG:
                         return new DockerHealthAwaitStrategy(cube, dockerClientExecutor, await);
                     default:
@@ -44,11 +55,11 @@ public class AwaitStrategyFactory {
                 }
             } else {
                 log.fine("No await strategy is set and Polling one is going to be used.");
-                return new PollingAwaitStrategy(cube, dockerClientExecutor, new Await());
             }
         } else {
             log.fine("No await strategy is set and Polling strategy is going to be used.");
-            return new PollingAwaitStrategy(cube, dockerClientExecutor, new Await());
         }
+
+        return new PollingAwaitStrategy(cube, dockerClientExecutor, new Await());
     }
 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/HttpAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/HttpAwaitStrategy.java
@@ -5,16 +5,18 @@ import java.net.HttpURLConnection;
 import java.net.URL;
 import java.util.Map;
 import java.util.Set;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import java.util.regex.Pattern;
 import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.util.Ping;
-import org.arquillian.cube.docker.impl.util.PingCommand;
 import org.arquillian.cube.impl.util.IOUtil;
 import org.arquillian.cube.spi.Cube;
 
 public class HttpAwaitStrategy extends SleepingAwaitStrategyBase {
 
+    private static final Logger logger = Logger.getLogger(HttpAwaitStrategy.class.getName());
     public static final String TAG = "http";
 
     private static final String REGEXP_PREFIX = "regexp:";
@@ -22,20 +24,14 @@ public class HttpAwaitStrategy extends SleepingAwaitStrategyBase {
     private static final int DEFAULT_POLL_ITERATIONS = 10;
 
     private int pollIterations = DEFAULT_POLL_ITERATIONS;
-    private URL url = null;
+    private URL url;
     private int responseCode = 200;
     private Map<String, Object> headers;
     private String matcher;
 
-    private Cube<?> cube;
-    private DockerClientExecutor dockerClientExecutor;
-    private HttpURLConnection urlConnection;
 
-    public HttpAwaitStrategy(Cube<?> cube, DockerClientExecutor dockerClientExecutor, Await params) {
+    public HttpAwaitStrategy(final Cube<?> cube, final DockerClientExecutor dockerClientExecutor, final Await params) {
         super(params.getSleepPollingTime());
-
-        this.cube = cube;
-        this.dockerClientExecutor = dockerClientExecutor;
 
         if (params.getIterations() != null) {
             this.pollIterations = params.getIterations();
@@ -45,11 +41,14 @@ public class HttpAwaitStrategy extends SleepingAwaitStrategyBase {
             String url = params.getUrl();
 
             if (url.contains(DOCKER_HOST)) {
-                url = url.replaceAll(DOCKER_HOST, dockerClientExecutor.getDockerServerIp());
+                url = url.replaceAll(DOCKER_HOST, (dockerClientExecutor.isDockerInsideDockerResolution()
+                    ? dockerClientExecutor.getDockerServerIp() : dockerClientExecutor.getDockerUri().getHost()));
             }
 
             try {
                 this.url = new URL(url);
+                logger.log(Level.INFO, String.format("Http await strategy URL for %s is: %s", cube.getId(), this.url.toExternalForm()));
+
             } catch (IOException e) {
                 throw new IllegalArgumentException(e);
             }
@@ -72,58 +71,69 @@ public class HttpAwaitStrategy extends SleepingAwaitStrategyBase {
 
     @Override
     public boolean await() {
-        return Ping.ping(pollIterations, getSleepTime(), getTimeUnit(), new PingCommand() {
-            @Override
-            public boolean call() {
-                try {
+        final boolean ping = Ping.ping(pollIterations, getSleepTime(), getTimeUnit(), () -> {
 
-                    urlConnection = (HttpURLConnection) url.openConnection();
-                    urlConnection.connect();
+            HttpURLConnection urlConnection = null;
 
-                    int connectionResponseCode = urlConnection.getResponseCode();
-                    if (responseCode != connectionResponseCode) {
-                        return false;
-                    }
+            try {
 
-                    if (matcher != null) {
-                        String content = IOUtil.asString(urlConnection.getInputStream());
+                urlConnection = (HttpURLConnection) url.openConnection();
+                urlConnection.connect();
 
-                        if (matcher.startsWith(REGEXP_PREFIX)) {
-                            String pattern = matcher.substring(REGEXP_PREFIX.length());
-                            final boolean matches = Pattern.compile(pattern, Pattern.DOTALL).matcher(content).matches();
-                            if (!matches) return false;
-                        } else {
-                            final boolean matches = content.startsWith(matcher);
-                            if (!matches) return false;
-                        }
-                    }
-
-                    if (headers != null) {
-                        final Set<String> keys = headers.keySet();
-
-                        for (String key : keys) {
-                            if (urlConnection.getHeaderField(key) != null) {
-                                String connectionHeaderValue = urlConnection.getHeaderField(key);
-                                if (!connectionHeaderValue.equals(headers.get(key))) {
-                                    return false;
-                                }
-                            } else {
-                                // header has not set the required field yet
-                                return false;
-                            }
-                        }
-                    }
-                } catch (IOException e) {
+                int connectionResponseCode = urlConnection.getResponseCode();
+                if (responseCode != connectionResponseCode) {
                     return false;
-                } finally {
-                    if (urlConnection != null) {
-                        urlConnection.disconnect();
+                }
+
+                if (matcher != null) {
+                    String content = IOUtil.asString(urlConnection.getInputStream());
+
+                    if (matcher.startsWith(REGEXP_PREFIX)) {
+                        String pattern = matcher.substring(REGEXP_PREFIX.length());
+                        final boolean matches = Pattern.compile(pattern, Pattern.DOTALL).matcher(content).matches();
+                        if (!matches) return false;
+                    } else {
+                        final boolean matches = content.startsWith(matcher);
+                        if (!matches) return false;
                     }
                 }
 
+                if (headers != null) {
+                    final Set<String> keys = headers.keySet();
+
+                    for (String key : keys) {
+                        if (urlConnection.getHeaderField(key) != null) {
+                            String connectionHeaderValue = urlConnection.getHeaderField(key);
+                            if (!connectionHeaderValue.equals(headers.get(key))) {
+                                return false;
+                            }
+                        } else {
+                            // header has not set the required field yet
+                            return false;
+                        }
+                    }
+                }
+
+                //If we get here then the connection attempt was successful
                 return true;
+
+            } catch (final Exception ignore) {
+                return false;
+            } finally {
+                if (urlConnection != null) {
+                    try {
+                        urlConnection.disconnect();
+                    } catch (final Exception ignore) {
+                        //no-op
+                    }
+                }
             }
         });
+
+        logger.log(Level.INFO, String.format("Ping on %s after %s iterations for %s %s is: %s"
+            , getUrl(), pollIterations, getSleepTime(), getTimeUnit(), ping));
+
+        return ping;
     }
 
     public String getUrl() {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
@@ -93,9 +93,13 @@ public class PollingAwaitStrategy extends SleepingAwaitStrategyBase {
                         throw new IllegalArgumentException(
                             "Can not use polling of type " + type + " on non externally bound port " + port);
                     }
-                    log.fine(String.format("Pinging host %s and port %s with type", mapping.getIP(), mapping.getPort(),
-                        this.type));
-                    if (!Ping.ping(mapping.getIP(), mapping.getPort(), this.pollIterations, this.getSleepTime(),
+
+                    final String host = (dockerClientExecutor.isDockerInsideDockerResolution()
+                        ? dockerClientExecutor.getDockerServerIp() : dockerClientExecutor.getDockerUri().getHost());
+
+                    log.fine(String.format("Pinging host %s:%s with type %s", host, mapping.getPort(), this.type));
+
+                    if (!Ping.ping(host, mapping.getPort(), this.pollIterations, this.getSleepTime(),
                         this.getTimeUnit())) {
                         return false;
                     }
@@ -121,7 +125,7 @@ public class PollingAwaitStrategy extends SleepingAwaitStrategyBase {
                                     "Can not use polling of type " + type + " on non externally bound port " + port);
                             }
                             log.fine(
-                                String.format("Pinging host %s and port %s with type", mapping.getIP(), mapping.getPort(),
+                                String.format("Pinging host %s and port %s with type %s", mapping.getIP(), mapping.getPort(),
                                     this.type));
                             if (!Ping.ping(mapping.getIP(), mapping.getPort(), this.pollIterations, this.getSleepTime(),
                                 this.getTimeUnit())) {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StaticAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/StaticAwaitStrategy.java
@@ -2,7 +2,10 @@ package org.arquillian.cube.docker.impl.await;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.logging.Level;
+import java.util.logging.Logger;
 import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
 import org.arquillian.cube.docker.impl.util.Ping;
 import org.arquillian.cube.spi.Cube;
 
@@ -17,11 +20,16 @@ public class StaticAwaitStrategy extends SleepingAwaitStrategyBase {
     private String ip;
     private List<Integer> ports = new ArrayList<Integer>();
 
-    public StaticAwaitStrategy(Cube<?> cube, Await params) {
+    public StaticAwaitStrategy(final Cube<?> cube, final DockerClientExecutor dockerClientExecutor, final Await params) {
         super(params.getSleepPollingTime());
 
-        this.ip = params.getIp();
+        this.ip = (dockerClientExecutor.isDockerInsideDockerResolution()
+            ? dockerClientExecutor.getDockerServerIp() : dockerClientExecutor.getDockerUri().getHost());
+
         this.ports.addAll(params.getPorts());
+
+        Logger.getLogger(StaticAwaitStrategy.class.getName()).log(Level.INFO, String.format("Static await strategy host for %s is: %s:%s"
+            , cube.getId(), this.ip, this.ports));
 
         if (params.getIterations() != null) {
             this.pollIterations = params.getIterations();

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerConfiguration.java
@@ -46,7 +46,7 @@ public class CubeDockerConfiguration {
     private static final String DOCKER_CONTAINERS_FILES = "dockerContainersFiles";
     private static final String DOCKER_CONTAINERS_RESOURCE = "dockerContainersResource";
     private static final String IGNORE_CONTAINERS_DEFINITION = "ignoreContainersDefinition";
-    private static final String DOCKER_REGISTRY = "dockerRegistry";
+    public static final String DOCKER_REGISTRY = "dockerRegistry";
     private static final String AUTO_START_CONTAINERS = "autoStartContainers";
     private static final String DEFINITION_FORMAT = "definitionFormat";
     private static final String CUBE_ENVIRONMENT = "cube.environment";

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeRegistrarTestCase.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeRegistrarTestCase.java
@@ -15,6 +15,8 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.when;
+
 @RunWith(MockitoJUnitRunner.class)
 public class CubeRegistrarTestCase extends AbstractManagerTestBase {
 
@@ -38,6 +40,7 @@ public class CubeRegistrarTestCase extends AbstractManagerTestBase {
     @Before
     public void setup() {
         bind(ApplicationScoped.class, CubeRegistry.class, registry);
+        when(executor.isDockerInsideDockerResolution()).thenReturn(true);
     }
 
     @Test

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/DockerImageControllerTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/DockerImageControllerTest.java
@@ -37,6 +37,7 @@ public class DockerImageControllerTest extends AbstractManagerTestBase {
     @Test
     public void should_remove_docker_image_if_built_by_cube() {
         DockerClientExecutor executor = Mockito.mock(DockerClientExecutor.class);
+        when(executor.isDockerInsideDockerResolution()).thenReturn(true);
         String config = "pingpong:\n" +
             "  buildImage:\n" +
             "    dockerfileLocation: src/test/resources/tomcat\n" +
@@ -72,6 +73,7 @@ public class DockerImageControllerTest extends AbstractManagerTestBase {
     @Test
     public void should_not_remove_docker_image_as_not_built_by_cube() {
         DockerClientExecutor executor = Mockito.mock(DockerClientExecutor.class);
+        when(executor.isDockerInsideDockerResolution()).thenReturn(true);
 
         String config = "pingpong:\n" +
             "  image: jonmorehouse/ping-pong\n" +

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/NetworkLifecycleControllerTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/NetworkLifecycleControllerTest.java
@@ -18,6 +18,8 @@ import org.mockito.Matchers;
 import org.mockito.Mockito;
 import org.mockito.runners.MockitoJUnitRunner;
 
+import static org.mockito.Mockito.when;
+
 @RunWith(MockitoJUnitRunner.class)
 public class NetworkLifecycleControllerTest extends AbstractManagerTestBase {
 
@@ -31,6 +33,7 @@ public class NetworkLifecycleControllerTest extends AbstractManagerTestBase {
     public void shouldStartNetworks() {
 
         DockerClientExecutor executor = Mockito.mock(DockerClientExecutor.class);
+        when(executor.isDockerInsideDockerResolution()).thenReturn(true);
 
         String config =
             "networks:\n" +
@@ -69,6 +72,7 @@ public class NetworkLifecycleControllerTest extends AbstractManagerTestBase {
     public void shouldStopNetworks() {
 
         DockerClientExecutor executor = Mockito.mock(DockerClientExecutor.class);
+        when(executor.isDockerInsideDockerResolution()).thenReturn(true);
 
         String config =
             "networks:\n" +

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/ContainerNetworkObjectDslTestEnricherTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/ContainerNetworkObjectDslTestEnricherTest.java
@@ -35,6 +35,7 @@ public class ContainerNetworkObjectDslTestEnricherTest {
         networkRegistry = new LocalDockerNetworkRegistry();
         cubeController = mock(CubeController.class);
         dockerClientExecutor = mock(DockerClientExecutor.class);
+        when(dockerClientExecutor.isDockerInsideDockerResolution()).thenReturn(true);
     }
 
     @Test

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/model/DockerCubeTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/model/DockerCubeTest.java
@@ -23,6 +23,7 @@ import org.jboss.arquillian.core.test.AbstractManagerTestBase;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Answers;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
 
@@ -38,7 +39,7 @@ public class DockerCubeTest extends AbstractManagerTestBase {
     @Mock
     private DockerClientExecutor executor;
 
-    @Mock
+    @Mock(answer = Answers.RETURNS_DEEP_STUBS)
     private DockerClient dockerClient;
 
     @Mock
@@ -60,6 +61,8 @@ public class DockerCubeTest extends AbstractManagerTestBase {
         when(inspectContainerCmd.exec()).thenReturn(inspectContainerResponse);
         when(dockerClient.inspectContainerCmd(anyString())).thenReturn(inspectContainerCmd);
         when(executor.getDockerClient()).thenReturn(dockerClient);
+        when(executor.isDockerInsideDockerResolution()).thenReturn(true);
+        when(executor.getDockerServerIp()).thenReturn("localhost");
         CubeContainer cubeContainer = new CubeContainer();
         cubeContainer.setRemoveVolumes(false);
         cube = injectorInst.get().inject(new DockerCube(ID, cubeContainer, executor));

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/CubeDroneConfiguration.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/CubeDroneConfiguration.java
@@ -1,5 +1,7 @@
 package org.arquillian.cube.docker.drone;
 
+import org.arquillian.cube.docker.impl.client.CubeDockerConfiguration;
+
 import java.util.Map;
 
 /**
@@ -38,6 +40,11 @@ public class CubeDroneConfiguration {
 
     private String dockerRegistry = "";
 
+    /**
+     * Default selenium port when using ContainerNameStrategy.STATIC
+     */
+    private int browserSeleniumPort = 14444;
+
     public static CubeDroneConfiguration fromMap(Map<String, String> config) {
         CubeDroneConfiguration cubeDroneConfiguration = new CubeDroneConfiguration();
 
@@ -57,6 +64,10 @@ public class CubeDroneConfiguration {
             cubeDroneConfiguration.browserDockerfileLocation = config.get("browserDockerfileLocation");
         }
 
+        if (config.containsKey("browserSeleniumPort")) {
+            cubeDroneConfiguration.browserSeleniumPort = Integer.parseInt(config.get("browserSeleniumPort"));
+        }
+
         if (config.containsKey("containerNameStrategy")) {
             cubeDroneConfiguration.containerNameStrategy = ContainerNameStrategy.valueOf(config.get("containerNameStrategy"));
         }
@@ -65,14 +76,14 @@ public class CubeDroneConfiguration {
             cubeDroneConfiguration.containerNamePrefix = config.get("containerNamePrefix");
         }
 
-        if (config.containsKey("dockerRegistry")) {
-            String dockerRegistry = config.get("dockerRegistry");
+        if (config.containsKey(CubeDockerConfiguration.DOCKER_REGISTRY)) {
+            String dockerRegistry = config.get(CubeDockerConfiguration.DOCKER_REGISTRY);
 
-            if(null != dockerRegistry) {
+            if (null != dockerRegistry) {
 
                 dockerRegistry = dockerRegistry.trim();
 
-                if(!dockerRegistry.endsWith("/")){
+                if (!dockerRegistry.endsWith("/")) {
                     dockerRegistry = dockerRegistry + "/";
                 }
 
@@ -118,12 +129,12 @@ public class CubeDroneConfiguration {
     public String getBrowserDockerfileLocation() {
         return browserDockerfileLocation;
     }
-    
-    public ContainerNameStrategy getContainerNameStrategy(){
+
+    public ContainerNameStrategy getContainerNameStrategy() {
         return this.containerNameStrategy;
     }
 
-    public String getContainerNamePrefix(){
+    public String getContainerNamePrefix() {
         return this.containerNamePrefix;
     }
 
@@ -131,10 +142,14 @@ public class CubeDroneConfiguration {
         return dockerRegistry;
     }
 
+    public int getBrowserSeleniumPort() {
+        return browserSeleniumPort;
+    }
+
     public static enum RecordMode {
         ALL, ONLY_FAILING, NONE;
     }
-    
+
     public static enum ContainerNameStrategy {
         STATIC, STATIC_PREFIX, RANDOM;
     }

--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -1,5 +1,11 @@
 package org.arquillian.cube.docker.drone;
 
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.logging.Logger;
 import org.arquillian.cube.docker.drone.util.SeleniumVersionExtractor;
 import org.arquillian.cube.docker.drone.util.VideoFileDestination;
 import org.arquillian.cube.docker.drone.util.VolumeCreator;
@@ -13,17 +19,9 @@ import org.arquillian.cube.docker.impl.client.config.StarOperator;
 import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 
-import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.UUID;
-import java.util.logging.Logger;
-
 public class SeleniumContainers {
 
     private static final Logger logger = Logger.getLogger(SeleniumContainers.class.getName());
-
-    private static final String SELENIUM_CONTAINER_BASE_NAME = "browser";
     private static final String VNC_CONTAINER_BASE_NAME = "vnc";
     private static final String CONVERSION_CONTAINER_BASE_NAME = "flv2mp4";
     private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
@@ -34,7 +32,7 @@ public class SeleniumContainers {
     private static final String VNC_HOSTNAME = "vnchost";
     private static final String VOLUME_DIR = "/recording";
     private static final int VNC_EXPOSED_PORT = 5900;
-    public static final String[] FLVREC_COMMAND = new String[] {
+    public static final String[] FLVREC_COMMAND = new String[]{
         "-o",
         VOLUME_DIR + "/screen.flv",
         "-P",
@@ -47,45 +45,47 @@ public class SeleniumContainers {
     private CubeContainer videoConverterContainer;
     private String browser;
     private Path videoRecordingFolder;
-    
+
     private final String seleniumContainerName;
     private final String vncContainerName;
     private final String conversionContainerName;
-    private final int seleniumBoundedPort;
-    private final String dockerRegistry;
 
     private SeleniumContainers(String browser, CubeDroneConfiguration cubeDroneConfiguration) {
         this.browser = browser;
-        
-        switch(cubeDroneConfiguration.getContainerNameStrategy()) {
+        final int seleniumBoundedPort;
+
+        final String browserBaseName = Optional.ofNullable(System.getenv("SELENIUM_CONTAINER_BASE_NAME"))
+            .orElse(System.getProperty("SELENIUM_CONTAINER_BASE_NAME", "browser"));
+
+        switch (cubeDroneConfiguration.getContainerNameStrategy()) {
             case RANDOM:
                 UUID uuid = UUID.randomUUID();
-                this.seleniumContainerName = StarOperator.generateNewName(SELENIUM_CONTAINER_BASE_NAME, uuid);
+                this.seleniumContainerName = StarOperator.generateNewName(browserBaseName, uuid);
                 this.vncContainerName = StarOperator.generateNewName(VNC_CONTAINER_BASE_NAME, uuid);
                 this.conversionContainerName = StarOperator.generateNewName(CONVERSION_CONTAINER_BASE_NAME, uuid);
-                this.seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
+                seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
                 break;
             case STATIC_PREFIX:
-                this.seleniumContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + SELENIUM_CONTAINER_BASE_NAME;
+                this.seleniumContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + browserBaseName;
                 this.vncContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + VNC_CONTAINER_BASE_NAME;
                 this.conversionContainerName = cubeDroneConfiguration.getContainerNamePrefix() + "_" + CONVERSION_CONTAINER_BASE_NAME;
-                this.seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
+                seleniumBoundedPort = StarOperator.generateRandomPrivatePort();
                 break;
             case STATIC:
             default:
-                this.seleniumContainerName = SELENIUM_CONTAINER_BASE_NAME;
+                this.seleniumContainerName = browserBaseName;
                 this.vncContainerName = VNC_CONTAINER_BASE_NAME;
                 this.conversionContainerName = CONVERSION_CONTAINER_BASE_NAME;
-                this.seleniumBoundedPort = 14444;
+                seleniumBoundedPort = cubeDroneConfiguration.getBrowserSeleniumPort();
                 break;
         }
 
-        this.dockerRegistry = cubeDroneConfiguration.getDockerRegistry();
+        final String dockerRegistry = cubeDroneConfiguration.getDockerRegistry();
         this.videoRecordingFolder = VolumeCreator.createTemporaryVolume(DEFAULT_PASSWORD);
-        this.seleniumContainer = createSeleniumContainer(browser, cubeDroneConfiguration, this.seleniumBoundedPort, this.dockerRegistry);
-        this.vncContainer = createVncContainer(this.videoRecordingFolder, this.seleniumContainerName, this.dockerRegistry);
+        this.seleniumContainer = createSeleniumContainer(browser, cubeDroneConfiguration, seleniumBoundedPort, dockerRegistry);
+        this.vncContainer = createVncContainer(this.videoRecordingFolder, this.seleniumContainerName, dockerRegistry);
         final Path targetVolume = VideoFileDestination.resolveTargetDirectory(cubeDroneConfiguration);
-        this.videoConverterContainer = createVideoConverterContainer(targetVolume, this.dockerRegistry);
+        this.videoConverterContainer = createVideoConverterContainer(targetVolume, dockerRegistry);
     }
 
     public static SeleniumContainers create(String browser, CubeDroneConfiguration cubeDroneConfiguration) {
@@ -130,7 +130,8 @@ public class SeleniumContainers {
         // Using sleeping strategy since VNC client is a CLI without exposing a port
         Await await = new Await();
         await.setStrategy("sleeping");
-        await.setSleepTime("100 ms");
+        await.setSleepTime("1 s");
+        await.setIterations(30);
 
         cubeContainer.setAwait(await);
 
@@ -141,37 +142,37 @@ public class SeleniumContainers {
 
         return cubeContainer;
     }
-    
+
     private static String convertToBind(Path hostPath, String containterPath, String mode) {
         boolean isWindows = new OperatingSystemResolver().currentOperatingSystem().getFamily() == OperatingSystemFamily.WINDOWS;
         Path absoluteHostPath = hostPath.toAbsolutePath();
-        if(isWindows) {
+        if (isWindows) {
             StringBuilder convertedHostPath = new StringBuilder();
             String hostRoot = absoluteHostPath.getRoot().toString();
-            if(hostRoot.matches("[a-zA-Z]:\\\\")) {
+            if (hostRoot.matches("[a-zA-Z]:\\\\")) {
                 // local path, converts C:\ to /c
                 convertedHostPath.append('/');
                 convertedHostPath.append(hostRoot.toLowerCase().charAt(0));
             } else {
                 // network share, converts \\servername\share\ to /servername/share
                 convertedHostPath.append(hostRoot.replace("\\\\", "/").replace("\\", "/"));
-                if(convertedHostPath.charAt(convertedHostPath.length() - 1) == '/'){
+                if (convertedHostPath.charAt(convertedHostPath.length() - 1) == '/') {
                     convertedHostPath.deleteCharAt(convertedHostPath.length() - 1);
                 }
             }
-            
+
             // join remaining path elements
-            for(Path pathElem : absoluteHostPath){
+            for (Path pathElem : absoluteHostPath) {
                 convertedHostPath.append('/');
                 convertedHostPath.append(pathElem.toString());
             }
 
-            if(!absoluteHostPath.startsWith("C:\\Users")) {
+            if (!absoluteHostPath.startsWith("C:\\Users")) {
                 logger.warning(String.format("You're not running below the default shared path 'C:\\Users'. Make sure you have set up a shared folder making the host path '%s' accessible as '%s' in your Docker virtual machine.", absoluteHostPath, convertedHostPath));
             }
-            
+
             return convertedHostPath + ":" + containterPath + ":" + mode;
-        }else {
+        } else {
             return absoluteHostPath + ":" + containterPath + ":" + mode;
         }
     }
@@ -236,6 +237,8 @@ public class SeleniumContainers {
             portBindings
         );
 
+        cubeContainer.setShmSize(2147483648L);
+
         Await await = new Await();
         await.setStrategy("http");
         await.setResponseCode(getSeleniumExpectedResponseCode());
@@ -245,16 +248,16 @@ public class SeleniumContainers {
         cubeContainer.setKillContainer(true);
     }
 
-    private static int getSeleniumExpectedResponseCode(){
+    private static int getSeleniumExpectedResponseCode() {
         // Selenium from 3.x onwards returns 200 if started
         int expectedResponseCode = 200;
-            String seleniumVersion = SeleniumVersionExtractor.fromClassPath();
-            if(seleniumVersion.matches("[0-9]+\\.?.*")){
-                int seleniumMajorVersion = Integer.parseInt(seleniumVersion.substring(0, seleniumVersion.indexOf('.')));
-                if(seleniumMajorVersion < 3){
-                    // Doing an http request to selenium node returns a 403 if Jetty is up and running for Selenium < 3
-                    expectedResponseCode = 403;
-                }
+        String seleniumVersion = SeleniumVersionExtractor.fromClassPath();
+        if (seleniumVersion.matches("[0-9]+\\.?.*")) {
+            int seleniumMajorVersion = Integer.parseInt(seleniumVersion.substring(0, seleniumVersion.indexOf('.')));
+            if (seleniumMajorVersion < 3) {
+                // Doing an http request to selenium node returns a 403 if Jetty is up and running for Selenium < 3
+                expectedResponseCode = 403;
+            }
         }
         return expectedResponseCode;
     }
@@ -277,10 +280,6 @@ public class SeleniumContainers {
 
     public Path getVideoRecordingFile() {
         return videoRecordingFolder.resolve("screen.flv");
-    }
-
-    public int getSeleniumBoundedPort() {
-        return seleniumBoundedPort;
     }
 
     public String getSeleniumContainerName() {

--- a/docs/drone.adoc
+++ b/docs/drone.adoc
@@ -45,9 +45,13 @@ recordingMode:: Configures mode for recording. The valid values are: `ALL, ONLY_
 videoOutput:: Directory where videos are stored. By default is `target/reports/videos` or if target does not exists `build/reports/videos` and if not creates a `target/reports/videos` by default.
 browserImage:: Docker image to be used as custom browser image instead of the official one (https://github.com/SeleniumHQ/docker-selenium). Notice that browser property will be used for setting `WebDriver` capabilities.
 browserDockerfileLocation:: Dockerfile location to be used to built custom docker image instead of the official one. This property has preference over browserImage.
+browserSeleniumPort:: When using the default `containerNameStrategy` of `STATIC`, then you can optionally provide a port to override the default of `14444`
 containerNameStrategy:: Sets the strategy for generating the container name. Valid values are `STATIC, STATIC_PREFIX, RANDOM` with the default being `STATIC`. `STATIC` will always use the same name, `STATIC_PREFIX` lets you define a prefix and enables running different tests in parallel and `RANDOM` generates a unique container name on every test run enabling running the same test in parallel.
 containerNamePrefix:: The prefix for the `STATIC_PREFIX` container name strategy.
-dockerRegistry:: Use this to override the default docker registry with a user specified registry.
+dockerRegistry:: Use this to override the default docker registry with a user specified registry - A trailing slash will be added if missing (i.e. _your.repo**/**_)
+
+TIP: To override the base `"browser"` name for all `containerNameStrategy` options you can specify the `SELENIUM_CONTAINER_BASE_NAME` System property or environment variable.
+This can be useful when running on a build server and you want to distinguish between multiple browser images, eg. `export SELENIUM_CONTAINER_BASE_NAME=MyProjectName`.
 
 IMPORTANT: Your custom images must expose the webdriver port `4444` and if you plan to use VNC, expose the default port `5900` as well
 


### PR DESCRIPTION
In a CI environment the DockerUri and DockerServer may not be interchangeable if the CI is not the actual DinD server, rather it has started and mapped a DinD runner.

If image XYZ is exposing port 4321 and `dockerInsideDockerResolution` is true (default) and the container is started **by** the DinD then `dockerServerIp:4321` will be accessible.

However, if the DinD host is a runner then `dockerInsideDockerResolution` is false (ie. dockerServerIp is not the DinD), and the `serverUri` host should be used (which will be set to something like http://myDindAlias:2375), so`myDindAlias:4321` will be accessible.

I'll provide a better description with diagrams in a later PR. It's complicated at best ;-)

#### Changes proposed in this pull request:

- Browser image, name and port override and enhance for DinD.
- Fixed a few tests for windows and updated for DinD.
- Providing more useful logging.
- Set the recommended minimum SHM size for selenium container.

Fixes #1107 
