### PR TITLE
[Issue:1272] Add github action workflow yml to build

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,60 @@
+name: Arquillian-Cube Maven Build
+
+on:
+  push:
+    branches:
+      - '**'
+  pull_request:
+    branches:
+      - '**'
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        os: [ubuntu-latest]
+        java: ['8','11']
+
+    steps:
+      - name: Setup Minikube
+        uses: manusa/actions-setup-minikube@v2.9.0
+        with:
+          driver: docker
+          container runtime: containerd
+          minikube version: 'v1.30.1'
+          kubernetes version: 'v1.27.1'
+          github token: ${{ secrets.GITHUB_TOKEN }}
+          start args: "--memory='4gb' --cpus='2'"
+      - name: Enable minikube registry
+        run: |
+          minikube addons enable registry
+          kubectl port-forward --namespace kube-system service/registry 5000:80 &
+      - name: Checkout arquillian-cube
+        uses: actions/checkout@v4
+      - uses: actions/cache@v3
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      - name: Set up JDK ${{ matrix.java }}
+        uses: actions/setup-java@v3
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'adopt'
+      - name: Build with Maven Java ${{ matrix.java }}
+        run: |
+          mvn -fae clean install
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: surefire-reports-${{ matrix.os }}-${{ matrix.java }}
+          path: '${{ github.workspace }}/**/surefire-reports/*.*'
+      - uses: actions/upload-artifact@v3
+        if: failure()
+        with:
+          name: server-logs-${{ matrix.os }}-${{ matrix.java }}
+          path: '${{ github.workspace }}/**/*.log'

--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -3,10 +3,17 @@ name: Arquillian-Cube Maven Build
 on:
   push:
     branches:
-      - '**'
+      - main
   pull_request:
     branches:
-      - '**'
+      - main
+    paths-ignore:
+      - 'doc/**'
+      - '.circleci/**'
+      - '.travis/**'
+env:
+  # failsafe.groups configuration depends on the env setup.
+  FAILSAFE_GROUPS: ''
 
 jobs:
   build:
@@ -16,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest]
-        java: ['8','11']
+        java: ['11']
 
     steps:
       - name: Setup Minikube
@@ -28,6 +35,8 @@ jobs:
           kubernetes version: 'v1.27.1'
           github token: ${{ secrets.GITHUB_TOKEN }}
           start args: "--memory='4gb' --cpus='2'"
+        env:
+          FAILSAFE_GROUPS: "-Dfailsafe.groups=org.arquillian.cube.docker.impl.requirement.RequiresDocker"
       - name: Enable minikube registry
         run: |
           minikube addons enable registry
@@ -45,9 +54,12 @@ jobs:
         with:
           java-version: ${{ matrix.java }}
           distribution: 'adopt'
+      - name: Maven pre-fetch dependencies ${{ matrix.java }}
+        run: |
+          ./mvnw verify -q -U -DskipTests # pre-fetch dependencies
       - name: Build with Maven Java ${{ matrix.java }}
         run: |
-          mvn -fae clean install
+          ./mvnw -fae clean package ${{ env.FAILSAFE_GROUPS }}
       - uses: actions/upload-artifact@v3
         if: failure()
         with:
@@ -58,3 +70,6 @@ jobs:
         with:
           name: server-logs-${{ matrix.os }}-${{ matrix.java }}
           path: '${{ github.workspace }}/**/*.log'
+      - name: Stop minikube
+        run: |
+          minikube stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_install:
   - BRANCH=${TRAVIS_PULL_REQUEST_BRANCH:-$TRAVIS_BRANCH}
   - '[ $(git log --format=%B  $TRAVIS_COMMIT_RANGE | grep -i "#doc" | wc -l) -gt 0 ] && FORCE_DOC_GEN=0 || FORCE_DOC_GEN=1'
   - MODIFIED_DOCS=$(git diff --name-only $TRAVIS_COMMIT_RANGE | grep -E 'README.adoc|^docs/.*.adoc$' | wc -l)
-  - '[ $BRANCH == "master" ] && [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
+  - '[ $BRANCH == "main" ] && [ $MODIFIED_DOCS -ge 1 ] && GENERATE_DOC=0 || GENERATE_DOC=1'
   - 'if [ $FORCE_DOC_GEN == 0 ] || [ $GENERATE_DOC == 0 ]; then
       git config user.name "${GH_USER}";
       git config user.email "${GH_EMAIL}";

--- a/README.adoc
+++ b/README.adoc
@@ -1,5 +1,5 @@
 = Arquillian Cube
-:asciidoctor-source: https://raw.githubusercontent.com/arquillian/arquillian-cube/master/docs
+:asciidoctor-source: https://raw.githubusercontent.com/arquillian/arquillian-cube/main/docs
 :numbered:
 :sectlink:
 :sectanchors:
@@ -10,7 +10,7 @@
 :icons: font
 :toc: left
 
-image:https://travis-ci.org/arquillian/arquillian-cube.svg?branch=master["Build Status", link="https://travis-ci.org/arquillian/arquillian-cube"]
+image:https://travis-ci.org/arquillian/arquillian-cube.svg?branch=main["Build Status", link="https://travis-ci.org/arquillian/arquillian-cube"]
 
 WARNING: 1.0.0.Alpha7 breaks incompatibility with previous versions in some cases. The major difference is that instead of using the _boot2docker_ keyword to refer to the auto resolved boot2docker ip in the _serverUri_ parameter, you should now used _dockerHost_.
 

--- a/docs/compose.adoc
+++ b/docs/compose.adoc
@@ -91,4 +91,4 @@ For example in case of using Maven, your `pom.xml` should look like:
 Notice that you don't need to specify _definitionFormat_ since docker compose format is the default one.
 
 And that's all, you can now reuse your existing docker-compose files in Arquillian Cube too.
-You can see the full example at: https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-docker-compose
+You can see the full example at: https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-docker-compose

--- a/docs/drone.adoc
+++ b/docs/drone.adoc
@@ -128,9 +128,9 @@ And finally among `cube` dependencies, add the `drone`, `selenium` and `cube-dro
 </dependencies>
 ----
 
-Full source code can be found at: https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-drone
+Full source code can be found at: https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-drone
 
-Full source code of usign custom image can be found at: https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-drone-custom
+Full source code of usign custom image can be found at: https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-drone-custom
 
 === Graphene
 
@@ -229,6 +229,6 @@ Apart from adding `arquillian`, `arquillian-drone`, `selenium-bom` and `arquilli
 </dependency>
 ----
 
-You can see the same example we used in Drone but using Graphene at https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-graphene
+You can see the same example we used in Drone but using Graphene at https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-graphene
 
 Also you can learn about Graphene at http://arquillian.org/guides/functional_testing_using_graphene/

--- a/docs/fabric8.adoc
+++ b/docs/fabric8.adoc
@@ -50,4 +50,4 @@ You can use following configuration options with kubernetes and openshift extens
 - If you have multiple profiles defined in your pom.xml, you can enable profile in which you have
 fabric8-maven-plugin dependency by using `cube.fmp.profiles` in arquillian.xml.
 
-You can see the example using `fabric8-maven-plugin` at: https://github.com/arquillian/arquillian-cube/tree/master/openshift/ftest-openshift-fabric8-maven-plugin
+You can see the example using `fabric8-maven-plugin` at: https://github.com/arquillian/arquillian-cube/tree/main/openshift/ftest-openshift-fabric8-maven-plugin

--- a/docs/reports.adoc
+++ b/docs/reports.adoc
@@ -80,10 +80,10 @@ For this reason you have to add following dependency:
 
 === Examples
 
-Arquillian Cube Docker Reports: https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-reporter
+Arquillian Cube Docker Reports: https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-reporter
 
-Arquillian Cube Docker Drone Reports: https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-drone-reporter
+Arquillian Cube Docker Drone Reports: https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-drone-reporter
 
-Arquillian Cube Kubernetes Reports: https://github.com/arquillian/arquillian-cube/tree/master/kubernetes/ftest-kubernetes-reporter
+Arquillian Cube Kubernetes Reports: https://github.com/arquillian/arquillian-cube/tree/main/kubernetes/ftest-kubernetes-reporter
 
 Arquillian Reporter for more information: https://github.com/arquillian/arquillian-reporter

--- a/docs/restassured.adoc
+++ b/docs/restassured.adoc
@@ -168,4 +168,4 @@ public class PingPongTest {
 
 Notice that no _ip_ nor _port_ configuration are required since everything is managed and configured by Cube.
 
-You can see full example at: https://github.com/arquillian/arquillian-cube/tree/master/docker/ftest-restassured
+You can see full example at: https://github.com/arquillian/arquillian-cube/tree/main/docker/ftest-restassured


### PR DESCRIPTION
Fixes #1272

I would like to propose the following changes in this PR:

* based on Jim's initial github action setup from #1274
* Replace docker image of `jonmorehouse/ping-pong` to `hashicorp/http-echo`, because the former one is missing from docker hub, it will fail the test in a clean env.
* Specify `sun.net.spi.nameservice.provider` configure in the `maven surefile plugin` configuration instead of set it in the test code, because it would be too late if other tests have load the InetAddress already
* Fixes test in `fabric8-maven-plugin-build` to check if the namespece is set correctly, that depends on the current environment setup.
* Disable jdk 11 in the github action for the moment, it should be enabled again after issue #1270 got fixed
* Disable minikube env in the github action for the moment, as there are test failures, not sure if the upgrade of fabric8 kubernetes client can solve it. We need to address those tests when the test failures got fixed in minikube environment.
