### PR TITLE
Adding a property to configure JKubeMavenPluginResourceGeneratorBuilder for using local maven

### DIFF
--- a/docs/fabric8.adoc
+++ b/docs/fabric8.adoc
@@ -35,6 +35,7 @@ link:https://eclipse.dev/jkube/docs/openshift-maven-plugin/[JKube OpenShift Mave
 | cube.fmp.logs  | Bool (true) | Any | Whether to show logs for generating resources using JKube Kubernetes or OpenShift maven plugin
 | cube.fmp.profiles  | List | Any | Comma-separated list of profiles which you want to activate while generating resources
 | cube.fmp.system.properties  | List | Any | Comma-separated key value pair to use for maven build
+| cube.fmp.local.maven  | Bool (false) | Any | Whether to use the local Maven installation, in which case the `maven.home` system property must be set
 |===
 
 *IMPORTANT*

--- a/jkube-maven-plugin-build/src/main/java/org/eclipse/jkube/maven/plugin/build/JKubeMavenPluginResourceGeneratorBuilder.java
+++ b/jkube-maven-plugin-build/src/main/java/org/eclipse/jkube/maven/plugin/build/JKubeMavenPluginResourceGeneratorBuilder.java
@@ -8,7 +8,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.logging.Logger;
 
-import com.google.common.base.Strings;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.BuiltProject;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.EmbeddedMaven;
 import org.jboss.shrinkwrap.resolver.api.maven.embedded.pom.equipped.ConfigurationDistributionStage;

--- a/jkube-maven-plugin-build/src/test/java/org/fabric8/maven/plugin/build/KubernetesResourceGeneratorBuilderIT.java
+++ b/jkube-maven-plugin-build/src/test/java/org/fabric8/maven/plugin/build/KubernetesResourceGeneratorBuilderIT.java
@@ -42,7 +42,16 @@ public class KubernetesResourceGeneratorBuilderIT {
     }
 
     @Test
-    public void should_build_images_and_generate_resources() throws IOException {
+    public void should_build_images_and_generate_resources_with_embedded_maven() throws IOException {
+        should_build_images_and_generate_resources(false);
+    }
+
+    @Test
+    public void should_build_images_and_generate_resources_with_local_maven() throws IOException {
+        should_build_images_and_generate_resources(true);
+    }
+
+    private void should_build_images_and_generate_resources(boolean useLocalMaven) throws IOException {
         // given
         final String rootPath = temporaryFolder.getRoot().toString() + "spring-boot";
         copyDirectory(Paths.get("src/test/resources/spring-boot"), Paths.get(rootPath));
@@ -56,6 +65,7 @@ public class KubernetesResourceGeneratorBuilderIT {
             .withProperties("version.cube", System.getProperty("version.cube", "2.0.0-SNAPSHOT"),
                 "jkube.docker.push.registry",System.getProperty("jkube.docker.push.registry", ""))
             .pluginConfigurationIn(Paths.get(rootPath, "pom.xml"))
+            .withMaven(useLocalMaven)
             .debug(false)
             .build();
 

--- a/jkube-maven-plugin-build/src/test/java/org/fabric8/maven/plugin/build/OpenShiftResourceGeneratorBuilderIT.java
+++ b/jkube-maven-plugin-build/src/test/java/org/fabric8/maven/plugin/build/OpenShiftResourceGeneratorBuilderIT.java
@@ -41,7 +41,16 @@ public class OpenShiftResourceGeneratorBuilderIT {
     }
 
     @Test
-    public void should_build_images_and_generate_resources() throws IOException {
+    public void should_build_images_and_generate_resources_with_embedded_maven() throws IOException {
+        should_build_images_and_generate_resources(false);
+    }
+
+    @Test
+    public void should_build_images_and_generate_resources_with_local_maven() throws IOException {
+        should_build_images_and_generate_resources(true);
+    }
+
+    private void should_build_images_and_generate_resources(boolean useLocalMaven) throws IOException {
         // given
         final String rootPath = temporaryFolder.getRoot().toString() + "spring-boot";
         copyDirectory(Paths.get("src/test/resources/spring-boot"), Paths.get(rootPath));
@@ -55,6 +64,7 @@ public class OpenShiftResourceGeneratorBuilderIT {
             .withProperties("version.cube", System.getProperty("version.cube", "2.0.0-SNAPSHOT"))
             .pluginConfigurationIn(Paths.get(rootPath, "pom.xml"))
             .forOpenshift(true)
+            .withMaven(useLocalMaven)
             .build();
 
         // then

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/api/Configuration.java
@@ -69,6 +69,7 @@ public interface Configuration {
     String FMP_PROFILES = "cube.fmp.profiles";
     String FMP_SYSTEM_PROPERTIES = "cube.fmp.system.properties";
     String FMP_BUILD_OPTIONS = "cube.fmp.build.options";
+    String FMP_LOCAL_MAVEN = "cube.fmp.local.maven";
 
     Long DEFAULT_WAIT_TIMEOUT = 8 * 60 * 1000L;
     Long DEFAULT_WAIT_POLL_INTERVAL = 5 * 1000L;
@@ -148,6 +149,8 @@ public interface Configuration {
     String getFmpPomPath();
 
     String getFmpBuildOptions();
+
+    boolean isFmpLocalMaven();
 
     List<String> getFmpProfiles();
 

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/DefaultConfiguration.java
@@ -80,19 +80,20 @@ public class DefaultConfiguration implements Configuration {
     private final List<String> fmpProfiles;
     private final List<String> fmpSystemProperties;
     private final String fmpBuildOptions;
+    private final boolean fmpLocalMaven;
 
     private String token;
 
-    public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables,  URL environmentSetupScriptUrl,
-        URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceUseCurrentEnabled,
-        boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
-        boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled,
-        boolean namespaceDestroyConfirmationEnabled, long namespaceDestroyTimeout, boolean waitEnabled, long waitTimeout,
-        long waitPollInterval, List<String> waitForServiceList, boolean ansiLoggerEnabled, boolean environmentInitEnabled, boolean logCopyEnabled,
-        String logPath, String kubernetesDomain, String dockerRegistry, String token, String username, String password,
-        String apiVersion, boolean trustCerts, boolean fmpBuildEnabled, boolean fmpBuildForMavenDisable,
-        boolean fmpDebugOutput, boolean fmpLogsEnabled, String fmpPomPath, List<String> fmpProfiles,
-        List<String> fmpSystemProperties, String fmpBuildOptions) {
+    public DefaultConfiguration(String sessionId, URL masterUrl, String namespace, Map<String, String> scriptEnvironmentVariables, URL environmentSetupScriptUrl,
+                                URL environmentTeardownScriptUrl, URL environmentConfigUrl, List<URL> environmentDependencies, boolean namespaceUseCurrentEnabled,
+                                boolean namespaceLazyCreateEnabled, boolean namespaceCleanupEnabled, long namespaceCleanupTimeout,
+                                boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled,
+                                boolean namespaceDestroyConfirmationEnabled, long namespaceDestroyTimeout, boolean waitEnabled, long waitTimeout,
+                                long waitPollInterval, List<String> waitForServiceList, boolean ansiLoggerEnabled, boolean environmentInitEnabled, boolean logCopyEnabled,
+                                String logPath, String kubernetesDomain, String dockerRegistry, String token, String username, String password,
+                                String apiVersion, boolean trustCerts, boolean fmpBuildEnabled, boolean fmpBuildForMavenDisable,
+                                boolean fmpDebugOutput, boolean fmpLogsEnabled, String fmpPomPath, List<String> fmpProfiles,
+                                List<String> fmpSystemProperties, String fmpBuildOptions, boolean fmpLocalMaven) {
         this.masterUrl = masterUrl;
         this.scriptEnvironmentVariables = scriptEnvironmentVariables;
         this.environmentSetupScriptUrl = environmentSetupScriptUrl;
@@ -132,6 +133,7 @@ public class DefaultConfiguration implements Configuration {
         this.fmpProfiles = fmpProfiles;
         this.fmpSystemProperties = fmpSystemProperties;
         this.fmpBuildOptions = fmpBuildOptions;
+        this.fmpLocalMaven = fmpLocalMaven;
     }
 
     public static DefaultConfiguration fromMap(Map<String, String> map) {
@@ -200,6 +202,7 @@ public class DefaultConfiguration implements Configuration {
                 .withFmpProfiles(Strings.splitAndTrimAsList(getStringProperty(FMP_PROFILES, map, ""), "\\s*,\\s*"))
                 .withFmpSystemProperties(Strings.splitAndTrimAsList(getStringProperty(FMP_SYSTEM_PROPERTIES, map, ""), "\\s*,\\s*"))
                 .withFmpBuildOptions(getStringProperty(FMP_BUILD_OPTIONS, map, null))
+                .withFmpLocalMaven(getBooleanProperty(FMP_LOCAL_MAVEN, map, false))
                 .build();
         } catch (Throwable t) {
             if (t instanceof RuntimeException) {
@@ -508,6 +511,11 @@ public class DefaultConfiguration implements Configuration {
     @Override
     public String getFmpBuildOptions() {
         return fmpBuildOptions;
+    }
+
+    @Override
+    public boolean isFmpLocalMaven() {
+        return fmpLocalMaven;
     }
 
     @Override

--- a/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
+++ b/kubernetes/kubernetes/src/main/java/org/arquillian/cube/kubernetes/impl/SessionManager.java
@@ -212,6 +212,7 @@ public class SessionManager implements SessionCreatedListener {
                 .profiles(configuration.getFmpProfiles())
                 .withProperties(configuration.getFmpSystemProperties())
                 .forOpenshift(client.supports(Project.class))
+                .withMaven(configuration.isFmpLocalMaven())
                 .build();
         }
 

--- a/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
+++ b/openshift/openshift/src/main/java/org/arquillian/cube/openshift/impl/client/CubeOpenShiftConfiguration.java
@@ -83,7 +83,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
                                       boolean namespaceCleanupConfirmationEnabled, boolean namespaceDestroyEnabled, long namespaceDestroyTimeout,
                                       boolean namespaceDestroyConfirmationEnabled, boolean waitEnabled, long waitTimeout, long waitPollInterval,
                                       List<String> waitForServiceList, boolean ansiLoggerEnabled, boolean environmentInitEnabled, boolean logCopyEnabled,
-                                      boolean fmpBuildEnabled, boolean fmpBuildForMavenDisable, boolean fmpDebugOutput, boolean fmpLogsEnabled, String fmpPomPath, List<String> fmpProfiles, List<String> fmpSystemProperties, String fmpBuildOptions,
+                                      boolean fmpBuildEnabled, boolean fmpBuildForMavenDisable, boolean fmpDebugOutput, boolean fmpLogsEnabled, String fmpPomPath, List<String> fmpProfiles, List<String> fmpSystemProperties, String fmpBuildOptions, boolean fmpLocalMaven,
                                       String logPath, String kubernetesDomain, String dockerRegistry, boolean keepAliveGitServer, String definitions,
                                       String definitionsFile, String[] autoStartContainers, Set<String> proxiedContainerPorts,
                                       String portForwardBindAddress, String routerHost, int openshiftRouterHttpPort, int openshiftRouterHttpsPort, boolean enableImageStreamDetection,
@@ -94,7 +94,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
             environmentConfigUrl, environmentDependencies, namespaceUseCurrentEnabled, namespaceLazyCreateEnabled, namespaceCleanupEnabled,
             namespaceCleanupTimeout, namespaceCleanupConfirmationEnabled, namespaceDestroyEnabled,
             namespaceDestroyConfirmationEnabled, namespaceDestroyTimeout, waitEnabled, waitTimeout, waitPollInterval,
-            waitForServiceList, ansiLoggerEnabled, environmentInitEnabled, logCopyEnabled, logPath, kubernetesDomain, dockerRegistry, token, username, password, apiVersion, trustCerts, fmpBuildEnabled,  fmpBuildForMavenDisable, fmpDebugOutput, fmpLogsEnabled, fmpPomPath, fmpProfiles, fmpSystemProperties,  fmpBuildOptions);
+            waitForServiceList, ansiLoggerEnabled, environmentInitEnabled, logCopyEnabled, logPath, kubernetesDomain, dockerRegistry, token, username, password, apiVersion, trustCerts, fmpBuildEnabled,  fmpBuildForMavenDisable, fmpDebugOutput, fmpLogsEnabled, fmpPomPath, fmpProfiles, fmpSystemProperties,  fmpBuildOptions, fmpLocalMaven);
         this.keepAliveGitServer = keepAliveGitServer;
         this.definitions = definitions;
         this.definitionsFile = definitionsFile;
@@ -207,6 +207,7 @@ public class CubeOpenShiftConfiguration extends DefaultConfiguration implements
                 .withFmpProfiles(Strings.splitAndTrimAsList(getStringProperty(FMP_PROFILES, map, ""), "\\s*,\\s*"))
                 .withFmpSystemProperties(Strings.splitAndTrimAsList(getStringProperty(FMP_SYSTEM_PROPERTIES, map, ""), "\\s*,\\s*"))
                 .withFmpBuildOptions(getStringProperty(FMP_BUILD_OPTIONS, map, ""))
+                .withFmpLocalMaven(getBooleanProperty(FMP_LOCAL_MAVEN, map, false))
                 .withAwaitRouteRepetitions(getIntProperty(AWAIT_ROUTE_REPETITIONS, "arquillian.await.route.repetitions", map, 1))
                 .build();
         } catch (Throwable t) {


### PR DESCRIPTION
#### Short description of what this resolves:
We're adding a property to expose the `JKubeMavenPluginResourceGeneratorBuilder::useCustomMaven` property so that users can configure the execution to selectively use an embedded or local Maven instance.

#### Changes proposed in this pull request:

- Adding the `cube.fmp.local.maven` property and related getters/setters to the configuration classes
- Modifying `SessionManager.java` in order to use such property and configure `JKubeMavenPluginResourceGeneratorBuilder::useCustomMaven` programmatically
- Updating the `KubernetesResourceGeneratorBuilderIT.java` and `OpenShiftResourceGeneratorBuilderIT.java` tests to validate using/not using a local Maven cases
- Updating the `fabric8.adoc` documentation file


Fixes #1387
