### PR TITLE
Copy files/logs after the container is stopped

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AfterStopContainerObserver.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/AfterStopContainerObserver.java
@@ -1,0 +1,121 @@
+package org.arquillian.cube.docker.impl.client;
+
+import org.arquillian.cube.docker.impl.client.config.AfterStop;
+import org.arquillian.cube.docker.impl.client.config.Copy;
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.Log;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.impl.util.IOUtil;
+import org.arquillian.cube.spi.Cube;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.jboss.arquillian.core.api.annotation.Observes;
+
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.Collection;
+
+public class AfterStopContainerObserver {
+
+    public void processCommands(@Observes org.arquillian.cube.spi.event.lifecycle.AfterStop afterStop,
+                                CubeRegistry cubeRegistry,
+                                DockerClientExecutor dockerClientExecutor) throws IOException {
+
+        Cube<CubeContainer> cube = cubeRegistry.getCube(afterStop.getCubeId(), DockerCube.class);
+        CubeContainer configuration = cube.configuration();
+
+        if (configuration.getAfterStop() != null) {
+            Collection<AfterStop> afterStopConfiguration = configuration.getAfterStop();
+
+            for (AfterStop map : afterStopConfiguration) {
+                if (map.getCopy() != null) {
+                    Copy copyConfiguration = map.getCopy();
+                    executeCopyAction(dockerClientExecutor, afterStop.getCubeId(), copyConfiguration);
+                } else {
+                    if (map.getLog() != null) {
+                        Log logConfiguration = map.getLog();
+                        executeLogAction(dockerClientExecutor, afterStop.getCubeId(), logConfiguration);
+                    }
+                }
+            }
+        }
+    }
+
+    protected void executeCopyAction(DockerClientExecutor dockerClientExecutor, String containerId,
+                                     Copy configurationParameters) throws IOException {
+        String to = null;
+        String from = null;
+        if (configurationParameters.getTo() != null && configurationParameters.getFrom() != null) {
+            to = configurationParameters.getTo();
+            from = configurationParameters.getFrom();
+        } else {
+            throw new IllegalArgumentException(
+                String.format("to and from property is mandatory when copying files from container %s.", containerId));
+        }
+
+        InputStream response = dockerClientExecutor.getFileOrDirectoryFromContainerAsTar(containerId, from);
+        Path toPath = Paths.get(to);
+        File toPathFile = toPath.toFile();
+
+        if (toPathFile.exists() && toPathFile.isFile()) {
+            throw new IllegalArgumentException(String.format(
+                "%s parameter should be a directory in copy operation but you set an already existing file not a directory. Check %s in your local directory because currently is a file.",
+                "to", toPath.normalize().toString()));
+        }
+
+        Files.createDirectories(toPath);
+
+        IOUtil.untar(response, toPathFile);
+    }
+
+    protected void executeLogAction(DockerClientExecutor dockerClientExecutor, String containerId,
+                                    Log configurationParameters) throws IOException {
+        String to = null;
+        if (configurationParameters.getTo() != null) {
+            to = configurationParameters.getTo();
+        } else {
+            throw new IllegalArgumentException(
+                String.format("to property is mandatory when getting logs from container %s.", containerId));
+        }
+
+        boolean follow = false;
+        boolean stderr = false;
+        boolean stdout = false;
+        boolean timestamps = false;
+        int tail = -1;
+
+        if (configurationParameters.getStdout() != null) {
+            stdout = configurationParameters.getStdout();
+        }
+
+        if (configurationParameters.getStderr() != null) {
+            stderr = configurationParameters.getStderr();
+        }
+
+        if (configurationParameters.getTimestamps() != null) {
+            timestamps = configurationParameters.getTimestamps();
+        }
+
+        if (configurationParameters.getTail() != null) {
+            tail = configurationParameters.getTail();
+        }
+
+        Path toPath = Paths.get(to);
+        File toPathFile = toPath.toFile();
+        if (toPathFile.exists() && toPathFile.isDirectory()) {
+            throw new IllegalArgumentException(String.format(
+                "%s parameter should be a file in log operation but you set an already existing directory not a file.",
+                "to"));
+        }
+
+        Path toDirectory = toPath.getParent();
+        Files.createDirectories(toDirectory);
+        dockerClientExecutor.copyLog(containerId, follow, stdout, stderr, timestamps, tail,
+            new FileOutputStream(toPathFile));
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/CubeDockerExtension.java
@@ -25,6 +25,7 @@ public class CubeDockerExtension implements LoadableExtension {
             //.observer(ClientCubeControllerCreator.class)
             .observer(AfterStartContainerObserver.class)
             .observer(BeforeStopContainerObserver.class)
+            .observer(AfterStopContainerObserver.class)
             .observer(Boot2DockerCreator.class)
             .observer(DockerMachineCreator.class)
             .observer(AfterClassContainerObjectObserver.class)

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/AfterStop.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/AfterStop.java
@@ -1,0 +1,26 @@
+package org.arquillian.cube.docker.impl.client.config;
+
+public class AfterStop {
+
+    private Copy copy;
+    private Log log;
+
+    public AfterStop() {
+    }
+
+    public Copy getCopy() {
+        return copy;
+    }
+
+    public void setCopy(Copy copy) {
+        this.copy = copy;
+    }
+
+    public Log getLog() {
+        return log;
+    }
+
+    public void setLog(Log log) {
+        this.log = log;
+    }
+}

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/CubeContainer.java
@@ -68,6 +68,7 @@ public class CubeContainer {
 
     private Collection<AfterStart> afterStart;
     private Collection<BeforeStop> beforeStop;
+    private Collection<AfterStop> afterStop;
 
     public Image getImage() {
         return image;
@@ -447,6 +448,18 @@ public class CubeContainer {
 
     public boolean hasBeforeStop() {
         return this.beforeStop != null && !this.beforeStop.isEmpty();
+    }
+
+    public Collection<AfterStop> getAfterStop() {
+        return afterStop;
+    }
+
+    public void setAfterStop(Collection<AfterStop> afterStop) {
+        this.afterStop = afterStop;
+    }
+
+    public boolean hasAfterStop() {
+        return this.afterStop != null && !this.afterStop.isEmpty();
     }
 
     public String getContainerName() {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/config/DockerCompositions.java
@@ -131,6 +131,10 @@ public class DockerCompositions {
                     cubeContainer.setBeforeStop(overrideCubeContainer.getBeforeStop());
                 }
 
+                if (overrideCubeContainer.hasAfterStop()) {
+                    cubeContainer.setAfterStop(overrideCubeContainer.getAfterStop());
+                }
+
                 if (overrideCubeContainer.isManual()) {
                     cubeContainer.setManual(overrideCubeContainer.isManual());
                 }

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/DockerClientExecutor.java
@@ -1002,7 +1002,7 @@ public class DockerClientExecutor {
     public InputStream getFileOrDirectoryFromContainerAsTar(String containerId, String from) {
         this.readWriteLock.readLock().lock();
         try {
-            InputStream response = dockerClient.copyFileFromContainerCmd(containerId, from).exec();
+            InputStream response = dockerClient.copyArchiveFromContainerCmd(containerId, from).exec();
             return response;
         } finally {
             this.readWriteLock.readLock().unlock();

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/AfterStopContainerObserverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/AfterStopContainerObserverTest.java
@@ -1,0 +1,117 @@
+package org.arquillian.cube.docker.impl.client;
+
+import org.arquillian.cube.docker.impl.client.config.CubeContainer;
+import org.arquillian.cube.docker.impl.client.config.DockerCompositions;
+import org.arquillian.cube.docker.impl.docker.DockerClientExecutor;
+import org.arquillian.cube.docker.impl.model.DockerCube;
+import org.arquillian.cube.docker.impl.util.ConfigUtil;
+import org.arquillian.cube.spi.CubeRegistry;
+import org.arquillian.cube.spi.event.lifecycle.AfterStop;
+import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
+import org.jboss.arquillian.core.test.AbstractManagerTestBase;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.runners.MockitoJUnitRunner;
+
+import java.io.File;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Matchers.*;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@RunWith(MockitoJUnitRunner.class)
+public class AfterStopContainerObserverTest extends AbstractManagerTestBase {
+
+    private static final String CUBE_CONTAINER_NAME = "test";
+
+    private static final String CONTAINER_COPY_CONFIGURATION =
+        "tomcat_default:\n" +
+            "  image: tutum/tomcat:7.0\n" +
+            "  afterStop:\n" +
+            "    - copy:\n" +
+            "        from: /test\n" +
+            "        to: ";
+
+    private static final String CONTAINER_LOG_CONFIGURATION =
+        "tomcat_default:\n" +
+            "  image: tutum/tomcat:7.0\n" +
+            "  afterStop:\n" +
+            "    - log:\n" +
+            "        to: ";
+
+    @Rule
+    public TemporaryFolder temporaryFolder = new TemporaryFolder();
+
+    @Mock
+    private DockerCube cube;
+
+    @Mock
+    private CubeRegistry registry;
+
+    @Mock
+    private DockerClientExecutor dockerClientExecutor;
+
+    @BeforeClass
+    public static void startDockerStub() {
+    }
+
+    @Override
+    protected void addExtensions(List<Class<?>> extensions) {
+        super.addExtensions(extensions);
+        extensions.add(AfterStopContainerObserver.class);
+    }
+
+    @Before
+    public void setup() {
+        bind(ApplicationScoped.class, DockerClientExecutor.class,
+            dockerClientExecutor);
+
+        Mockito.when(registry.getCube(CUBE_CONTAINER_NAME, DockerCube.class)).thenReturn(
+            cube);
+        bind(ApplicationScoped.class, CubeRegistry.class, registry);
+    }
+
+    @Test
+    public void shouldCopyFileFromContainer() throws IOException {
+        File newFolder = temporaryFolder.newFolder();
+        String content = CONTAINER_COPY_CONFIGURATION;
+        content += newFolder.getAbsolutePath();
+
+        DockerCompositions configuration = ConfigUtil.load(content);
+        CubeContainer config = configuration.get("tomcat_default");
+
+        Mockito.when(cube.configuration()).thenReturn(config);
+        Mockito.when(dockerClientExecutor.getFileOrDirectoryFromContainerAsTar(eq(CUBE_CONTAINER_NAME), anyString()))
+            .thenReturn(AfterStopContainerObserverTest.class.getResourceAsStream("/hello.tar"));
+        fire(new AfterStop(CUBE_CONTAINER_NAME));
+        verify(dockerClientExecutor).getFileOrDirectoryFromContainerAsTar(eq(CUBE_CONTAINER_NAME), eq("/test"));
+        assertThat(new File(newFolder, "hello.txt").exists(), is(true));
+    }
+
+    @Test
+    public void shouldGetLogFromContainer() throws IOException {
+        File newFolder = temporaryFolder.newFolder();
+        String content = CONTAINER_LOG_CONFIGURATION;
+        content += newFolder.getAbsolutePath();
+        content += "mylog.log";
+
+        DockerCompositions configuration = ConfigUtil.load(content);
+        CubeContainer config = configuration.get("tomcat_default");
+        Mockito.when(cube.configuration()).thenReturn(config);
+        fire(new AfterStop(CUBE_CONTAINER_NAME));
+        verify(dockerClientExecutor, times(1)).copyLog(eq(CUBE_CONTAINER_NAME), eq(false), eq(false), eq(false),
+            eq(false), eq(-1), any(OutputStream.class));
+    }
+}
+

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfigurationTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfigurationTest.java
@@ -70,6 +70,10 @@ public class CubeConfigurationTest {
             "  beforeStop: \n" +
             "    - copy:\n" +
             "        from: /test\n" +
+            "        to: /tmp\n" +
+            "  afterStop: \n" +
+            "    - copy:\n" +
+            "        from: /test\n" +
             "        to: /tmp";
 
     private static final String VERSION_2_WITH_VOLUMES = "version: '2'\n" +


### PR DESCRIPTION
## Short description of what this resolves:
Sometimes it is useful to get access to files/logs after the container is stopped.

#### Changes proposed in this pull request:
- new AfterStopContainerObserver
- new afterStop configuration

Fixes #