### PR TITLE
Fix maven build stability warning by removing duplicated dependency o…

### DIFF
--- a/openshift/ftest-istio-openshift/pom.xml
+++ b/openshift/ftest-istio-openshift/pom.xml
@@ -47,16 +47,10 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.rest-assured</groupId>
-      <artifactId>rest-assured</artifactId>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>org.arquillian.cube</groupId>
       <artifactId>arquillian-cube-istio-kubernetes-api</artifactId>
       <version>2.0.0-SNAPSHOT</version>
       <scope>test</scope>
-
     </dependency>
   </dependencies>
 


### PR DESCRIPTION
…n io.rest-assured
