### PR TITLE
[issues-1428] - Fix K8s CI workflow

### DIFF
--- a/.github/workflows/e2e-tests.yml
+++ b/.github/workflows/e2e-tests.yml
@@ -55,13 +55,13 @@ jobs:
       - name: Checkout arquillian-cube
         uses: actions/checkout@v6
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.14.0
+        uses: manusa/actions-setup-minikube@v2.16.1
         with:
           driver: docker
-          minikube version: 'v1.32.0'
-          kubernetes version: 'v1.30.0'
+          minikube version: 'v1.38.1'
+          kubernetes version: 'v1.34.2'
           github token: ${{ secrets.GITHUB_TOKEN }}
-          start args: "--memory='4gb' --cpus='2'"
+          start args: "--force"
       - name: Enable minikube registry
         run: |
           minikube addons enable registry


### PR DESCRIPTION
#### Short description of what this resolves:
Fixing the execution of the Kubernetes e2e workflow.


#### Changes proposed in this pull request:

- Updating the configuration of the `manusa/actions-setup-minikube` action, using latest minikube, see [here](https://github.com/kubernetes/minikube/issues/22587#issuecomment-3820797792)


Fixes #1428 
