### PR TITLE
Bump commons-compress to 1.21, to fix security issues, and related commons-* dependencies to align with docker-java:3.4.0

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -107,17 +107,17 @@
     <dependency>
       <groupId>commons-io</groupId>
       <artifactId>commons-io</artifactId>
-      <version>2.14.0</version>
+      <version>2.13.0</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.27.1</version>
+      <version>1.21</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
-      <version>3.9</version>
+      <version>3.12.0</version>
     </dependency>
     <dependency>
       <groupId>org.arquillian.cube</groupId>

--- a/core/pom.xml
+++ b/core/pom.xml
@@ -112,7 +112,7 @@
     <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-compress</artifactId>
-      <version>1.19</version>
+      <version>1.27.1</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
Duplicates #1325 but using 1.27.1, since the one proposed by dependantbot is throwing a NoClassFound exception. 

#### Short description of what this resolves:
See #1325 

#### Changes proposed in this pull request:

- commons-compress from 1.19 to 1.27.1

Fixes https://github.com/arquillian/arquillian-cube/security/dependabot?q=package%3Aorg.apache.commons%3Acommons-compress+manifest%3Acore%2Fpom.xml+has%3Apatch
