### PR TITLE
Fixing CircleCI unit tests for JDK8 and Docker

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,9 +1,45 @@
 version: 2.1
+
+commands:
+  mvn-build:
+    parameters:
+      category:
+        type: enum
+        enum: ["docker", "kubernetes", "openshift"]
+    steps:
+      - run:
+          name: "Maven pre-fetch dependencies"
+          command: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
+      - when:
+          condition:
+            equal: [ docker, << parameters.category >> ]
+          steps:   
+            - run:
+                name: "Maven build for Docker"
+                command: ./mvnw clean package -Dfailsafe.groups=org.arquillian.cube.docker.impl.requirement.RequiresDocker
+      - when:
+          condition:
+            equal: [ kubernetes, << parameters.category >> ]
+          steps:   
+            - run:
+                name: "Maven build for Kubernetes"
+                command: ./mvnw clean package -Dfailsafe.groups=org.arquillian.cube.docker.impl.requirement.RequiresDocker          
+      - when:
+          condition:
+            equal: [ openshift, << parameters.category >> ]
+          steps:   
+            - run:
+                name: "Maven build for OpenShift" 
+                command: ./mvnw clean package -Dfailsafe.groups=org.arquillian.cube.docker.impl.requirement.RequiresDocker        
+
 jobs:
   build:
     parameters:
       jdk-version:
         type: string
+      category:
+        type: enum
+        enum: ["docker", "kubernetes", "openshift"]
     working_directory: ~/circleci-arquillian-cube
     docker:
       - image: cimg/openjdk:<< parameters.jdk-version >>
@@ -21,8 +57,8 @@ jobs:
               echo 'Changing owner of /var/run/docker.sock to circleci' 
                   sudo chown circleci /var/run/docker.sock
               fi
-      - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
-      - run: ./mvnw package
+      - mvn-build:
+          category: << parameters.category >> 
       - store_test_results:
           path: target/surefire-reports
       - save_cache:
@@ -38,3 +74,4 @@ workflows:
           matrix:
             parameters:
               jdk-version: ["8.0"] # TODO: Add JDK 11.0 when builds for JDK8 work
+              category: ["docker"] # TODO: Add builds for kubernetes and openshift

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -6,13 +6,21 @@ jobs:
         type: string
     working_directory: ~/circleci-arquillian-cube
     docker:
-      - image: circleci/openjdk:<< parameters.jdk-version >>
+      - image: cimg/openjdk:<< parameters.jdk-version >>
     steps:
       - checkout
-      - restore_cache:
-          key: circleci-arquillian-cube-{{ checksum "pom.xml" }}
       - setup_remote_docker:
           version: 20.10.18
+          docker_layer_caching: true
+      - restore_cache:
+          key: circleci-arquillian-cube-{{ checksum "pom.xml" }}
+      - run:
+          name: "Change owner of /var/run/docker.sock to circleci for local CLI builds"
+          command: |
+              if [[ $CIRCLE_SHELL_ENV == *"localbuild"* ]]; then
+              echo 'Changing owner of /var/run/docker.sock to circleci' 
+                  sudo chown circleci /var/run/docker.sock
+              fi
       - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
       - run: ./mvnw package
       - store_test_results:
@@ -29,4 +37,4 @@ workflows:
       - build:
           matrix:
             parameters:
-              jdk-version: ["8", "11"]
+              jdk-version: ["8.0"] # TODO: Add JDK 11.0 when builds for JDK8 work

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,6 +11,8 @@ jobs:
       - checkout
       - restore_cache:
           key: circleci-arquillian-cube-{{ checksum "pom.xml" }}
+      - setup_remote_docker:
+          version: 20.10.18
       - run: ./mvnw verify -q -U -DskipTests # pre-fetch dependencies (dependency:resolve fails)
       - run: ./mvnw package
       - store_test_results:

--- a/docker/docker/pom.xml
+++ b/docker/docker/pom.xml
@@ -153,8 +153,8 @@
         <configuration>
           <environmentVariables>
             <TESTIMAGENAME>MyImageName</TESTIMAGENAME>
-            <DOCKER_HOST />
-            <DOCKER_CERT_PATH />
+            <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
+            <DOCKER_CERT_PATH>${env.DOCKER_CERT_PATH}</DOCKER_CERT_PATH>
           </environmentVariables>
           <systemPropertyVariables>
             <SYSTEMTESTIMAGENAME>TestImageName</SYSTEMTESTIMAGENAME>

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeConfiguratorTest.java
@@ -26,7 +26,9 @@ import org.jboss.arquillian.core.api.annotation.ApplicationScoped;
 import org.jboss.arquillian.core.test.AbstractManagerTestBase;
 import org.junit.Assume;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -44,6 +46,9 @@ import static org.mockito.Mockito.when;
 
 @RunWith(MockitoJUnitRunner.class)
 public class CubeConfiguratorTest extends AbstractManagerTestBase {
+    
+    @Rule
+    public final EnvironmentVariables environmentVariables = new EnvironmentVariables();
 
     @Mock
     CommandLineExecutor commandLineExecutor;
@@ -92,6 +97,8 @@ public class CubeConfiguratorTest extends AbstractManagerTestBase {
         bind(ApplicationScoped.class, Top.class, top);
 
         when(top.isSpinning()).thenReturn(false);
+        
+        environmentVariables.clear("DOCKER_HOST", "DOCKER_MACHINE_NAME", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH");
     }
 
     @Test

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/client/CubeDockerConfigurationResolverTest.java
@@ -17,7 +17,11 @@ import org.arquillian.cube.docker.impl.util.OperatingSystemFamilyInterface;
 import org.arquillian.cube.docker.impl.util.OperatingSystemInterface;
 import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
 import org.arquillian.cube.docker.impl.util.Top;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.mockito.Matchers;
 import org.mockito.Mock;
@@ -32,6 +36,9 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class CubeDockerConfigurationResolverTest {
 
+    @ClassRule
+    public static final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+    
     @Mock
     private static OperatingSystemInterface operatingSystemInterface;
 
@@ -58,6 +65,11 @@ public class CubeDockerConfigurationResolverTest {
         when(dockerClient.infoCmd()).thenReturn(infoCmd);
         when(infoCmd.exec()).thenReturn(info);
         return defaultDocker;
+    }
+    
+    @BeforeClass
+    public static void beforeEach() {
+        environmentVariables.clear("DOCKER_HOST", "DOCKER_MACHINE_NAME", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH");
     }
 
     @Test

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerRequirementTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerRequirementTest.java
@@ -15,7 +15,10 @@ import org.arquillian.cube.docker.impl.client.CubeDockerConfigurationResolver;
 import org.arquillian.cube.docker.impl.util.CommandLineExecutor;
 import org.arquillian.cube.spi.requirement.UnsatisfiedRequirementException;
 import org.arquillian.spacelift.execution.ExecutionException;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
+import org.junit.contrib.java.lang.system.EnvironmentVariables;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
@@ -25,11 +28,19 @@ import static org.mockito.Mockito.when;
 @RunWith(MockitoJUnitRunner.class)
 public class DockerRequirementTest {
 
+    @ClassRule
+    public static final EnvironmentVariables environmentVariables = new EnvironmentVariables();
+
     @Mock
     CubeDockerConfigurationResolver configResolver;
 
     @Mock
     CommandLineExecutor commandLineExecutor;
+
+    @BeforeClass
+    public static void beforeEach() {
+        environmentVariables.clear("DOCKER_HOST", "DOCKER_MACHINE_NAME", "DOCKER_TLS_VERIFY", "DOCKER_CERT_PATH");
+    }
 
     @Test(expected = UnsatisfiedRequirementException.class)
     public void testDockerRequirementCheckWhenExecutionExceptionThrown() throws UnsatisfiedRequirementException {
@@ -101,7 +112,8 @@ public class DockerRequirementTest {
         }
 
         public String getConnectionString() {
-            return "tcp://" + serverSocket.getInetAddress().getHostName() + ":" + serverSocket.getLocalPort();
+            return "tcp://" + serverSocket.getInetAddress()
+                .getHostName() + ":" + serverSocket.getLocalPort();
         }
 
         @Override
@@ -110,7 +122,8 @@ public class DockerRequirementTest {
             Socket socket = null;
             try {
                 socket = serverSocket.accept();
-                socket.getInputStream().read(); // Will hang on windows if stream is not read
+                socket.getInputStream()
+                    .read(); // Will hang on windows if stream is not read
                 writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream()));
 
                 String versionJSON = "{\"Client\":{\"Version\":\"0.0.0\",\"ApiVersion\":\"0.00\"}}";

--- a/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerRequirementTest.java
+++ b/docker/docker/src/test/java/org/arquillian/cube/docker/impl/requirement/DockerRequirementTest.java
@@ -110,6 +110,7 @@ public class DockerRequirementTest {
             Socket socket = null;
             try {
                 socket = serverSocket.accept();
+                socket.getInputStream().read(); // Will hang on windows if stream is not read
                 writer = new PrintWriter(new OutputStreamWriter(socket.getOutputStream()));
 
                 String versionJSON = "{\"Client\":{\"Version\":\"0.0.0\",\"ApiVersion\":\"0.00\"}}";

--- a/docker/ftest-docker-junit5/src/test/java/org/arquillian/cube/docker/junit5/NetworkTest.java
+++ b/docker/ftest-docker-junit5/src/test/java/org/arquillian/cube/docker/junit5/NetworkTest.java
@@ -2,12 +2,11 @@ package org.arquillian.cube.docker.junit5;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 // tag::docs[]
-@ExtendWith(NetworkDslResolver.class)
+//@ExtendWith(NetworkDslResolver.class)
 // end::docs[]
 @Disabled("Test disabled because requirements module has no support for JUnit5 yet")
 // tag::docs[]

--- a/docker/ftest-docker-junit5/src/test/java/org/arquillian/cube/docker/junit5/RedisTest.java
+++ b/docker/ftest-docker-junit5/src/test/java/org/arquillian/cube/docker/junit5/RedisTest.java
@@ -2,13 +2,12 @@ package org.arquillian.cube.docker.junit5;
 
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.ExtendWith;
 import redis.clients.jedis.Jedis;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 // tag::docs[]
-@ExtendWith(ContainerDslResolver.class)
+//@ExtendWith(ContainerDslResolver.class)
 // end::docs[]
 @Disabled("Test disabled because requirements module has no support for JUnit5 yet")
 // tag::docs[]

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -23,6 +23,28 @@
   <packaging>pom</packaging>
 
   <name>Arquillian Cube Docker Parent</name>
+  
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <configuration>
+            <environmentVariables>
+              <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
+              <DOCKER_CERT_PATH>${env.DOCKER_CERT_PATH}</DOCKER_CERT_PATH>
+              <DOCKER_TLS_VERIFY>${env.DOCKER_TLS_VERIFY}</DOCKER_TLS_VERIFY>
+              <DOCKER_MACHINE_NAME>${env.DOCKER_MACHINE_NAME}</DOCKER_MACHINE_NAME>
+            </environmentVariables>
+            <systemPropertyVariables>
+              <SYSTEMTESTIMAGENAME>TestImageName</SYSTEMTESTIMAGENAME>
+            </systemPropertyVariables>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
 
   <dependencies>
     <dependency>

--- a/docker/pom.xml
+++ b/docker/pom.xml
@@ -25,25 +25,23 @@
   <name>Arquillian Cube Docker Parent</name>
   
   <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <configuration>
-            <environmentVariables>
-              <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
-              <DOCKER_CERT_PATH>${env.DOCKER_CERT_PATH}</DOCKER_CERT_PATH>
-              <DOCKER_TLS_VERIFY>${env.DOCKER_TLS_VERIFY}</DOCKER_TLS_VERIFY>
-              <DOCKER_MACHINE_NAME>${env.DOCKER_MACHINE_NAME}</DOCKER_MACHINE_NAME>
-            </environmentVariables>
-            <systemPropertyVariables>
-              <SYSTEMTESTIMAGENAME>TestImageName</SYSTEMTESTIMAGENAME>
-            </systemPropertyVariables>
-          </configuration>
-        </plugin>
-      </plugins>
-    </pluginManagement>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <configuration>
+          <environmentVariables>
+            <DOCKER_HOST>${env.DOCKER_HOST}</DOCKER_HOST>
+            <DOCKER_CERT_PATH>${env.DOCKER_CERT_PATH}</DOCKER_CERT_PATH>
+            <DOCKER_TLS_VERIFY>${env.DOCKER_TLS_VERIFY}</DOCKER_TLS_VERIFY>
+            <DOCKER_MACHINE_NAME>${env.DOCKER_MACHINE_NAME}</DOCKER_MACHINE_NAME>
+          </environmentVariables>
+          <systemPropertyVariables>
+            <SYSTEMTESTIMAGENAME>TestImageName</SYSTEMTESTIMAGENAME>
+          </systemPropertyVariables>
+        </configuration>
+      </plugin>
+    </plugins>
   </build>
 
   <dependencies>

--- a/kubernetes/ftest-kubernetes-assistant/src/test/java/org/arquillian/cube/kubernetes/assistant/HelloWorldKubernetesAssistantTest.java
+++ b/kubernetes/ftest-kubernetes-assistant/src/test/java/org/arquillian/cube/kubernetes/assistant/HelloWorldKubernetesAssistantTest.java
@@ -8,6 +8,7 @@ import org.arquillian.cube.kubernetes.impl.requirement.RequiresKubernetes;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
 import java.io.IOException;
@@ -18,6 +19,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 // tag::k8_assistant_example[]
 @RunWith(ArquillianConditionalRunner.class)
+@Category(RequiresKubernetes.class)
 @RequiresKubernetes
 public class HelloWorldKubernetesAssistantTest {
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
@@ -27,11 +27,11 @@ public class KubernetesRequirement implements Constraint<RequiresKubernetes> {
 
         final DefaultConfiguration config = new ExtensionRegistrar().loadExtension(extension);
 
-        KubernetesClient client = new DefaultKubernetesClient(new ClientConfigBuilder().configuration(config).build());
+        try (KubernetesClient client = new DefaultKubernetesClient(
+            new ClientConfigBuilder().configuration(config).build())) {
 
-        OkHttpClient httpClient = client.adapt(OkHttpClient.class);
+            OkHttpClient httpClient = client.adapt(OkHttpClient.class);
 
-        try {
             Request versionRequest = new Request.Builder()
                 .get()
                 .url(URLUtils.join(client.getMasterUrl().toString(), "version"))

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/requirement/KubernetesRequirement.java
@@ -30,18 +30,19 @@ public class KubernetesRequirement implements Constraint<RequiresKubernetes> {
         KubernetesClient client = new DefaultKubernetesClient(new ClientConfigBuilder().configuration(config).build());
 
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
-        Request versionRequest = new Request.Builder()
-            .get()
-            .url(URLUtils.join(client.getMasterUrl().toString(), "version"))
-            .build();
 
         try {
+            Request versionRequest = new Request.Builder()
+                .get()
+                .url(URLUtils.join(client.getMasterUrl().toString(), "version"))
+                .build();
+
             Response response = httpClient.newCall(versionRequest).execute();
             if (!response.isSuccessful()) {
                 throw new UnsatisfiedRequirementException(
                     "Failed to verify kubernetes version, due to: [" + response.message() + "]");
             }
-        } catch (IOException e) {
+        } catch (IOException | IllegalArgumentException e) {
             throw new UnsatisfiedRequirementException(
                 "Error while checking kubernetes version: [" + e.getMessage() + "]");
         }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
@@ -30,21 +30,24 @@ public class OpenshiftRequirement implements Constraint<RequiresOpenshift> {
         KubernetesClient client = new DefaultKubernetesClient(new ClientConfigBuilder().configuration(config).build());
 
         OkHttpClient httpClient = client.adapt(OkHttpClient.class);
-        Request versionRequest = new Request.Builder()
-            .get()
-            .url(URLUtils.join(client.getMasterUrl().toString(), "version"))
-            .build();
 
         try {
+            Request versionRequest = new Request.Builder()
+                .get()
+                .url(URLUtils.join(client.getMasterUrl().toString(), "version"))
+                .build();
+
             Response response = httpClient.newCall(versionRequest).execute();
             if (!response.isSuccessful()) {
                 throw new UnsatisfiedRequirementException(
                     "Failed to verify Openshift version, due to: [" + response.message() + "]");
             } else if (!client.isAdaptable(OpenShiftClient.class)) {
-                throw new UnsatisfiedRequirementException("A valid Kubernetes environmnet was found, but not Openshift.");
+                throw new UnsatisfiedRequirementException(
+                    "A valid Kubernetes environmnet was found, but not Openshift.");
             }
-        } catch (IOException e) {
-            throw new UnsatisfiedRequirementException("Error while checking Openshift version: [" + e.getMessage() + "]");
+        } catch (IOException | IllegalArgumentException e) {
+            throw new UnsatisfiedRequirementException(
+                "Error while checking Openshift version: [" + e.getMessage() + "]");
         }
     }
 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
@@ -27,11 +27,11 @@ public class OpenshiftRequirement implements Constraint<RequiresOpenshift> {
 
         final DefaultConfiguration config = new ExtensionRegistrar().loadExtension(extension);
 
-        KubernetesClient client = new DefaultKubernetesClient(new ClientConfigBuilder().configuration(config).build());
+        try (KubernetesClient client = new DefaultKubernetesClient(
+            new ClientConfigBuilder().configuration(config).build())) {
 
-        OkHttpClient httpClient = client.adapt(OkHttpClient.class);
+            OkHttpClient httpClient = client.adapt(OkHttpClient.class);
 
-        try {
             Request versionRequest = new Request.Builder()
                 .get()
                 .url(URLUtils.join(client.getMasterUrl().toString(), "version"))


### PR DESCRIPTION
#### Short description of what this resolves:

This is an initial try to fix #1255 with at least unit testing enabled.


#### Changes proposed in this pull request:

- Changed the circleci build script to support the current builds. Also in hope to be a little more future proof if integration tests are added
- Most important fix for the builds is the addition of ``setup_remote_docker`` to allow some docker specific tests
- Tried to get rid of some side effects based on environment variables in some unit tests by using ``@ClassRule EnvironmentVariables``
- Commented out some ``@ExtendWith`` annotations in the prepared Junit5 tests since the extension had problems and the tests did not contain actual tests
- Added some missing ``@Category``s to tests
- Fixed a problem with the ``OpenshiftRequirement`` and ``KubernetesRequirement`` where an unconfigured url raised an unhandled ``IllegalArgumentException``

This PR should at least let the normal unit tests for JDK8 and Docker run again. I could not get the code run on JDK11 since there were multiple other problems. And the integration tests do also not run since the setup was to complex for me without knowledge of Openshift or Kubernetes.

I hope this PR helps a bit and look forward to some feedback.