### PR TITLE
Fix SessionManager in order to use a supported way to determine whether the the client is a k8s or OpenShift one

### DIFF
--- a/kubernetes/istio/istio/src/main/java/org/arquillian/cube/istio/impl/IstioClientAdapter.java
+++ b/kubernetes/istio/istio/src/main/java/org/arquillian/cube/istio/impl/IstioClientAdapter.java
@@ -59,6 +59,7 @@ public class IstioClientAdapter implements IstioClient {
         return unwrap().v1alpha3();
     }
 
+    @Deprecated
     @Override
     public <C extends Client> Boolean isAdaptable(Class<C> type) {
         return unwrap().isAdaptable(type);

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -25,7 +25,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
 
 import io.fabric8.kubernetes.client.KubernetesClientTimeoutException;
-import io.fabric8.openshift.client.OpenShiftClient;
+import io.fabric8.openshift.api.model.Project;
 import org.arquillian.cube.kubernetes.api.AnnotationProvider;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.DependencyResolver;
@@ -211,7 +211,7 @@ public class SessionManager implements SessionCreatedListener {
                 .pluginConfigurationIn(Paths.get("", configuration.getFmpPomPath()))
                 .profiles(configuration.getFmpProfiles())
                 .withProperties(configuration.getFmpSystemProperties())
-                .forOpenshift(client.isAdaptable(OpenShiftClient.class))
+                .forOpenshift(client.supports(Project.class))
                 .build();
         }
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/namespace/DefaultNamespaceService.java
@@ -9,6 +9,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Scanner;
 
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.api.LabelProvider;
@@ -169,7 +170,7 @@ public class DefaultNamespaceService implements NamespaceService {
             client.pods().inNamespace(namespace).delete();
             client.extensions().ingresses().inNamespace(namespace).delete();
             client.services().inNamespace(namespace).delete();
-            if (client.isAdaptable(OpenShiftClient.class)) {
+            if (client.supports(Project.class)) {
                 client.adapt(OpenShiftClient.class)
                       .securityContextConstraints().withName(namespace).delete();
             }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClientCreator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/OpenShiftClientCreator.java
@@ -2,6 +2,7 @@ package org.arquillian.cube.openshift.impl.client;
 
 import io.fabric8.kubernetes.client.Config;
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.Project;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.impl.event.AfterStart;
 import org.jboss.arquillian.core.api.Instance;
@@ -29,7 +30,7 @@ public class OpenShiftClientCreator {
         final CubeOpenShiftConfiguration configuration = (CubeOpenShiftConfiguration) conf;
 
         final KubernetesClient kubernetesClient = kubernetesClientInstance.get();
-        if (kubernetesClient != null && kubernetesClient.isAdaptable(io.fabric8.openshift.client.OpenShiftClient.class)) {
+        if (kubernetesClient != null && kubernetesClient.supports(Project.class)) {
             io.fabric8.openshift.client.OpenShiftClient client = kubernetesClient.adapt(io.fabric8.openshift.client.OpenShiftClient.class);
             openShiftClientProducer.set(
                 createClient(client, client.getConfiguration(), client.getNamespace(), configuration.shouldKeepAliveGitServer()));

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/OpenshiftClientResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/external/OpenshiftClientResourceProvider.java
@@ -1,5 +1,6 @@
 package org.arquillian.cube.openshift.impl.enricher.external;
 
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.DefaultOpenShiftClient;
 import java.util.logging.Logger;
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
@@ -32,7 +33,7 @@ public class OpenshiftClientResourceProvider extends AbstractKubernetesResourceP
 
         if (client == null) {
             throw new IllegalStateException("Unable to inject Kubernetes client into test.");
-        } else if (!client.isAdaptable(OpenShiftClient.class)) {
+        } else if (!client.supports(Project.class)) {
             throw new IllegalStateException("Could not adapt to OpenShiftClient.");
         }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/internal/OpenshiftClientResourceProvider.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/enricher/internal/OpenshiftClientResourceProvider.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.openshift.impl.enricher.internal;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.lang.annotation.Annotation;
 import org.arquillian.cube.kubernetes.impl.enricher.AbstractKubernetesResourceProvider;
@@ -23,7 +24,7 @@ public class OpenshiftClientResourceProvider extends AbstractKubernetesResourceP
 
         if (client == null) {
             throw new IllegalStateException("Unable to inject Kubernetes client into test.");
-        } else if (!client.isAdaptable(OpenShiftClient.class)) {
+        } else if (!client.supports(Project.class)) {
             throw new IllegalStateException("Could not adapt to OpenShiftClient.");
         }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/install/OpenshiftResourceInstaller.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/install/OpenshiftResourceInstaller.java
@@ -5,6 +5,7 @@ import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesList;
 import io.fabric8.kubernetes.client.KubernetesClient;
 import io.fabric8.kubernetes.client.KubernetesClientException;
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.impl.util.Strings;
 import org.arquillian.cube.impl.util.SystemEnvironmentVariables;
@@ -47,7 +48,7 @@ public class OpenshiftResourceInstaller extends DefaultResourceInstaller {
         @Override
         public List<HasMetadata> install(URL url) {
             CompositeVisitor compositeVisitor = new CompositeVisitor(visitors);
-            if (!client.isAdaptable(OpenShiftClient.class)) {
+            if (!client.supports(Project.class)) {
                 return super.install(url);
             }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/locator/OpenshiftKubernetesResourceLocator.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.openshift.impl.locator;
 
 import io.fabric8.kubernetes.client.KubernetesClient;
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.api.Configuration;
 import org.arquillian.cube.kubernetes.impl.locator.DefaultKubernetesResourceLocator;
@@ -29,7 +30,7 @@ public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourc
 
     @Override
     protected String[] getResourceNames() {
-        if (!client.get().isAdaptable(OpenShiftClient.class)) {
+        if (!client.get().supports(Project.class)) {
             return super.getResourceNames();
         }
         return RESOURCE_NAMES;
@@ -37,7 +38,7 @@ public class OpenshiftKubernetesResourceLocator extends DefaultKubernetesResourc
 
     @Override
     public Collection<URL> locateAdditionalResources() {
-        if (!client.get().isAdaptable(OpenShiftClient.class)) {
+        if (!client.get().supports(Project.class)) {
             return super.locateAdditionalResources();
         }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/namespace/OpenshiftNamespaceService.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/namespace/OpenshiftNamespaceService.java
@@ -46,7 +46,7 @@ public class OpenshiftNamespaceService extends DefaultNamespaceService {
 
         @Override
         public Namespace create(String namespace, Map<String, String> annotations) {
-            if (client.isAdaptable(OpenShiftClient.class)) {
+            if (client.supports(Project.class)) {
                 OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
                 logger.status("Creating project: " + namespace);
                 ProjectRequest projectRequest = new ProjectRequestBuilder()
@@ -75,7 +75,7 @@ public class OpenshiftNamespaceService extends DefaultNamespaceService {
 
         @Override
         public Boolean delete(String namespace) {
-            if (client.isAdaptable(OpenShiftClient.class)) {
+            if (client.supports(Project.class)) {
 
                 logger.info("Deleting project: " + namespace + "...");
                 OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
@@ -92,7 +92,7 @@ public class OpenshiftNamespaceService extends DefaultNamespaceService {
 
         @Override
         public Boolean exists(String namespace) {
-            if (client.isAdaptable(OpenShiftClient.class)) {
+            if (client.supports(Project.class)) {
                 OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
                 try {
                     // It is preferable to iterate on the list of projects as regular user
@@ -117,7 +117,7 @@ public class OpenshiftNamespaceService extends DefaultNamespaceService {
 
         @Override
         public Namespace annotate(String namespace, Map<String, String> annotations) {
-            if (client.isAdaptable(OpenShiftClient.class)) {
+            if (client.supports(Project.class)) {
                 OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
 
                 /* FIXME: Openshift currently doesn't support annotations
@@ -143,7 +143,7 @@ public class OpenshiftNamespaceService extends DefaultNamespaceService {
         @Override
         @Deprecated // The method is redundant (since its called always before destroy).
         public void clean(String namespace) {
-            if (client.isAdaptable(OpenShiftClient.class)) {
+            if (client.supports(Project.class)) {
                 OpenShiftClient openShiftClient = client.adapt(OpenShiftClient.class);
                 openShiftClient.deploymentConfigs().inNamespace(namespace).delete();
             }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/Openshift4Requirement.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/Openshift4Requirement.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory;
 import io.fabric8.kubernetes.client.utils.URLUtils;
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.impl.ClientConfigBuilder;
 import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
@@ -48,7 +49,7 @@ public class Openshift4Requirement implements Constraint<RequiresOpenshift4> {
             if (!response.isSuccessful()) {
                 throw new UnsatisfiedRequirementException(
                     "Failed to verify Openshift version, due to: [" + response.message() + "]");
-            } else if (!client.isAdaptable(OpenShiftClient.class)) {
+            } else if (!client.supports(Project.class)) {
                 throw new UnsatisfiedRequirementException(
                     "A valid Kubernetes environment was found, but not Openshift.");
             }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftOlmRequirement.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftOlmRequirement.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory;
 import io.fabric8.kubernetes.client.utils.URLUtils;
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import org.arquillian.cube.kubernetes.impl.ClientConfigBuilder;
 import org.arquillian.cube.kubernetes.impl.DefaultConfiguration;
@@ -49,7 +50,7 @@ public class OpenshiftOlmRequirement implements Constraint<RequiresOlm> {
                 throw new UnsatisfiedRequirementException(
                     "Failed to verify Openshift version, due to: [" + response.message() + "]");
             } else {
-                if (!client.isAdaptable(OpenShiftClient.class)) {
+                if (!client.supports(Project.class)) {
                     throw new UnsatisfiedRequirementException(
                         "A valid Kubernetes environment was found, but not Openshift.");
                 }

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/requirement/OpenshiftRequirement.java
@@ -8,6 +8,7 @@ import io.fabric8.kubernetes.client.http.HttpRequest;
 import io.fabric8.kubernetes.client.http.HttpResponse;
 import io.fabric8.kubernetes.client.jdkhttp.JdkHttpClientFactory;
 import io.fabric8.kubernetes.client.utils.URLUtils;
+import io.fabric8.openshift.api.model.Project;
 import io.fabric8.openshift.client.OpenShiftClient;
 import java.io.IOException;
 import java.net.URL;
@@ -47,7 +48,7 @@ public class OpenshiftRequirement implements Constraint<RequiresOpenshift> {
             if (!response.isSuccessful()) {
                 throw new UnsatisfiedRequirementException(
                     "Failed to verify Openshift version, due to: [" + response.message() + "]");
-            } else if (!client.isAdaptable(OpenShiftClient.class)) {
+            } else if (!client.supports(Project.class)) {
                 throw new UnsatisfiedRequirementException(
                     "A valid Kubernetes environmnet was found, but not Openshift.");
             }


### PR DESCRIPTION
#### Short description of what this resolves:
SessionManager is using a deprecated call to `isAdaptable`. This can lead to some classpath issues with Fabtric8 Kubernetes Client adapters, so this PR is proposing to replace the call with the non deprecated `supports()` method

#### Changes proposed in this pull request:

- SessionManager::start 


Resolves #1360 
