### PR TITLE
[issue-1423] - Replace openshift/hello-openshift:v3.6.0 with quay.io/openshift/origin-hello-openshift:latest

### DIFF
--- a/kubernetes/ftest-kubernetes-assistant/src/test/resources/kubernetes.json
+++ b/kubernetes/ftest-kubernetes-assistant/src/test/resources/kubernetes.json
@@ -38,7 +38,7 @@
         },
         "spec" : {
           "containers" : [ {
-            "image" : "openshift/hello-openshift:v3.6.0",
+            "image" : "quay.io/openshift/origin-hello-openshift:latest",
             "imagePullPolicy": "IfNotPresent",
             "name" : "hello-world-container",
             "ports" : [ {


### PR DESCRIPTION
#### Short description of what this resolves:

To avoid toomanyrequests error from dockerhub

#### Changes proposed in this pull request:

- Replace openshift/hello-openshift:v3.6.0 with quay.io/openshift/origin-hello-openshift:latest in HelloWorldKubernetesAssistantTest

Fixes #1423
