### PR TITLE
[issue-1393] Adding Windows 11 to the OperatingSystem enumerations

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystem.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/util/OperatingSystem.java
@@ -20,6 +20,7 @@ public enum OperatingSystem implements OperatingSystemInterface {
     WINDOWS_7("Windows 7", WINDOWS),
     WINDOWS_8("Windows 8", WINDOWS),
     WINDOWS_10("Windows 10", WINDOWS),
+    WINDOWS_11("Windows 11", WINDOWS),
     WINDOWS_2003("Windows 2003", WINDOWS),
     WINDOWS_2008("Windows 2008", WINDOWS),
     SUN_OS("Sun OS ", UNIX),


### PR DESCRIPTION
#### Short description of what this resolves:

Builds not working on Windows 11 since the OperatingSystem enumeration is missing.

#### Changes proposed in this pull request:

- Just added Windows 11 as a new enumeration to OperatingSystem

Fixes #1393
