### PR TITLE
Reduce e2e scheduled tests from daily to twice weekly

### DIFF
--- a/.github/workflows/e2e-tests-scheduled.yml
+++ b/.github/workflows/e2e-tests-scheduled.yml
@@ -6,7 +6,12 @@ on:
     paths:
       - .github/workflows/e2e-tests-scheduled.yml
   schedule:
-    - cron: '0 4 * * *' # Every day at 4am
+    # Scheduled to run twice weekly instead of daily to reduce load and mitigate
+    # GitHub public runner capacity issues. Times chosen to target lowest-traffic periods:
+    # - Wednesday 2am UTC: Deep off-peak (Tuesday late night US, very early morning EU)
+    # - Sunday 6am UTC: Weekend early morning when runner usage is typically lowest
+    - cron: '0 2 * * 3'  # Wednesday at 2am UTC
+    - cron: '0 6 * * 0'  # Sunday at 6am UTC
 
 concurrency:
   group: single-instance-for-crc-okd-cluster


### PR DESCRIPTION
  #### Short description of what this resolves:

  Reduces the frequency of scheduled e2e tests from daily to twice weekly to mitigate ongoing GitHub public runner capacity issues that have been causing regular test failures since late October.

  #### Changes proposed in this pull request:

  - Changed e2e-tests-scheduled workflow from daily execution to twice weekly (Wednesday and Sunday)
  - Updated cron schedule to Wednesday at 2am UTC and Sunday at 6am UTC to target lowest runner traffic periods
  - Added detailed comments explaining the rationale for timing choices to help with future maintenance
  - Schedule times chosen to maximize runner availability: Wednesday 2am UTC targets deep off-peak (Tuesday late night US, very early morning EU), and Sunday 6am UTC targets weekend low-traffic periods


  Fixes #1419

  ---

  🤖 Generated with [Claude Code](https://claude.com/claude-code)

  Co-Authored-By: Claude Sonnet 4.5 <noreply@anthropic.com>
