### PR TITLE
Bump Fabric8 Kubernetes Client version to 7.1.0

### DIFF
--- a/kubernetes/istio/istio/src/main/java/org/arquillian/cube/istio/impl/IstioClientAdapter.java
+++ b/kubernetes/istio/istio/src/main/java/org/arquillian/cube/istio/impl/IstioClientAdapter.java
@@ -6,6 +6,7 @@ import io.fabric8.istio.client.V1beta1APIGroupDSL;
 import io.fabric8.kubernetes.api.model.APIGroup;
 import io.fabric8.kubernetes.api.model.APIGroupList;
 import io.fabric8.kubernetes.api.model.APIResourceList;
+import io.fabric8.kubernetes.api.model.APIVersions;
 import io.fabric8.kubernetes.api.model.HasMetadata;
 import io.fabric8.kubernetes.api.model.KubernetesResource;
 import io.fabric8.kubernetes.api.model.KubernetesResourceList;
@@ -59,12 +60,6 @@ public class IstioClientAdapter implements IstioClient {
         return unwrap().v1alpha3();
     }
 
-    @Deprecated
-    @Override
-    public <C extends Client> Boolean isAdaptable(Class<C> type) {
-        return unwrap().isAdaptable(type);
-    }
-
     @Override
     public <R extends KubernetesResource> boolean supports(Class<R> type) {
         return unwrap().supports(type);
@@ -113,6 +108,11 @@ public class IstioClientAdapter implements IstioClient {
     @Override
     public void close() {
         unwrap().close();
+    }
+
+    @Override
+    public APIVersions getAPIVersions() {
+        return unwrap().getAPIVersions();
     }
 
     @Override

--- a/kubernetes/istio/istio/src/main/java/org/arquillian/cube/istio/impl/IstioResourceList.java
+++ b/kubernetes/istio/istio/src/main/java/org/arquillian/cube/istio/impl/IstioResourceList.java
@@ -1,9 +1,6 @@
 package org.arquillian.cube.istio.impl;
 
-import io.fabric8.istio.api.meta.v1alpha1.IstioStatus;
 import io.fabric8.kubernetes.api.model.DefaultKubernetesResourceList;
-import io.fabric8.kubernetes.api.model.KubernetesResourceList;
-import io.fabric8.kubernetes.client.CustomResource;
 
 public class IstioResourceList extends DefaultKubernetesResourceList<IstioResource> {
 }

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/portforward/PortForwarder.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/portforward/PortForwarder.java
@@ -1,6 +1,7 @@
 package org.arquillian.cube.kubernetes.impl.portforward;
 
 import io.fabric8.kubernetes.client.Config;
+import io.fabric8.kubernetes.client.ConfigBuilder;
 import io.fabric8.kubernetes.client.internal.SSLUtils;
 import io.undertow.UndertowOptions;
 import io.undertow.client.ClientCallback;
@@ -180,7 +181,7 @@ public final class PortForwarder implements Closeable {
             }
         }
 
-        final Config config = new Config();
+        final Config config = new ConfigBuilder().build();
         config.setNamespace(namespace);
         final PortForwarder forwarder = new PortForwarder(config, podName);
         forwarder.setPortForwardBindAddress(bindAddress);

--- a/kubernetes/reporter/pom.xml
+++ b/kubernetes/reporter/pom.xml
@@ -34,6 +34,12 @@
       <groupId>org.jboss.arquillian.core</groupId>
       <artifactId>arquillian-core-api</artifactId>
     </dependency>
+
+    <dependency>
+      <groupId>io.fabric8</groupId>
+      <artifactId>kubernetes-client</artifactId>
+      <scope>test</scope>
+    </dependency>
     <dependency>
       <groupId>org.arquillian.reporter</groupId>
       <artifactId>arquillian-reporter-impl</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -74,13 +74,13 @@
     <version.junit>4.13.2</version.junit>
     <version.hamcrest>2.2</version.hamcrest>
     <version.docker-java>3.4.0</version.docker-java>
-    <version.kubernetes_client>6.9.2</version.kubernetes_client>
+    <version.kubernetes_client>7.1.0</version.kubernetes_client>
     <version.snakeyaml>2.4</version.snakeyaml>
     <version.shrinkwrap_resolver>3.3.4</version.shrinkwrap_resolver>
     <version.shrinkwrap>1.2.6</version.shrinkwrap>
     <version.shrinkwrap_descriptors>2.0.0</version.shrinkwrap_descriptors>
     <version.mockito>5.7.0</version.mockito>
-    <version.fabric8_mockwebserver>6.9.2</version.fabric8_mockwebserver>
+    <version.fabric8_mockwebserver>7.1.0</version.fabric8_mockwebserver>
     <version.descriptor.docker>1.0.0-alpha-2</version.descriptor.docker>
     <version.undertow>1.3.33.Final</version.undertow>
     <version.arquillian_spacelift>1.0.2</version.arquillian_spacelift>


### PR DESCRIPTION
SSIA

#### Short description of what this resolves:

Here we're bumping the Fabric8 Kubernetes client to the latest GA version.

#### Changes proposed in this pull request:

- Upgrade Fabric8 Kubernetes client to 7.1.0


Fixes #1368
