### PR TITLE
[issue 1397] - Adding support to mount volumes with free string configuration option

### DIFF
--- a/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/ContainerBuilder.java
+++ b/docker/docker/src/main/java/org/arquillian/cube/docker/impl/client/containerobject/dsl/ContainerBuilder.java
@@ -166,12 +166,41 @@ public class ContainerBuilder {
             return this;
         }
 
+        /**
+         * Configure volume mount on the Docker container, setting {@link BindMode#READ_WRITE} as the default volume
+         * mount option.
+         * @param hostPath Path of the host directory that should be mounted on the container
+         * @param containerPath Path of the container directory where the volume should be mounted
+         * @return The current {@link ContainerOptionsBuilder} instance holding the configuration
+         *
+         * @deprecated The current Docker documentation doesn't mention {@code rw} as a valid option.
+         */
         public ContainerOptionsBuilder withVolume(String hostPath, String containerPath) {
             return withVolume(hostPath, containerPath, BindMode.READ_WRITE);
         }
 
+        /**
+         * Configure volume mount on the Docker container.
+         * @param hostPath Path of the host directory that should be mounted on the container
+         * @param containerPath Path of the container directory where the volume should be mounted
+         * @param bindMode {@link BindMode} enumeration value representing a valid option for the volume mount
+         *  configuration, based on {@code docker-java} {@link com.github.dockerjava.api.model.AccessMode}
+         * @return The current {@link ContainerOptionsBuilder} instance holding the configuration
+         */
         public ContainerOptionsBuilder withVolume(String hostPath, String containerPath, BindMode bindMode) {
-            setVolume(hostPath + ":" + containerPath + ":" + bindMode.accessMode.name());
+            return withVolume(hostPath, containerPath, bindMode.accessMode.name());
+        }
+
+        /**
+         * Configure volume mount on the Docker container.
+         * @param hostPath Path of the host directory that should be mounted on the container
+         * @param containerPath Path of the container directory where the volume should be mounted
+         * @param bindModeOption String representing a valid option for the volume mount configuration, see the
+         *  <a href="https://docs.docker.com/engine/storage/bind-mounts/#options-for---volume">Docker documentation</a>
+         * @return The current {@link ContainerOptionsBuilder} instance holding the configuration
+         */
+        public ContainerOptionsBuilder withVolume(String hostPath, String containerPath, String bindModeOption) {
+            setVolume(hostPath + ":" + containerPath + ":" + bindModeOption);
             return this;
         }
 

--- a/docker/ftest-docker-containerobject-dsl/src/test/java/org/arquillian/cube/containerobject/dsl/PostgreSqlIT.java
+++ b/docker/ftest-docker-containerobject-dsl/src/test/java/org/arquillian/cube/containerobject/dsl/PostgreSqlIT.java
@@ -1,0 +1,102 @@
+package org.arquillian.cube.containerobject.dsl;
+
+import org.arquillian.cube.docker.impl.await.StaticAwaitStrategy;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.Container;
+import org.arquillian.cube.docker.impl.client.containerobject.dsl.DockerContainer;
+import org.arquillian.cube.docker.impl.requirement.RequiresDocker;
+import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
+import org.arquillian.cube.requirement.ArquillianConditionalRunner;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verify that {@link DockerContainer} can be used to define a valid {@code PosatgreSql} Docker container.
+ * <p>
+ *     A {@link DockerContainer} annotation is used to define a PostgreSql Docker container.
+ *     A local directory is created on the host to hold the PostgreSql data and to be mounted as a volume on the
+ *     Docker container.
+ *     The data directory is created statically, so that it can be used by the {@link DockerContainer} definition later
+ *     in the test lifecycle.
+ *     The {@code Z} bind mode option is passed so that it can be used by SELinux enabled systems, see the related
+ *     <a href="https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label">Docker documentation</a>,
+ *     otherwise the container would fail to start with the following error:<br>
+ *     {@code mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied}
+ * </p>
+ */
+@Category({ RequiresDocker.class})
+@RunWith(ArquillianConditionalRunner.class)
+public class PostgreSqlIT {
+    static final String POSTGRESQL_USER = "user";
+    static final String POSTGRESQL_PASSWORD = "pass";
+    static final String POSTGRESQL_DATABASE = "test-database";
+    static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-13-centos7:centos7";
+    static final int POSTGRESQL_HOST_PORT_BINDING = 5432;
+    static final String POSTGRESQL_CONTAINER_DATA_DIRECTORY_PATH = "/var/lib/pgsql/data";
+    static final File POSTGRESQL_HOST_DATA_DIRECTORY;
+
+    static {
+        try {
+            POSTGRESQL_HOST_DATA_DIRECTORY = java.nio.file.Files.createTempDirectory(null).toFile();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create PostgreSql data dir", e);
+        }
+    }
+
+    @BeforeClass
+    public static void configurePostgresDataDir() throws IOException {
+        final boolean isLinux = new OperatingSystemResolver().currentOperatingSystem().getFamily() == OperatingSystemFamily.LINUX;
+        if (isLinux) {
+            // This is needed to run on SELinux enabled Docker hosts
+            // otherwise the following error will prevent the container from starting successfully:
+            //   mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied
+            java.nio.file.Files.setPosixFilePermissions(Path.of(POSTGRESQL_HOST_DATA_DIRECTORY.toURI()),
+                PosixFilePermissions.fromString("rwxrwxrwx"));
+        }
+    }
+
+    private static Await postgreSqlContainerStaticAwaitStrategy() {
+        Await await = new Await();
+        await.setStrategy(StaticAwaitStrategy.TAG);
+        await.setIp("localhost");
+        await.setPorts(List.of(5432));
+        return await;
+    }
+
+    @DockerContainer
+    Container postgres = Container.withContainerName("postgres")
+        .fromImage(POSTGRESQL_IMAGE)
+        .withPortBinding(String.format("%s->5432", POSTGRESQL_HOST_PORT_BINDING))
+        .withEnvironment("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE)
+        .withEnvironment("POSTGRESQL_USER", POSTGRESQL_USER)
+        .withEnvironment("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)
+        .withVolume(POSTGRESQL_HOST_DATA_DIRECTORY.getAbsolutePath(), POSTGRESQL_CONTAINER_DATA_DIRECTORY_PATH, "Z")
+        .withAwaitStrategy(postgreSqlContainerStaticAwaitStrategy())
+        .build();
+
+    /**
+     * Verify that the {@code PostgreSql} Docker container is up and running by looking into an expected message in the
+     * container logs, which are retrieved via a call to {@link Container#getLog()}.
+     */
+    @Test
+    public void postgres_should_be_up_and_running() throws InterruptedException {
+        // For some (yet) unknown reason, DockerContainer::getLog() would throw a NPE when called inside an Awaitility
+        // block, so we sleep for 10 seconds here in order to give PostgreSql the time to fully boot up and have the
+        // expected message logged.
+        Thread.sleep(10_000);
+        assertThat(postgres.getLog())
+            .isNotBlank()
+            .contains("Success. You can now start the database server using:");
+    }
+}

--- a/docker/ftest-docker-junit-rule/pom.xml
+++ b/docker/ftest-docker-junit-rule/pom.xml
@@ -53,5 +53,10 @@
       <artifactId>junit</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 </project>

--- a/docker/ftest-docker-junit-rule/src/test/java/org/arquillian/cube/docker/junit/rule/PostgreSqlIT.java
+++ b/docker/ftest-docker-junit-rule/src/test/java/org/arquillian/cube/docker/junit/rule/PostgreSqlIT.java
@@ -1,0 +1,104 @@
+package org.arquillian.cube.docker.junit.rule;
+
+import org.arquillian.cube.docker.impl.await.StaticAwaitStrategy;
+import org.arquillian.cube.docker.impl.client.config.Await;
+import org.arquillian.cube.docker.impl.requirement.RequiresDocker;
+import org.arquillian.cube.docker.impl.util.OperatingSystemFamily;
+import org.arquillian.cube.docker.impl.util.OperatingSystemResolver;
+import org.arquillian.cube.requirement.RequirementRule;
+import org.awaitility.Awaitility;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.nio.file.attribute.PosixFilePermissions;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verify that {@link ContainerDslRule} can be used to build a valid {@code PosatgreSql} Docker container.
+ * <p>
+ *     A {@link ContainerDslRule} is used to define a PostgreSql Docker container.
+ *     A local directory is created on the host to hold the PostgreSql data and to be mounted as a volume on the
+ *     Docker container.
+ *     The data directory is created statically, so that it can be used by the {@link ContainerDslRule} definition later
+ *     in the test lifecycle.
+ *     The {@code Z} bind mode option is passed so that it can be used by SELinux enabled systems, see the related
+ *     <a href="https://docs.docker.com/engine/storage/bind-mounts/#configure-the-selinux-label">Docker documentation</a>,
+ *     otherwise the container would fail to start with the following error:<br>
+ *     {@code mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied}
+ * </p>
+ */
+@Category({ RequiresDocker.class})
+public class PostgreSqlIT {
+    static final String POSTGRESQL_USER = "user";
+    static final String POSTGRESQL_PASSWORD = "pass";
+    static final String POSTGRESQL_DATABASE = "test-database";
+    static final String POSTGRESQL_IMAGE = "quay.io/centos7/postgresql-13-centos7:centos7";
+    static final int POSTGRESQL_HOST_PORT_BINDING = 5432;
+    static final String POSTGRESQL_CONTAINER_DATA_DIRECTORY_PATH = "/var/lib/pgsql/data";
+    static final File POSTGRESQL_HOST_DATA_DIRECTORY;
+
+    static {
+        try {
+            POSTGRESQL_HOST_DATA_DIRECTORY = createPostgresDataDir();
+        } catch (IOException e) {
+            throw new IllegalStateException("Cannot create PostgreSql data dir", e);
+        }
+    }
+
+    private static File createPostgresDataDir() throws IOException {
+        // create local data dir for postgres database
+        File postgresDataDir = java.nio.file.Files.createTempDirectory(null).toFile();
+        final boolean isLinux = new OperatingSystemResolver().currentOperatingSystem().getFamily() == OperatingSystemFamily.LINUX;
+        if (isLinux) {
+            // This is needed to run on SELinux enabled Docker hosts
+            // otherwise the following error will prevent the container from starting successfully:
+            //   mkdir: cannot create directory '/var/lib/pgsql/data/userdata': Permission denied
+            java.nio.file.Files.setPosixFilePermissions(Path.of(postgresDataDir.toURI()),
+                PosixFilePermissions.fromString("rwxrwxrwx"));
+        }
+        return postgresDataDir;
+    }
+
+    private static Await postgreSqlContainerStaticAwaitStrategy() {
+        Await await = new Await();
+        await.setStrategy(StaticAwaitStrategy.TAG);
+        await.setIp("localhost");
+        await.setPorts(List.of(5432));
+        return await;
+    }
+
+    @Rule
+    public RequirementRule requirementRule = new RequirementRule();
+
+    @ClassRule
+    public static ContainerDslRule postgres =
+        new ContainerDslRule(POSTGRESQL_IMAGE, "postgres")
+            .withPortBinding(String.format("%s->5432", POSTGRESQL_HOST_PORT_BINDING))
+            .withEnvironment("POSTGRESQL_DATABASE", POSTGRESQL_DATABASE)
+            .withEnvironment("POSTGRESQL_USER", POSTGRESQL_USER)
+            .withEnvironment("POSTGRESQL_PASSWORD", POSTGRESQL_PASSWORD)
+            .withVolume(POSTGRESQL_HOST_DATA_DIRECTORY.getAbsolutePath(), POSTGRESQL_CONTAINER_DATA_DIRECTORY_PATH, "Z")
+            .withAwaitStrategy(postgreSqlContainerStaticAwaitStrategy());
+
+    /**
+     * Verify that the {@code PostgreSql} Docker container is up and running by looking into an expected message in the
+     * container logs, which are retrieved via a call to {@link ContainerDslRule#getLog()}.
+     */
+    @Test
+    public void postgres_should_be_up_and_running() {
+        Awaitility.await()
+            .atMost(30, TimeUnit.SECONDS)
+            .untilAsserted(() -> assertThat(postgres.getLog())
+                .isNotBlank()
+                .contains("Success. You can now start the database server using:")
+            );
+    }
+}

--- a/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/rule/ContainerDslRule.java
+++ b/docker/junit-rule/src/main/java/org/arquillian/cube/docker/junit/rule/ContainerDslRule.java
@@ -106,12 +106,43 @@ public class ContainerDslRule implements TestRule {
         return this;
     }
 
+    /**
+     * Configure volume mount on the Docker container defined by the JUnit {@link org.junit.Rule} DSL based definition,
+     * setting {@link BindMode#READ_WRITE} as the default volume.
+     * mount option
+     * @param hostPath Path of the host directory that should be mounted on the container
+     * @param containerPath Path of the container directory where the volume should be mounted
+     * @return The current {@link ContainerDslRule} instance holding the configuration
+     *
+     * @deprecated The current Docker documentation doesn't mention {@code rw} as a valid option.
+     */
     public ContainerDslRule withVolume(String hostPath, String containerPath) {
         return withVolume(hostPath, containerPath, BindMode.READ_WRITE);
     }
 
+    /**
+     * Configure volume mount on the Docker container defined by the JUnit {@link org.junit.Rule} DSL based definition.
+     * @param hostPath Path of the host directory that should be mounted on the container
+     * @param containerPath Path of the container directory where the volume should be mounted
+     * @param bindMode {@link BindMode} enumeration value representing a valid option for the volume mount
+     *  configuration, based on {@code docker-java} {@link com.github.dockerjava.api.model.AccessMode}
+     * @return The current {@link ContainerDslRule} instance holding the configuration
+     */
     public ContainerDslRule withVolume(String hostPath, String containerPath, BindMode bindMode) {
         containerBuilder.withVolume(hostPath, containerPath, bindMode);
+        return this;
+    }
+
+    /**
+     * Configure volume mount on the Docker container defined by the JUnit {@link org.junit.Rule} DSL based definition.
+     * @param hostPath Path of the host directory that should be mounted on the container
+     * @param containerPath Path of the container directory where the volume should be mounted
+     * @param bindModeOption String representing a valid option for the volume mount configuration, see the
+     *  <a href="https://docs.docker.com/engine/storage/bind-mounts/#options-for---volume">Docker documentation</a>
+     * @return The current {@link ContainerDslRule} instance holding the configuration
+     */
+    public ContainerDslRule withVolume(String hostPath, String containerPath, String bindModeOption) {
+        containerBuilder.withVolume(hostPath, containerPath, bindModeOption);
         return this;
     }
 

--- a/docker/junit5/src/main/java/org/arquillian/cube/docker/junit5/ContainerDsl.java
+++ b/docker/junit5/src/main/java/org/arquillian/cube/docker/junit5/ContainerDsl.java
@@ -5,8 +5,6 @@ import org.arquillian.cube.docker.impl.client.config.Await;
 import org.arquillian.cube.docker.impl.client.containerobject.dsl.BindMode;
 import org.arquillian.cube.docker.impl.client.containerobject.dsl.Container;
 import org.arquillian.cube.docker.impl.client.containerobject.dsl.ContainerBuilder;
-import org.arquillian.cube.docker.junit.rule.ContainerDslRule;
-import org.arquillian.cube.docker.junit.rule.NetworkDslRule;
 import org.arquillian.cube.spi.CubeOutput;
 import org.jboss.shrinkwrap.api.Archive;
 
@@ -78,12 +76,43 @@ public class ContainerDsl {
         return this;
     }
 
+    /**
+     * Configure volume mount on the Docker container defined by the DSL based definition,
+     * setting {@link BindMode#READ_WRITE} as the default volume.
+     * mount option
+     * @param hostPath Path of the host directory that should be mounted on the container
+     * @param containerPath Path of the container directory where the volume should be mounted
+     * @return The current {@link ContainerDsl} instance holding the configuration
+     *
+     * @deprecated The current Docker documentation doesn't mention {@code rw} as a valid option.
+     */
     public ContainerDsl withVolume(String hostPath, String containerPath) {
         return withVolume(hostPath, containerPath, BindMode.READ_WRITE);
     }
 
+    /**
+     * Configure volume mount on the Docker container defined by the DSL based definition.
+     * @param hostPath Path of the host directory that should be mounted on the container
+     * @param containerPath Path of the container directory where the volume should be mounted
+     * @param bindMode {@link BindMode} enumeration value representing a valid option for the volume mount
+     *  configuration, based on {@code docker-java} {@link com.github.dockerjava.api.model.AccessMode}
+     * @return The current {@link ContainerDsl} instance holding the configuration
+     */
     public ContainerDsl withVolume(String hostPath, String containerPath, BindMode bindMode) {
         containerBuilder.withVolume(hostPath, containerPath, bindMode);
+        return this;
+    }
+
+    /**
+     * Configure volume mount on the Docker container defined by the DSL based definition.
+     * @param hostPath Path of the host directory that should be mounted on the container
+     * @param containerPath Path of the container directory where the volume should be mounted
+     * @param bindModeOption String representing a valid option for the volume mount configuration, see the
+     *  <a href="https://docs.docker.com/engine/storage/bind-mounts/#options-for---volume">Docker documentation</a>
+     * @return The current {@link ContainerDsl} instance holding the configuration
+     */
+    public ContainerDsl withVolume(String hostPath, String containerPath, String bindModeOption) {
+        containerBuilder.withVolume(hostPath, containerPath, bindModeOption);
         return this;
     }
 


### PR DESCRIPTION
#### Short description of what this resolves:
Changes allow to set a free form bind mount configuration option when creating a docker container so that - for example - `:Z` can be set for container that run on SELinux.

#### Changes proposed in this pull request:

- Adding an overloaded version of `withVolume(String, String, String)` to ContainerBuilder, ContainerDsl and ContainerDslRule to allow setting free form option for volume mounts.

Fixes #1397
