### PR TITLE
chore(deps): bumps snakeyaml to 1.24

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <version.hamcrest>1.3</version.hamcrest>
     <version.docker-java>3.0.14</version.docker-java>
     <version.kubernetes_client>4.0.3</version.kubernetes_client>
-    <version.snakeyaml>1.19</version.snakeyaml>
+    <version.snakeyaml>1.24</version.snakeyaml>
     <version.shrinkwrap_resolver>3.0.1</version.shrinkwrap_resolver>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.mockito>1.10.19</version.mockito>


### PR DESCRIPTION
This PR fixes issue #1049 

In snakeyaml 1.20 the API of `BaseConstructor.constructScalar(ScalarNode)` changed to return a String. This broke binary compatibility. `arquillian-cube` at the moment cannot be used with snakeyaml versions 1.20 or newer. The actual change is really simple: just upgrade to 1.24, no changes in source are needed. Recompiling the code with the new dependency will make it work with the new version.