### PR TITLE
[issue-1395] Fixing problems with running docker drone using Windows 11

### DIFF
--- a/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
+++ b/docker/drone/src/main/java/org/arquillian/cube/docker/drone/SeleniumContainers.java
@@ -28,7 +28,7 @@ public class SeleniumContainers {
     private static final String CONVERSION_CONTAINER_BASE_NAME = "flv2mp4";
     private static final String CHROME_IMAGE = "selenium/standalone-chrome-debug:%s";
     private static final String FIREFOX_IMAGE = "selenium/standalone-firefox-debug:%s";
-    private static final String VNC_IMAGE = "richnorth/vnc-recorder:latest";
+    private static final String VNC_IMAGE = "testcontainers/vnc-recorder:latest";
     private static final String CONVERSION_IMAGE = "arquillian/flv2mp4:0.0.1";
     private static final String DEFAULT_PASSWORD = "secret";
     private static final String VNC_HOSTNAME = "vnchost";

--- a/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
+++ b/docker/drone/src/test/java/org/arquillian/cube/docker/drone/SeleniumContainersTest.java
@@ -199,6 +199,6 @@ public class SeleniumContainersTest {
         final SeleniumContainers seleniumContainers = SeleniumContainers.create("firefox", conf);
         assertThat(seleniumContainers.getSeleniumContainer().getImage().toString(), startsWith("my.registry/selenium"));
         assertThat(seleniumContainers.getVideoConverterContainer().getImage().toString(), startsWith("my.registry/arquillian"));
-        assertThat(seleniumContainers.getVncContainer().getImage().toString(), startsWith("my.registry/richnorth"));
+        assertThat(seleniumContainers.getVncContainer().getImage().toString(), startsWith("my.registry/testcontainers/vnc-recorder"));
     }
 }


### PR DESCRIPTION
#### Short description of what this resolves:

Docker drone does not work on Windows 11 using WSL2 and Docker Desktop. Will produce the following Exception:
```
java.lang.IllegalArgumentException: java.nio.file.NoSuchFileException: target\vnc\.tmp1755861477422\screen.flv
	at org.arquillian.cube.docker.drone.VncRecorderLifecycleManager.moveFromVolumeFolderToBuildDirectory(VncRecorderLifecycleManager.java:111)
```

Problem seems to be in the `richnorth/vnc-recorder` image.

#### Changes proposed in this pull request:

- Change the used image to an updated version by another maintainer. Namely: testcontainers/vnc-recorder

Fixes #1395