### PR TITLE
feat: adds docker-compose support for environment maps

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/ContainerBuilder.java
@@ -192,7 +192,11 @@ public class ContainerBuilder {
             this.addVolumesFrom(asListOfString(dockerComposeContainerDefinition, VOLUMES_FROM));
         }
         if (dockerComposeContainerDefinition.containsKey(ENVIRONMENT)) {
-            this.addEnvironment(asListOfString(dockerComposeContainerDefinition, ENVIRONMENT));
+            try {
+                this.addEnvironment(asListOfString(dockerComposeContainerDefinition, ENVIRONMENT));
+            } catch (ClassCastException e) {
+                this.addEnvironment(asListOfString(asMap(dockerComposeContainerDefinition, ENVIRONMENT)));
+            }
         }
         if (dockerComposeContainerDefinition.containsKey(ENV_FILE)) {
             if(dockerComposeContainerDefinition.get(ENV_FILE) instanceof List) {
@@ -233,7 +237,11 @@ public class ContainerBuilder {
             this.addWorkingDir(asString(dockerComposeContainerDefinition, WORKING_DIR));
         }
         if (dockerComposeContainerDefinition.containsKey(ENTRYPOINT)) {
-            this.addEntrypoint(asString(dockerComposeContainerDefinition, ENTRYPOINT));
+            try {
+                this.addEntrypoint(asString(dockerComposeContainerDefinition, ENTRYPOINT));
+            } catch (ClassCastException e) {
+                this.addEntrypoint(asListOfString(dockerComposeContainerDefinition, ENTRYPOINT));
+            }
         }
         if (dockerComposeContainerDefinition.containsKey(USER)) {
             this.addUser(asString(dockerComposeContainerDefinition, USER));
@@ -776,6 +784,11 @@ public class ContainerBuilder {
 
     public ContainerBuilder addEntrypoint(String entrypoint) {
         configuration.setEntryPoint(Arrays.asList(entrypoint));
+        return this;
+    }
+
+    public ContainerBuilder addEntrypoint(Collection<String> entrypoint) {
+        configuration.setEntryPoint(entrypoint);
         return this;
     }
 

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverter.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/docker/compose/DockerComposeConverter.java
@@ -65,7 +65,7 @@ public class DockerComposeConverter implements Converter {
 
         Set<String> names = dockerComposeDefinitionMap.keySet();
 
-        boolean isV2OrGreater = names.contains(DOCKER_COMPOSE_VERSION_KEY) && Integer.parseInt((String) dockerComposeDefinitionMap.get(DOCKER_COMPOSE_VERSION_KEY)) > 1;
+        boolean isV2OrGreater = names.contains(DOCKER_COMPOSE_VERSION_KEY) && Double.parseDouble((String) dockerComposeDefinitionMap.get(DOCKER_COMPOSE_VERSION_KEY)) > 1;
         if (isV2OrGreater) {
             dockerCompositions = convertCompose(dockerComposeDefinitionMap);
         } else {

--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/YamlUtil.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/YamlUtil.java
@@ -1,6 +1,8 @@
 package org.arquillian.cube.docker.impl.util;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 import java.util.Map;
 
 public class YamlUtil {
@@ -23,6 +25,21 @@ public class YamlUtil {
         return (Collection<String>) map.get(property);
     }
 
+    /**
+     * This method converts a map of key:value pairs into a list of 'key=value' strings
+     *
+     * @param mapOfStrings Map of key:value pairs
+     * @return List of key=value strings
+     */
+    public static final List<String> asListOfString(Map<String, ?> mapOfStrings) {
+        ArrayList<String> result = new ArrayList<>();
+        for (Map.Entry<String, ?> ent: mapOfStrings.entrySet()) {
+            result.add(ent.getKey() + "=" + (ent.getValue() != null ? ent.getValue() : ""));
+        }
+        return result;
+    }
+
+    @SuppressWarnings("unchecked")
     public static final String asString(Map<String, Object> map, String property) {
         return (String) map.get(property);
     }


### PR DESCRIPTION
This patch allows using the following syntax in docker-compose:
- Decimal value for version (e.g. version: '3.5')
- List for entrypoint (e.g. entrypoint: [], or entrypoint: [/bin/sh, -c, echo]
- Map for environment
