### PR TITLE
[issue-1378] - Skip maven-deploy-plugin execution for the new k8s and OpenShift tests

### DIFF
--- a/kubernetes/ftest-kubernetes-wildfly-bootable-jar/pom.xml
+++ b/kubernetes/ftest-kubernetes-wildfly-bootable-jar/pom.xml
@@ -166,6 +166,14 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/openshift/ftest-openshift-wildfly-bootable-jar/pom.xml
+++ b/openshift/ftest-openshift-wildfly-bootable-jar/pom.xml
@@ -173,6 +173,14 @@
           <skip>true</skip>
         </configuration>
       </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
#### Short description of what this resolves:

SSIA

#### Changes proposed in this pull request:

- kubernetes/ftest-kubernetes-wildfly-bootable-jar/pom.xml
- openshift/ftest-openshift-wildfly-bootable-jar/pom.xml

add `maven-deploy-plugin` config with `skip=true`

Fixes #1378 
