### PR TITLE
fix: avoid issuing invalid wait-for-it command

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/await/PollingAwaitStrategy.java
@@ -111,7 +111,7 @@ public class PollingAwaitStrategy extends SleepingAwaitStrategyBase {
                     } catch (UnsupportedOperationException e) {
                         // In case of not having ss command installed on container, it automatically fall back to waitforit approach
                         try {
-                            if (!executeWaitForIt(portBindings.getInternalIP(), port)) {
+                            if (!executeWaitForIt(getReadyCheckIp(portBindings), port)) {
                                 return false;
                             }
                         } catch (UnsupportedOperationException ex) {
@@ -132,7 +132,7 @@ public class PollingAwaitStrategy extends SleepingAwaitStrategyBase {
                 }
                 break;
                 case "waitforit": {
-                    if (!executeWaitForIt(portBindings.getInternalIP(), port)) {
+                    if (!executeWaitForIt(getReadyCheckIp(portBindings), port)) {
                         return false;
                     }
                 }
@@ -140,6 +140,17 @@ public class PollingAwaitStrategy extends SleepingAwaitStrategyBase {
         }
 
         return true;
+    }
+
+    private String getReadyCheckIp(HasPortBindings portBindings) {
+        String ip = portBindings.getInternalIP();
+        if (ip == null || "".equals(ip)) {
+            ip = portBindings.getContainerIP();
+        }
+        if (ip == null || "".equals(ip)) {
+            ip = "localhost";
+        }
+        return ip;
     }
 
     private boolean executeWaitForIt(String containerIp, int port) {


### PR DESCRIPTION
The default wait-for-it script is easily invoked without a HOST, because internalIP easily resolves to empty string.

An example invocation which can never succeed because it's syntactically incorrect:

    /tmp/wait-for-it.sh :8080 -s -- echo Service is Up

We can go an extra step, and make sure that a non-empty HOST is set. we may not default to a good value but at least it's one that sometimes works.

#### Changes proposed in this pull request:

- if internalIP is empty, default to containerIP, if that one is also empty default to localhost
