### PR TITLE
[issue-1384] - Increase timeout for Drone instantiation in openshift/ftest-openshift-graphene

### DIFF
--- a/openshift/ftest-openshift-graphene/src/test/resources/arquillian.xml
+++ b/openshift/ftest-openshift-graphene/src/test/resources/arquillian.xml
@@ -10,6 +10,10 @@
     <property name="browser">phantomjs</property>
   </extension>
 
+  <extension qualifier="drone">
+    <property name="instantiationTimeoutInSeconds">120</property>
+  </extension>
+
   <extension qualifier="graphene">
     <property name="url">http://hello-world:8080</property>
   </extension>


### PR DESCRIPTION
#### Short description of what this resolves:

These changes add a `drone` extension to the arquillian.xml to define a configuration property to set the timeout for instantiating Drone to 120 seconds, thus overriding the dfault value (60 seconds).

This is needed since the test started failing recently because the time needed for downloading the PhantomJS binaries is longer than the default.

#### Changes proposed in this pull request:

- Adding a `drone` extension and related configuration to the arquillian.xml file in `openshift/ftest-openshift-graphene`, to overcome the limitation of 60 seconds when instantiating Drone.


Fixes #1384 
