### PR TITLE
Fix HelloPodDeploymentOpenShiftITCase by removing Gitea dependency

### DIFF
--- a/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentPreBuiltOpenShiftITCase.java
+++ b/openshift/ftest/src/test/java/org/arquillian/cube/openshift/ftest/HelloPodDeploymentPreBuiltOpenShiftITCase.java
@@ -4,30 +4,29 @@ import java.net.URL;
 
 import org.arquillian.cube.olm.impl.requirement.RequiresOlm;
 import org.arquillian.cube.openshift.impl.requirement.RequiresOpenshift;
-import org.arquillian.cube.remote.requirement.RequiresRemoteResource;
 import org.arquillian.cube.requirement.ArquillianConditionalRunner;
 import org.jboss.arquillian.container.test.api.Deployment;
+import org.jboss.arquillian.container.test.api.TargetsContainer;
 import org.jboss.arquillian.test.api.ArquillianResource;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.asset.EmptyAsset;
 import org.jboss.shrinkwrap.api.spec.WebArchive;
 import org.junit.Assert;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 
-@Ignore("Needs the Gitea operator, which Arquillian Cube tries to provision, but it does not work on GitHub CI which uses CRC")
-@Category({RequiresOpenshift.class, RequiresOlm.class, RequiresRemoteResource.class})
+@Category({RequiresOpenshift.class, RequiresOlm.class})
 @RequiresOpenshift
 @RequiresOlm
 @RunWith(ArquillianConditionalRunner.class)
-public class HelloPodDeploymentOpenShiftITCase {
+public class HelloPodDeploymentPreBuiltOpenShiftITCase {
 
     @ArquillianResource
     private URL base;
 
     @Deployment(testable = false)
+    @TargetsContainer("hello-openshift-prebuilt")
     public static WebArchive deploy() {
         return ShrinkWrap.create(WebArchive.class)
             .addAsWebInfResource(EmptyAsset.INSTANCE, "beans.xml");

--- a/openshift/ftest/src/test/resources/arquillian.xml
+++ b/openshift/ftest/src/test/resources/arquillian.xml
@@ -4,11 +4,19 @@
   xsi:schemaLocation="http://jboss.org/schema/arquillian http://jboss.org/schema/arquillian/arquillian_1_0.xsd">
 
   <extension qualifier="openshift">
-    <property name="definitionsFile">src/test/resources/hello_pod.json</property>
-    <property name="proxiedContainerPorts">hello-openshift:9990</property>
+    <property name="definitionsFile">src/test/resources/hello_pod.json,src/test/resources/hello_pod_prebuilt.json</property>
+    <property name="proxiedContainerPorts">hello-openshift:9990,hello-openshift-prebuilt:9990</property>
   </extension>
 
   <container qualifier="hello-openshift" default="true">
+    <configuration>
+      <property name="target">wildfly:33.0.2.Final-jdk11:remote</property>
+      <property name="username">admin</property>
+      <property name="password">Admin#70365</property>
+    </configuration>
+  </container>
+
+  <container qualifier="hello-openshift-prebuilt">
     <configuration>
       <property name="target">wildfly:33.0.2.Final-jdk11:remote</property>
       <property name="username">admin</property>

--- a/openshift/ftest/src/test/resources/hello_pod_prebuilt.json
+++ b/openshift/ftest/src/test/resources/hello_pod_prebuilt.json
@@ -2,16 +2,18 @@
 	"apiVersion":"v1",
 	"kind": "Pod",
 	"metadata": {
-		"name": "hello-openshift",
+		"name": "hello-openshift-prebuilt",
 		"labels": {
-			"name": "hello-openshift"
+			"name": "hello-openshift-prebuilt"
 		}
 	},
 	"spec": {
 		"containers": [{
-			"name": "hello-openshift",
-			"image": "arquillian:./src/test/resources/wildfly",
+			"name": "hello-openshift-prebuilt",
+			"image": "quay.io/wildfly/wildfly:33.0.2.Final-jdk11",
       "imagePullPolicy": "IfNotPresent",
+      "command": ["/bin/bash", "-c"],
+      "args": ["/opt/jboss/wildfly/bin/add-user.sh -up mgmt-users.properties admin Admin#70365 --silent && /opt/jboss/wildfly/bin/standalone.sh -b 0.0.0.0 -bmanagement 0.0.0.0"],
       "ports": [
           {
               "containerPort": 8080,


### PR DESCRIPTION
#### Short description of what this resolves:
The `HelloPodDeploymentOpenShiftITCase` was being skipped due to Gitea operator deployment failures in CI environments using CRC (CodeReady Containers). The test was marked with `@Ignore("Needs the Gitea operator, which Arquillian Cube tries to provision, but it does not work on GitHub CI which uses CRC")`.

#### Changes proposed in this pull request:
This PR eliminates the Gitea dependency by switching from build-from-source to a pre-built image approach while preserving all original testing functionality.

Fixes #
- Remove @Ignore annotation to allow test execution
- Replace build-from-source approach with pre-built WildFly image
- Remove RequiresRemoteResource dependency
- Add runtime admin user creation instead of build-time setup
- Enhance readiness probe to validate WildFly management API
- Expose management port (9990) alongside application port (8080)